### PR TITLE
feat(flask): add /actions/image-edit pipeline + Pillow and GUI trigger

### DIFF
--- a/README_flask_bridge.md
+++ b/README_flask_bridge.md
@@ -24,6 +24,9 @@ Une fois le serveur lancé, l'endpoint `/health` répond sans authentification.
 #      -d '{"url": "https://exemple.com", "selector": "img"}' \
 #      http://localhost:5001/scrape
 # curl -H "X-API-KEY: VOTRE_CLE" http://localhost:5001/jobs/<job_id>
+# curl -X POST http://localhost:5001/actions/image-edit \\
+#      -H "X-API-KEY: VOTRE_CLE" -H "Content-Type: application/json" \\
+#      -d '{"source":{"folder":"/path/images"},"operations":[{"op":"resize","width":1024,"height":1024,"keep_ratio":true}]}'
 ```
 
 Les réponses pour les autres endpoints (`/scrape`, `/jobs`, `/profiles`,

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ requests
 openpyxl
 Flask
 pyngrok
+Pillow

--- a/tests/test_image_action_endpoint.py
+++ b/tests/test_image_action_endpoint.py
@@ -1,0 +1,44 @@
+import time
+from pathlib import Path
+
+from PIL import Image
+
+from MOTEUR.scraping.server.flask_server import FlaskBridgeServer
+
+
+def _make_image(path: Path, color: str) -> None:
+    img = Image.new("RGB", (10, 10), color)
+    img.save(path)
+
+
+def test_image_action_endpoint(tmp_path):
+    _make_image(tmp_path / "a.png", "red")
+    _make_image(tmp_path / "b.jpg", "blue")
+
+    srv = FlaskBridgeServer()
+    srv.api_key = "k"
+    client = srv.app.test_client()
+
+    payload = {
+        "source": {"folder": str(tmp_path)},
+        "operations": [{"op": "resize", "width": 5, "height": 5, "keep_ratio": True}],
+        "target_subdir": "out",
+    }
+    resp = client.post(
+        "/actions/image-edit", json=payload, headers={"X-API-KEY": "k"}
+    )
+    assert resp.status_code == 202
+    job_id = resp.get_json()["job_id"]
+
+    for _ in range(30):
+        data = client.get(
+            f"/jobs/{job_id}", headers={"X-API-KEY": "k"}
+        ).get_json()
+        if data["status"] in {"done", "error"}:
+            break
+        time.sleep(0.1)
+    assert data["status"] == "done"
+    assert data["progress"]["downloaded"] == 2
+    out_dir = Path(data["output_dir"])
+    assert (out_dir / "a.png").exists()
+    assert (out_dir / "b.jpg").exists()


### PR DESCRIPTION
## Summary
- add `/actions/image-edit` endpoint to process image operations via jobs
- implement image action runner supporting resize, sharpen and remove_bg stub
- extend Flask server widget with UI to trigger image actions and check job status
- document endpoint usage and add Pillow dependency

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899c112f4588330900882008b17d822