### PR TITLE
Add scraping widget tests

### DIFF
--- a/tests/test_image_scraper_widget.py
+++ b/tests/test_image_scraper_widget.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+import sys
+import os
+from PySide6.QtWidgets import QApplication
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from MOTEUR.scraping import profile_manager as pm
+from MOTEUR.scraping import history
+from MOTEUR.scraping.widgets.image_widget import ImageScraperWidget
+
+
+def test_scrape_logs_history(tmp_path, monkeypatch):
+    pm.PROFILES_FILE = tmp_path / "profiles.json"
+    history.HISTORY_FILE = tmp_path / "history.json"
+    history.LAST_USED_FILE = tmp_path / "last.json"
+    pm.save_profiles([{"name": "p1", "selector": ".a"}])
+
+    app = QApplication.instance() or QApplication([])
+    widget = ImageScraperWidget()
+    widget.refresh_profiles()
+    widget.set_selected_profile("p1")
+    widget.url_edit.setText("http://example.com")
+    widget.folder_edit.setText(str(tmp_path))
+
+    monkeypatch.setattr("MOTEUR.scraping.widgets.image_widget.scrape_images", lambda url, sel: 5)
+
+    widget._start()
+
+    entries = history.load_history()
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["url"] == "http://example.com"
+    assert entry["profile"] == "p1"
+    assert entry["images"] == 5
+    widget.close()

--- a/tests/test_profile_manager.py
+++ b/tests/test_profile_manager.py
@@ -37,3 +37,13 @@ def test_add_update_delete_profile(tmp_path: Path):
     # Update/delete non-existing returns False
     assert pm.update_profile("missing", "x") is False
     assert pm.delete_profile("missing") is False
+
+
+def test_profile_persistence(tmp_path: Path):
+    """Profiles created via :mod:`profile_manager` should persist on disk."""
+    pm.PROFILES_FILE = tmp_path / "profiles.json"
+
+    pm.add_profile("persist", ".x")
+    # Reload from disk to verify persistence
+    new_list = pm.load_profiles()
+    assert new_list == [{"name": "persist", "selector": ".x"}]

--- a/tests/test_profile_widget.py
+++ b/tests/test_profile_widget.py
@@ -51,3 +51,25 @@ def test_add_and_delete(tmp_path):
     assert widget.profile_list.count() == 2
     assert len(updates) == 2
     widget.close()
+
+
+def test_profile_selection_updates_image_widget(tmp_path):
+    """Selecting a profile should update the ImageScraperWidget."""
+    from MOTEUR.scraping.widgets.image_widget import ImageScraperWidget
+
+    pm.PROFILES_FILE = tmp_path / "profiles.json"
+    pm.save_profiles([
+        {"name": "p1", "selector": ".a"},
+        {"name": "p2", "selector": ".b"},
+    ])
+
+    app = QApplication.instance() or QApplication([])
+    profile_widget = ProfileWidget()
+    image_widget = ImageScraperWidget()
+    image_widget.refresh_profiles()
+    profile_widget.profile_chosen.connect(image_widget.set_selected_profile)
+
+    profile_widget.profile_list.setCurrentRow(1)
+    assert image_widget.profile_combo.currentText() == "p2"
+    profile_widget.close()
+    image_widget.close()


### PR DESCRIPTION
## Summary
- add persistence check for profile manager
- exercise profile_widget/profile_chosen signal with image widget
- ensure scraping writes to history log

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a992855f48330a087ab4230c11c5b