### PR TITLE
Handle base64 image URLs

### DIFF
--- a/MOTEUR/scraping/image_scraper.py
+++ b/MOTEUR/scraping/image_scraper.py
@@ -58,6 +58,9 @@ def _extract_urls(driver: webdriver.Chrome, selector: str) -> List[str]:
 
 
 def _download(url: str, folder: Path) -> None:
+    if url.startswith("data:image"):
+        print(f"\u26A0\uFE0F Ignoré (image base64) : {url[:50]}...")
+        return
     try:
         resp = requests.get(url, timeout=10)
         resp.raise_for_status()


### PR DESCRIPTION
## Summary
- ignore `data:image` URLs in `_download` to prevent `requests` errors

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_688aa5873ff08330b65e17a9834b5ee9