### PR TITLE
Add photoswipe image support

### DIFF
--- a/MOTEUR/scraping/image_scraper.py
+++ b/MOTEUR/scraping/image_scraper.py
@@ -8,6 +8,8 @@ import requests
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 
 DEFAULT_USER_AGENT = (
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
@@ -42,6 +44,17 @@ def _scroll_page(driver: webdriver.Chrome, pause: float = 0.5) -> None:
         last_height = driver.execute_script("return document.body.scrollHeight")
 
 
+def _simulate_slider_interaction(driver: webdriver.Chrome) -> None:
+    try:
+        dots = driver.find_elements(By.CSS_SELECTOR, ".flickity-page-dots .dot")
+        for i, dot in enumerate(dots):
+            driver.execute_script("arguments[0].click();", dot)
+            print(f"🟡 Clic sur le point {i+1}/{len(dots)}")
+            time.sleep(1.2)
+    except Exception as e:
+        print(f"⚠️ Aucun slider détecté ou erreur : {e}")
+
+
 def _extract_urls(driver: webdriver.Chrome, selector: str) -> List[str]:
     elements = driver.find_elements(By.CSS_SELECTOR, selector)
     urls: Set[str] = set()
@@ -56,8 +69,12 @@ def _extract_urls(driver: webdriver.Chrome, selector: str) -> List[str]:
                 urls.add(href)
                 continue
 
-        # Si c'est une balise <img> ou autre avec src / data-src
-        src = el.get_attribute("src") or el.get_attribute("data-src")
+        # Si c'est une balise <img> ou autre avec data-photoswipe-src / src / data-src
+        src = (
+            el.get_attribute("data-photoswipe-src")
+            or el.get_attribute("src")
+            or el.get_attribute("data-src")
+        )
         if src and not src.startswith("data:image"):
             urls.add(src)
             continue
@@ -114,10 +131,19 @@ def scrape_images(page_url: str, selector: str) -> int:
     driver = _create_driver()
     try:
         driver.get(page_url)
+        WebDriverWait(driver, 15).until(
+            EC.presence_of_element_located((By.CSS_SELECTOR, selector))
+        )
+        _simulate_slider_interaction(driver)
         _scroll_page(driver)
         urls = _extract_urls(driver, selector)
         total = len(urls)
-        print(f"{total} images trouv\u00e9es")
+        if total == 0:
+            print(
+                "⚠️ Aucune image trouvée. Vérifie si le slider charge bien dynamiquement."
+            )
+        else:
+            print(f"{total} images trouv\u00e9es")
     finally:
         driver.quit()
 


### PR DESCRIPTION
## Summary
- prioritize `data-photoswipe-src` attributes when scraping
- wait for images with `WebDriverWait` and interact with sliders
- log a warning when no images are found

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b20e3d6a8833085b3c9d54f90d19b