### PR TITLE
Add image scraper widget

### DIFF
--- a/MOTEUR/scraping/widgets/image_widget.py
+++ b/MOTEUR/scraping/widgets/image_widget.py
@@ -1,0 +1,94 @@
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QLabel,
+    QPushButton,
+    QTextEdit,
+    QProgressBar,
+    QLineEdit,
+    QFileDialog,
+    QHBoxLayout,
+)
+from PySide6.QtCore import Qt, Slot
+
+from ..image_scraper import scrape_images
+
+
+class ImageScraperWidget(QWidget):
+    """Simple interface to run the image scraper."""
+
+    def __init__(self) -> None:
+        super().__init__()
+
+        self.url_edit = QLineEdit()
+        self.url_edit.setPlaceholderText("URL de la page")
+
+        self.selector_edit = QLineEdit()
+        self.selector_edit.setPlaceholderText("Sélecteur CSS des images")
+
+        self.folder_edit = QLineEdit()
+        self.folder_edit.setPlaceholderText("Dossier de destination")
+
+        browse_btn = QPushButton("Parcourir…")
+        browse_btn.clicked.connect(self._choose_folder)
+
+        folder_layout = QHBoxLayout()
+        folder_layout.addWidget(self.folder_edit)
+        folder_layout.addWidget(browse_btn)
+
+        self.start_btn = QPushButton("Lancer")
+        self.start_btn.clicked.connect(self._start)
+
+        self.console = QTextEdit()
+        self.console.setReadOnly(True)
+
+        self.progress_bar = QProgressBar()
+        self.progress_bar.hide()
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("URL:"))
+        layout.addWidget(self.url_edit)
+        layout.addWidget(QLabel("Sélecteur:"))
+        layout.addWidget(self.selector_edit)
+        layout.addWidget(QLabel("Dossier:"))
+        layout.addLayout(folder_layout)
+        layout.addWidget(self.start_btn)
+        layout.addWidget(self.console)
+        layout.addWidget(self.progress_bar)
+
+    def set_selected_profile(self, profile: str) -> None:
+        """Placeholder for profile selection support."""
+        self.console.append(f"Profil sélectionné: {profile}")
+
+    def refresh_profiles(self) -> None:
+        """Placeholder to refresh available profiles."""
+        pass
+
+    @Slot()
+    def _choose_folder(self) -> None:
+        path = QFileDialog.getExistingDirectory(self, "Choisir un dossier")
+        if path:
+            self.folder_edit.setText(path)
+
+    @Slot()
+    def _start(self) -> None:
+        url = self.url_edit.text().strip()
+        selector = self.selector_edit.text().strip()
+        folder = self.folder_edit.text().strip() or "images"
+        if not url or not selector:
+            self.console.append("❌ URL ou sélecteur manquant")
+            return
+
+        self.start_btn.setEnabled(False)
+        self.progress_bar.show()
+        self.progress_bar.setRange(0, 0)
+        try:
+            scrape_images(url, selector)
+        except Exception as exc:
+            self.console.append(f"❌ Erreur: {exc}")
+        else:
+            self.console.append("✅ Terminé")
+        finally:
+            self.progress_bar.hide()
+            self.start_btn.setEnabled(True)
+

--- a/MOTEUR/scraping/widgets/scrap_widget.py
+++ b/MOTEUR/scraping/widgets/scrap_widget.py
@@ -1,18 +1,12 @@
-from PySide6.QtWidgets import QWidget, QVBoxLayout, QTabWidget, QPushButton, QTextEdit, QProgressBar, QLineEdit
+from PySide6.QtWidgets import QWidget, QVBoxLayout, QTabWidget
+
+from .image_widget import ImageScraperWidget
 
 
 class _DummySubWidget(QWidget):
     def __init__(self) -> None:
         super().__init__()
-        self.start_btn = QPushButton("Start")
-        self.console = QTextEdit()
-        self.progress_bar = QProgressBar()
-        self.url_edit = QLineEdit()
-        self.folder_edit = QLineEdit()
         layout = QVBoxLayout(self)
-        layout.addWidget(self.start_btn)
-        layout.addWidget(self.console)
-        layout.addWidget(self.progress_bar)
 
     def set_selected_profile(self, profile: str) -> None:
         pass
@@ -24,8 +18,8 @@ class _DummySubWidget(QWidget):
 class ScrapWidget(QWidget):
     def __init__(self) -> None:
         super().__init__()
-        self.modules_order = []
-        self.images_widget = _DummySubWidget()
+        self.modules_order = ["images", "combined"]
+        self.images_widget = ImageScraperWidget()
         self.combined_widget = _DummySubWidget()
         self.tabs = QTabWidget()
         self.tabs.addTab(self.images_widget, "Images")
@@ -38,3 +32,4 @@ class ScrapWidget(QWidget):
 
     def set_rename(self, enabled: bool) -> None:
         pass
+

--- a/tests/test_mainwindow.py
+++ b/tests/test_mainwindow.py
@@ -1,4 +1,14 @@
+import sys
+from pathlib import Path
 from PySide6.QtWidgets import QApplication
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+import os
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
 from localapp.app import MainWindow
 
 


### PR DESCRIPTION
## Summary
- add `ImageScraperWidget` to provide simple UI for downloading images
- integrate the widget into `ScrapWidget`
- allow tests to run headless and import project modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a6a948ae483309ac330258f9c5fb0