### PR TITLE
Add per-URL image subfolders

### DIFF
--- a/MOTEUR/scraping/widgets/image_widget.py
+++ b/MOTEUR/scraping/widgets/image_widget.py
@@ -153,7 +153,7 @@ class ImageScraperWidget(QWidget):
         old_stdout = sys.stdout
         sys.stdout = stream
         try:
-            total = scrape_images(url, selector)
+            total = scrape_images(url, selector, folder)
         except Exception as exc:
             self.console.append(f"❌ Erreur: {exc}")
         else:

--- a/tests/test_image_scraper_widget.py
+++ b/tests/test_image_scraper_widget.py
@@ -27,7 +27,10 @@ def test_scrape_logs_history(tmp_path, monkeypatch):
     widget.url_edit.setText("http://example.com")
     widget.folder_edit.setText(str(tmp_path))
 
-    monkeypatch.setattr("MOTEUR.scraping.widgets.image_widget.scrape_images", lambda url, sel: 5)
+    monkeypatch.setattr(
+        "MOTEUR.scraping.widgets.image_widget.scrape_images",
+        lambda url, sel, folder: 5,
+    )
 
     widget._start()
 


### PR DESCRIPTION
## Summary
- create helper to determine folder name from page URL
- save images inside a subfolder derived from the URL
- pass destination folder from the widget
- adjust widget tests for new argument

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b2f9c9754833087f67d3e1de0f0d4