### PR TITLE
Fix application restart relaunch path

### DIFF
--- a/MOTEUR/scraping/utils/restart.py
+++ b/MOTEUR/scraping/utils/restart.py
@@ -11,7 +11,8 @@ def relaunch_current_process(delay_sec: float = 0.2) -> None:
     Ne quitte PAS le process courant (laisse l'appelant le faire).
     """
     python = sys.executable
-    argv = [python] + sys.argv
+    script = os.path.abspath(sys.argv[0])
+    argv = [python, script] + sys.argv[1:]
     try:
         creationflags = 0
         # Évite une console parasite sur Windows

--- a/tests/test_restart_utils.py
+++ b/tests/test_restart_utils.py
@@ -1,0 +1,27 @@
+import os
+import sys
+import subprocess
+import time
+
+from MOTEUR.scraping.utils.restart import relaunch_current_process
+
+
+def test_relaunch_uses_absolute_script_path(monkeypatch, tmp_path):
+    # simulate a script launched with a relative path
+    script = tmp_path / "script.py"
+    script.write_text("print('hi')\n")
+    monkeypatch.setattr(sys, 'argv', [script.name, 'arg1'])
+
+    called = {}
+    def fake_popen(argv, **kwargs):
+        called['argv'] = argv
+        class Dummy: pass
+        return Dummy()
+
+    monkeypatch.setattr(subprocess, 'Popen', fake_popen)
+    monkeypatch.setattr(time, 'sleep', lambda s: None)
+
+    relaunch_current_process()
+
+    assert os.path.isabs(called['argv'][1])
+    assert called['argv'][1].endswith('script.py')


### PR DESCRIPTION
## Summary
- ensure relaunch_current_process uses absolute script path so restart works
- test restart relaunch uses absolute path

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898a469e45483308e7b9b9d46c10097