### PR TITLE
Add WooCommerce tab

### DIFF
--- a/MOTEUR/scraping/widgets/scrap_widget.py
+++ b/MOTEUR/scraping/widgets/scrap_widget.py
@@ -2,6 +2,7 @@ from PySide6.QtWidgets import QWidget, QVBoxLayout, QTabWidget
 
 from .image_widget import ImageScraperWidget
 from .history_widget import HistoryWidget
+from .woocommerce_widget import WooCommerceProductWidget
 
 
 class _DummySubWidget(QWidget):
@@ -19,14 +20,16 @@ class _DummySubWidget(QWidget):
 class ScrapWidget(QWidget):
     def __init__(self) -> None:
         super().__init__()
-        self.modules_order = ["images", "combined", "history"]
+        self.modules_order = ["images", "combined", "history", "woocommerce"]
         self.images_widget = ImageScraperWidget()
         self.combined_widget = _DummySubWidget()
         self.history_widget = HistoryWidget()
+        self.woocommerce_widget = WooCommerceProductWidget()
         self.tabs = QTabWidget()
         self.tabs.addTab(self.images_widget, "Images")
         self.tabs.addTab(self.combined_widget, "Combined")
         self.tabs.addTab(self.history_widget, "Historique")
+        self.tabs.addTab(self.woocommerce_widget, "Fiche Produit WooCommerce")
         layout = QVBoxLayout(self)
         layout.addWidget(self.tabs)
 

--- a/MOTEUR/scraping/widgets/woocommerce_widget.py
+++ b/MOTEUR/scraping/widgets/woocommerce_widget.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QFileDialog,
+    QAbstractItemView,
+)
+from PySide6.QtCore import Slot
+import csv
+
+
+class WooCommerceProductWidget(QWidget):
+    """Widget to edit WooCommerce product data in a table."""
+
+    HEADERS = [
+        "ID",
+        "Type",
+        "SKU",
+        "Name",
+        "Published",
+        "Is featured?",
+        "Visibility in catalog",
+        "Short description",
+        "Description",
+        "Date sale price starts",
+        "Date sale price ends",
+        "Tax status",
+        "Tax class",
+        "In stock?",
+        "Stock",
+        "Backorders allowed?",
+        "Sold individually?",
+        "Allow customer reviews?",
+        "Purchase note",
+        "Sale price",
+        "Regular price",
+        "Categories",
+        "Tags",
+        "Shipping class",
+        "Images",
+        "Download limit",
+        "Download expiry days",
+        "Parent",
+        "Grouped products",
+        "Upsells",
+        "Cross-sells",
+        "External URL",
+        "Button text",
+        "Position",
+        "Attribute 1 name",
+        "Attribute 1 value(s)",
+        "Attribute 1 visible",
+        "Attribute 1 global",
+        "Attribute 2 name",
+        "Attribute 2 value(s)",
+        "Attribute 2 visible",
+        "Attribute 2 global",
+        "Meta: _wpcom_is_markdown",
+        "Download 1 name",
+        "Download 1 URL",
+        "Download 2 name",
+        "Download 2 URL",
+    ]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.table = QTableWidget(0, len(self.HEADERS))
+        self.table.setHorizontalHeaderLabels(self.HEADERS)
+        self.table.setSelectionBehavior(QAbstractItemView.SelectRows)
+
+        add_btn = QPushButton("Ajouter une ligne")
+        del_btn = QPushButton("Supprimer la ligne sélectionnée")
+        import_btn = QPushButton("Importer CSV")
+        export_btn = QPushButton("Exporter CSV")
+
+        add_btn.clicked.connect(self.add_row)
+        del_btn.clicked.connect(self.delete_selected_row)
+        import_btn.clicked.connect(self.import_csv)
+        export_btn.clicked.connect(self.export_csv)
+
+        btn_layout = QHBoxLayout()
+        btn_layout.addWidget(add_btn)
+        btn_layout.addWidget(del_btn)
+        btn_layout.addStretch()
+        btn_layout.addWidget(import_btn)
+        btn_layout.addWidget(export_btn)
+
+        layout = QVBoxLayout(self)
+        layout.addLayout(btn_layout)
+        layout.addWidget(self.table)
+
+    # ------------------------------------------------------------------
+    @Slot()
+    def add_row(self) -> None:
+        row = self.table.rowCount()
+        self.table.insertRow(row)
+        for col in range(self.table.columnCount()):
+            self.table.setItem(row, col, QTableWidgetItem(""))
+
+    @Slot()
+    def delete_selected_row(self) -> None:
+        row = self.table.currentRow()
+        if row >= 0:
+            self.table.removeRow(row)
+
+    @Slot()
+    def import_csv(self) -> None:
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Importer CSV", "", "CSV Files (*.csv);;All Files (*)"
+        )
+        if not path:
+            return
+        try:
+            with open(path, newline="", encoding="utf-8") as f:
+                reader = csv.reader(f, delimiter="\t")
+                rows = list(reader)
+        except Exception:
+            return
+        if not rows:
+            return
+        start = 1 if rows[0][: len(self.HEADERS)] == self.HEADERS else 0
+        for data in rows[start:]:
+            row = self.table.rowCount()
+            self.table.insertRow(row)
+            for col in range(len(self.HEADERS)):
+                value = data[col] if col < len(data) else ""
+                self.table.setItem(row, col, QTableWidgetItem(value))
+
+    @Slot()
+    def export_csv(self) -> None:
+        path, _ = QFileDialog.getSaveFileName(
+            self, "Exporter CSV", "", "CSV Files (*.csv);;All Files (*)"
+        )
+        if not path:
+            return
+        with open(path, "w", newline="", encoding="utf-8") as f:
+            writer = csv.writer(f, delimiter="\t")
+            writer.writerow(self.HEADERS)
+            for row in range(self.table.rowCount()):
+                data = []
+                for col in range(self.table.columnCount()):
+                    item = self.table.item(row, col)
+                    data.append(item.text() if item else "")
+                writer.writerow(data)

--- a/tests/test_woocommerce_widget.py
+++ b/tests/test_woocommerce_widget.py
@@ -1,0 +1,31 @@
+import sys
+import os
+from pathlib import Path
+import pytest
+
+QtWidgets = pytest.importorskip("PySide6.QtWidgets")
+QApplication = QtWidgets.QApplication
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from MOTEUR.scraping.widgets.woocommerce_widget import WooCommerceProductWidget
+from MOTEUR.scraping.widgets.scrap_widget import ScrapWidget
+
+
+def test_widget_headers():
+    app = QApplication.instance() or QApplication([])
+    widget = WooCommerceProductWidget()
+    assert widget.table.columnCount() == len(widget.HEADERS)
+    widget.close()
+
+
+def test_tab_added_to_scrapwidget():
+    app = QApplication.instance() or QApplication([])
+    sw = ScrapWidget()
+    labels = [sw.tabs.tabText(i) for i in range(sw.tabs.count())]
+    assert "Fiche Produit WooCommerce" in labels
+    sw.close()


### PR DESCRIPTION
## Summary
- implement `WooCommerceProductWidget` featuring editable table and CSV import/export
- integrate WooCommerce product tab inside `ScrapWidget`
- test widget and tab presence

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b6dea83bc8330991a4d6b52bdb4da