### PR TITLE
Add Flask bridge server and UI integration

### DIFF
--- a/MOTEUR/scraping/server/__init__.py
+++ b/MOTEUR/scraping/server/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for exposing the scraping features through a Flask bridge."""
+
+from .flask_server import FlaskBridgeServer, JobManager, JobStatus
+
+__all__ = ["FlaskBridgeServer", "JobManager", "JobStatus"]

--- a/MOTEUR/scraping/server/flask_server.py
+++ b/MOTEUR/scraping/server/flask_server.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+"""Small Flask server to remotely trigger scraping jobs.
+
+The module exposes :class:`FlaskBridgeServer` which wraps a Flask
+application and provides a thread based HTTP server.  The endpoints are
+minimal and secured through an API key passed in the ``X-API-KEY``
+header.  Jobs are executed in a :class:`~concurrent.futures.ThreadPoolExecutor`
+so the UI remains responsive.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+import datetime as _dt
+import os
+import threading
+import time
+import uuid
+import logging
+from pathlib import Path
+
+from flask import Flask, request, jsonify
+from werkzeug.serving import make_server
+from concurrent.futures import ThreadPoolExecutor, Future
+
+from ..image_scraper import scrape_images, scrape_variants
+from ..profile_manager import load_profiles
+from ..history import load_history
+
+
+log = logging.getLogger("flask-bridge")
+log.setLevel(logging.INFO)
+
+
+@dataclass
+class JobStatus:
+    """Represents the state of a running scraping job."""
+
+    job_id: str
+    status: str = "queued"   # queued|running|done|error
+    progress: Dict[str, int] = field(
+        default_factory=lambda: {"found": 0, "downloaded": 0, "failed": 0}
+    )
+    output_dir: str = ""
+    started_at: Optional[str] = None
+    finished_at: Optional[str] = None
+    variants: Dict[str, str] = field(default_factory=dict)
+    sample_images: list[str] = field(default_factory=list)
+    errors: list[Dict[str, str]] = field(default_factory=list)
+    message: str = ""
+
+
+class JobManager:
+    """Simple registry for running scraping jobs."""
+
+    def __init__(self, max_workers: int = 2) -> None:
+        self.jobs: Dict[str, JobStatus] = {}
+        self.executor = ThreadPoolExecutor(max_workers=max_workers)
+        self.lock = threading.Lock()
+
+    def submit(self, fn, *args, **kwargs) -> JobStatus:
+        job_id = uuid.uuid4().hex[:12]
+        st = JobStatus(job_id=job_id)
+        with self.lock:
+            self.jobs[job_id] = st
+        self.executor.submit(fn, st, *args, **kwargs)
+        return st
+
+
+class StoppableWSGIServer(threading.Thread):
+    """Wrapper around Werkzeug's WSGI server allowing clean shutdown."""
+
+    def __init__(self, app: Flask, host: str, port: int) -> None:
+        super().__init__(daemon=True)
+        self.srv = make_server(host, port, app)
+        self.ctx = app.app_context()
+        self.ctx.push()
+
+    def run(self) -> None:  # pragma: no cover - simple thread runner
+        self.srv.serve_forever()
+
+    def shutdown(self) -> None:
+        self.srv.shutdown()
+        self.ctx.pop()
+
+
+class FlaskBridgeServer:
+    """Expose scraping helpers through a small Flask application."""
+
+    def __init__(self, on_log=None) -> None:
+        self.on_log = on_log
+        self.app = Flask(__name__)
+        self._server: Optional[StoppableWSGIServer] = None
+        self._ngrok_tunnel = None
+        self.public_url = ""
+        self.api_key = os.getenv("SCRAPER_API_KEY", "")
+        self.default_flags = {
+            "headless": True,
+            "ignore_robots": False,
+            "rate_limit": 0,
+            "max_workers": 1,
+        }
+        self.jobs = JobManager(max_workers=2)
+        self._mount_routes()
+
+    # ------------------------------------------------------------------
+    # helpers
+    def _log(self, msg: str) -> None:
+        log.info(msg)
+        if self.on_log:
+            self.on_log(msg)
+
+    # ------------------------------------------------------------------
+    # Flask routes
+    def _mount_routes(self) -> None:
+        app = self.app
+
+        @app.get("/health")
+        def health() -> Any:
+            return jsonify(
+                {
+                    "ok": True,
+                    "version": "1.0",
+                    "time": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                }
+            )
+
+        def require_key():
+            key = request.headers.get("X-API-KEY", "")
+            if not self.api_key or key != self.api_key:
+                return jsonify({"error": "unauthorized"}), 401
+            return None
+
+        @app.post("/scrape")
+        def scrape() -> Any:
+            auth = require_key()
+            if auth:
+                return auth
+            data = request.get_json(force=True, silent=True) or {}
+            url = data.get("url")
+            selector = data.get("selector")
+            if not url or not selector:
+                return (
+                    jsonify({"error": "invalid_request", "detail": "url & selector required"}),
+                    400,
+                )
+            folder = data.get("folder") or "images"
+            opts = {**self.default_flags, **(data.get("options") or {})}
+            st = self.jobs.submit(self._run_scrape_job, url, selector, folder, opts)
+            self._log(f"Job {st.job_id} accepté pour {url}")
+            return jsonify({"job_id": st.job_id, "message": "accepted"}), 202
+
+        @app.get("/jobs/<job_id>")
+        def job_status(job_id: str) -> Any:
+            auth = require_key()
+            if auth:
+                return auth
+            st = self.jobs.jobs.get(job_id)
+            if not st:
+                return jsonify({"error": "not_found"}), 404
+            return jsonify(st.__dict__)
+
+        @app.get("/jobs")
+        def list_jobs() -> Any:
+            auth = require_key()
+            if auth:
+                return auth
+            return jsonify([j.__dict__ for j in self.jobs.jobs.values()])
+
+        @app.get("/profiles")
+        def profiles() -> Any:
+            auth = require_key()
+            if auth:
+                return auth
+            profs = load_profiles()
+            out = [
+                {"name": p.get("name", ""), "selector": p.get("selector", "")}
+                for p in profs
+            ]
+            return jsonify(out)
+
+        @app.get("/history")
+        def hist() -> Any:
+            auth = require_key()
+            if auth:
+                return auth
+            return jsonify(load_history())
+
+    # ------------------------------------------------------------------
+    # job execution
+    def _run_scrape_job(
+        self,
+        st: JobStatus,
+        url: str,
+        selector: str,
+        folder: str,
+        opts: Dict[str, Any],
+    ) -> None:
+        st.status = "running"
+        st.started_at = _dt.datetime.utcnow().isoformat() + "Z"
+        try:
+            if opts.get("with_variants"):
+                total, driver = scrape_images(
+                    url,
+                    selector,
+                    folder,
+                    keep_driver=True,
+                )
+                st.variants = scrape_variants(driver)
+                driver.quit()
+            else:
+                total = scrape_images(url, selector, folder)
+            st.progress["found"] = total
+            st.progress["downloaded"] = total
+            st.output_dir = folder
+            images_dir = Path(folder)
+            if images_dir.exists():
+                files = sorted(images_dir.glob("*"))[:5]
+                st.sample_images = [f.name for f in files]
+            st.status = "done"
+        except Exception as exc:  # pragma: no cover - hard to trigger in tests
+            st.status = "error"
+            st.message = str(exc)
+            st.errors.append({"url": url, "error": str(exc)})
+        finally:
+            st.finished_at = _dt.datetime.utcnow().isoformat() + "Z"
+
+    # ------------------------------------------------------------------
+    # public API
+    def start(
+        self,
+        port: int,
+        api_key: str,
+        *,
+        headless_default: bool,
+        user_agent: str | None,
+        ignore_robots_default: bool,
+        rate_limit: int,
+        max_workers: int,
+    ) -> None:
+        """Start the HTTP server."""
+
+        self.api_key = api_key or self.api_key
+        self.default_flags.update(
+            {
+                "headless": headless_default,
+                "user_agent": user_agent,
+                "ignore_robots": ignore_robots_default,
+                "rate_limit": rate_limit,
+                "max_workers": max_workers,
+            }
+        )
+        self.jobs = JobManager(max_workers=max_workers)
+        self._server = StoppableWSGIServer(self.app, "0.0.0.0", port)
+        self._server.start()
+        self._log(f"Serveur lancé sur le port {port}")
+
+    def stop(self) -> None:
+        """Stop the HTTP server and any active ngrok tunnel."""
+
+        if self._server:
+            self._server.shutdown()
+            self._server = None
+            self._log("Serveur arrêté")
+        self.disable_ngrok()
+
+    def enable_ngrok(self, authtoken: str, port: int) -> str:
+        """Expose the local server via ngrok."""
+
+        try:
+            from pyngrok import ngrok
+
+            if authtoken:
+                ngrok.set_auth_token(authtoken)
+            self._ngrok_tunnel = ngrok.connect(port, "http")
+            self.public_url = self._ngrok_tunnel.public_url
+            self._log(f"Ngrok exposé sur {self.public_url}")
+        except Exception as exc:  # pragma: no cover - requires network
+            self._log(f"Erreur ngrok : {exc}")
+            self.public_url = ""
+        return self.public_url
+
+    def disable_ngrok(self) -> None:
+        """Close the ngrok tunnel if opened."""
+
+        try:
+            if self._ngrok_tunnel:
+                from pyngrok import ngrok
+
+                ngrok.disconnect(self._ngrok_tunnel.public_url)
+                ngrok.kill()
+                self._log("Ngrok arrêté")
+        except Exception:  # pragma: no cover - best effort
+            pass
+        finally:
+            self._ngrok_tunnel = None
+            self.public_url = ""
+
+    def is_running(self) -> bool:
+        """Return ``True`` if the server is currently running."""
+
+        return self._server is not None

--- a/MOTEUR/scraping/widgets/flask_server_widget.py
+++ b/MOTEUR/scraping/widgets/flask_server_widget.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+"""Widget de contrôle pour :class:`FlaskBridgeServer`."""
+
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QCheckBox,
+    QTextEdit,
+    QApplication,
+)
+from PySide6.QtCore import Slot
+import json
+import os
+import secrets
+
+from ..server.flask_server import FlaskBridgeServer
+
+CFG_FILE = "server_config.json"
+
+
+class FlaskServerWidget(QWidget):
+    """Interface graphique minimaliste pour démarrer le serveur Flask."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.server = FlaskBridgeServer(on_log=self._append)
+        self._build_ui()
+        self._load_cfg()
+
+    # ------------------------------------------------------------------
+    def _build_ui(self) -> None:
+        self.port = QLineEdit("5001")
+        self.api_key = QLineEdit(os.getenv("SCRAPER_API_KEY", ""))
+        gen = QPushButton("Générer")
+        gen.clicked.connect(self._gen_key)
+        self.expose = QCheckBox("Expose via ngrok")
+        self.ngrok_token = QLineEdit(os.getenv("NGROK_AUTHTOKEN", ""))
+        self.ngrok_token.setEchoMode(QLineEdit.Password)
+        self.headless = QCheckBox("Headless par défaut")
+        self.headless.setChecked(True)
+        self.ignore_robots = QCheckBox("Ignorer robots.txt par défaut")
+        self.rate = QLineEdit("0")
+        self.maxw = QLineEdit("1")
+
+        self.start = QPushButton("Démarrer")
+        self.stop = QPushButton("Arrêter")
+        self.stop.setEnabled(False)
+        self.url_label = QLabel("URL publique : (non exposé)")
+        self.status_label = QLabel("Statut : Arrêté")
+        self.console = QTextEdit()
+        self.console.setReadOnly(True)
+        copyurl = QPushButton("Copier URL")
+        copyurl.clicked.connect(self._copy_url)
+
+        # layouts
+        top = QHBoxLayout()
+        top.addWidget(QLabel("Port:"))
+        top.addWidget(self.port)
+
+        k = QHBoxLayout()
+        k.addWidget(QLabel("API Key:"))
+        k.addWidget(self.api_key)
+        k.addWidget(gen)
+
+        n = QHBoxLayout()
+        n.addWidget(self.expose)
+        n.addWidget(QLabel("Ngrok token:"))
+        n.addWidget(self.ngrok_token)
+
+        o = QHBoxLayout()
+        o.addWidget(self.headless)
+        o.addWidget(self.ignore_robots)
+
+        r = QHBoxLayout()
+        r.addWidget(QLabel("Rate (img/min):"))
+        r.addWidget(self.rate)
+        r.addWidget(QLabel("Max workers:"))
+        r.addWidget(self.maxw)
+
+        btn = QHBoxLayout()
+        btn.addWidget(self.start)
+        btn.addWidget(self.stop)
+        btn.addWidget(copyurl)
+
+        lay = QVBoxLayout(self)
+        for row in (top, k, n, o, r, btn):
+            lay.addLayout(row)
+        lay.addWidget(self.status_label)
+        lay.addWidget(self.url_label)
+        lay.addWidget(self.console)
+
+        self.start.clicked.connect(self._start)
+        self.stop.clicked.connect(self._stop)
+
+    # ------------------------------------------------------------------
+    def _append(self, text: str) -> None:
+        self.console.append(text)
+
+    def _gen_key(self) -> None:
+        self.api_key.setText(secrets.token_urlsafe(24))
+
+    def _copy_url(self) -> None:
+        QApplication.clipboard().setText(
+            self.url_label.text().replace("URL publique : ", "")
+        )
+
+    # ------------------------------------------------------------------
+    def _load_cfg(self) -> None:
+        try:
+            if os.path.exists(CFG_FILE):
+                with open(CFG_FILE, "r", encoding="utf-8") as f:
+                    cfg = json.load(f)
+                self.port.setText(str(cfg.get("port", 5001)))
+                self.api_key.setText(cfg.get("api_key", ""))
+                self.expose.setChecked(bool(cfg.get("expose", False)))
+                self.ngrok_token.setText(cfg.get("ngrok_token", ""))
+                self.headless.setChecked(bool(cfg.get("headless", True)))
+                self.ignore_robots.setChecked(bool(cfg.get("ignore_robots", False)))
+                self.rate.setText(str(cfg.get("rate", 0)))
+                self.maxw.setText(str(cfg.get("max_workers", 1)))
+        except Exception:
+            pass
+
+    def _save_cfg(self) -> dict:
+        cfg = {
+            "port": int(self.port.text() or 5001),
+            "api_key": self.api_key.text().strip(),
+            "expose": self.expose.isChecked(),
+            "ngrok_token": self.ngrok_token.text().strip(),
+            "headless": self.headless.isChecked(),
+            "ignore_robots": self.ignore_robots.isChecked(),
+            "rate": int(self.rate.text() or 0),
+            "max_workers": int(self.maxw.text() or 1),
+        }
+        with open(CFG_FILE, "w", encoding="utf-8") as f:
+            json.dump(cfg, f, indent=2, ensure_ascii=False)
+        return cfg
+
+    # ------------------------------------------------------------------
+    @Slot()
+    def _start(self) -> None:
+        cfg = self._save_cfg()
+        try:
+            self.server.start(
+                port=cfg["port"],
+                api_key=cfg["api_key"],
+                headless_default=cfg["headless"],
+                user_agent=None,
+                ignore_robots_default=cfg["ignore_robots"],
+                rate_limit=cfg["rate"],
+                max_workers=cfg["max_workers"],
+            )
+            pub = ""
+            if cfg["expose"]:
+                pub = self.server.enable_ngrok(cfg["ngrok_token"], cfg["port"])
+            self.status_label.setText("Statut : En cours d’exécution")
+            self.url_label.setText(
+                f"URL publique : {pub or f'http://localhost:{cfg['port']}/health'}"
+            )
+            self.start.setEnabled(False)
+            self.stop.setEnabled(True)
+            self._append("🚀 Serveur démarré")
+        except Exception as e:  # pragma: no cover - UI feedback
+            self._append(f"❌ Erreur démarrage : {e}")
+
+    @Slot()
+    def _stop(self) -> None:
+        try:
+            self.server.stop()
+            self.status_label.setText("Statut : Arrêté")
+            self.url_label.setText("URL publique : (non exposé)")
+            self.start.setEnabled(True)
+            self.stop.setEnabled(False)
+            self._append("🛑 Serveur arrêté")
+        except Exception as e:  # pragma: no cover - UI feedback
+            self._append(f"❌ Erreur arrêt : {e}")

--- a/MOTEUR/scraping/widgets/scrap_widget.py
+++ b/MOTEUR/scraping/widgets/scrap_widget.py
@@ -4,6 +4,7 @@ from .image_widget import ImageScraperWidget
 from .history_widget import HistoryWidget
 from .woocommerce_widget import WooCommerceProductWidget
 from .storage_widget import StorageWidget
+from .flask_server_widget import FlaskServerWidget
 
 
 class _DummySubWidget(QWidget):
@@ -24,6 +25,7 @@ class ScrapWidget(QWidget):
         self.modules_order = [
             "images",
             "combined",
+            "flask",
             "history",
             "woocommerce",
             "stockage",
@@ -31,6 +33,7 @@ class ScrapWidget(QWidget):
         self.storage_widget = StorageWidget()
         self.images_widget = ImageScraperWidget(storage_widget=self.storage_widget)
         self.combined_widget = _DummySubWidget()
+        self.flask_widget = FlaskServerWidget()
         self.history_widget = HistoryWidget()
         self.woocommerce_widget = WooCommerceProductWidget(
             storage_widget=self.storage_widget
@@ -38,6 +41,7 @@ class ScrapWidget(QWidget):
         self.tabs = QTabWidget()
         self.tabs.addTab(self.images_widget, "Images")
         self.tabs.addTab(self.combined_widget, "Combined")
+        self.tabs.addTab(self.flask_widget, "Serveur Flask")
         self.tabs.addTab(self.history_widget, "Historique")
         self.tabs.addTab(self.woocommerce_widget, "Fiche Produit WooCommerce")
         self.tabs.addTab(self.storage_widget, "Stockage")

--- a/README_flask_bridge.md
+++ b/README_flask_bridge.md
@@ -1,0 +1,30 @@
+# Flask Bridge
+
+Ce module ajoute un petit serveur Flask permettant de piloter le scraping à
+l'aide d'appels HTTP.  Il peut être lancé depuis l'onglet **Serveur Flask** de
+l'application.
+
+## Démarrage
+1. Lancez l'application graphique `app.py`.
+2. Rendez-vous dans l'onglet *Serveur Flask*.
+3. Choisissez un port et une clé API puis cliquez sur **Démarrer**.
+4. Optionnel : cochez *Expose via ngrok* pour obtenir une URL publique.
+
+L'API key est également lue depuis la variable d'environnement
+``SCRAPER_API_KEY``.  Pour ngrok, la variable ``NGROK_AUTHTOKEN`` est prise en
+compte si aucun jeton n'est saisi.
+
+## Test de l'API
+Une fois le serveur lancé, l'endpoint `/health` répond sans authentification.
+
+```bash
+# Exemples de commandes curl
+# curl http://localhost:5001/health
+# curl -X POST -H "Content-Type: application/json" -H "X-API-KEY: VOTRE_CLE" \
+#      -d '{"url": "https://exemple.com", "selector": "img"}' \
+#      http://localhost:5001/scrape
+# curl -H "X-API-KEY: VOTRE_CLE" http://localhost:5001/jobs/<job_id>
+```
+
+Les réponses pour les autres endpoints (`/scrape`, `/jobs`, `/profiles`,
+`/history`) nécessitent le header `X-API-KEY`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ pytest
 selenium
 requests
 openpyxl
+Flask
+pyngrok


### PR DESCRIPTION
## Summary
- expose scraping features through a new FlaskBridgeServer with ngrok support and API key security
- add a PySide6 widget to start/stop the server and integrate it into the main tabs
- document usage and add required Flask/pyngrok dependencies

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897bb7ea3988330bd01a48769021d09