### PR TITLE
feat: refresh profiles from flask

### DIFF
--- a/MOTEUR/scraping/bus/event_bus.py
+++ b/MOTEUR/scraping/bus/event_bus.py
@@ -1,0 +1,10 @@
+from PySide6.QtCore import QObject, Signal
+
+
+class EventBus(QObject):
+    profiles_changed = Signal()
+    history_changed = Signal()
+
+
+# singleton
+bus = EventBus()

--- a/tests/manual_profiles_test.md
+++ b/tests/manual_profiles_test.md
@@ -1,0 +1,16 @@
+# Manual Profiles Test
+
+1. Lancer l'application Qt et démarrer le serveur Flask depuis l'onglet dédié.
+2. Depuis un terminal ou Postman, envoyer :
+   ```bash
+   curl -X POST https://<ngrok>.ngrok-free.app/profiles \
+        -H "X-API-KEY: <CLE>" -H "Content-Type: application/json" \
+        -d '{"name":"Test","selector":".img-class"}'
+   ```
+3. Vérifier que la réponse HTTP est `201` et que le profil "Test" apparaît immédiatement dans l'onglet Profil Scraping.
+4. Répéter la requête POST identique : la réponse doit être `409` et aucun doublon ne doit apparaître dans l'UI.
+5. Tester la route de liste :
+   ```bash
+   curl -X GET https://<ngrok>.ngrok-free.app/profiles -H "X-API-KEY: <CLE>"
+   ```
+   Le profil "Test" doit être présent dans le JSON retourné.


### PR DESCRIPTION
## Summary
- add event bus to notify UI of profile changes
- refresh profile list when Flask adds a new profile
- expose POST /profiles and /debug/ping in Flask server

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6897d352052083309d8973ed65c70222