### PR TITLE
Improve URL extraction

### DIFF
--- a/MOTEUR/scraping/widgets/profile_widget.py
+++ b/MOTEUR/scraping/widgets/profile_widget.py
@@ -26,6 +26,9 @@ class ProfileWidget(QWidget):
 
         self.name_edit = QLineEdit()
         self.selector_edit = QLineEdit()
+        self.selector_edit.setText(
+            ".woocommerce-product-gallery__image a"
+        )
 
         self.add_btn = QPushButton("Ajouter")
         self.add_btn.clicked.connect(self._add_profile)


### PR DESCRIPTION
## Summary
- expand image scraper `_extract_urls` for `<a>` tags, background images and skip base64
- preload default WooCommerce selector in `ProfileWidget`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688aae4520b08330a29e41d78484d40e