### PR TITLE
fix(ui): expose theme settings and restore maintenance controls

### DIFF
--- a/MOTEUR/ui/settings_widget.py
+++ b/MOTEUR/ui/settings_widget.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from PySide6.QtWidgets import (
     QWidget,
     QVBoxLayout,
@@ -7,10 +9,14 @@ from PySide6.QtWidgets import (
     QLabel,
     QRadioButton,
     QPushButton,
+    QTextEdit,
+    QMessageBox,
 )
-from PySide6.QtCore import Slot
+from PySide6.QtCore import Slot, QProcess, QCoreApplication
 
 from .theme import load_theme, save_theme, apply_theme
+from MOTEUR.scraping.utils.restart import relaunch_current_process
+from MOTEUR.scraping.utils.update import PROJECT_ROOT
 
 
 class SettingsWidget(QWidget):
@@ -40,13 +46,103 @@ class SettingsWidget(QWidget):
         layout.addLayout(radios)
         layout.addWidget(self.apply_btn)
         layout.addWidget(
-            QLabel(
-                "Appliqué à toute l’application. Persistant dans settings.json"
-            )
+            QLabel("Appliqué à toute l’application. Persistant dans settings.json")
         )
+
+        self._build_maintenance_ui(layout)
 
     @Slot()
     def _apply(self) -> None:
         name = "dark" if self.dark_radio.isChecked() else "light"
         apply_theme(name)
         save_theme(name)
+
+    # ------------------------------------------------------------------
+    def _build_maintenance_ui(self, layout: QVBoxLayout) -> None:
+        row = QHBoxLayout()
+        self.update_btn = QPushButton("Mettre à jour")
+        self.update_btn.setObjectName("btn_update")
+        self.restart_btn = QPushButton("Redémarrer")
+        self.restart_btn.setObjectName("btn_restart")
+        row.addWidget(self.update_btn)
+        row.addWidget(self.restart_btn)
+        layout.addLayout(row)
+
+        self.log_edit = QTextEdit()
+        self.log_edit.setReadOnly(True)
+        layout.addWidget(self.log_edit)
+
+        self._git_proc = QProcess(self)
+        self._git_proc.readyReadStandardOutput.connect(
+            lambda: self._append_log(
+                bytes(self._git_proc.readAllStandardOutput()).decode("utf-8", "ignore")
+            )
+        )
+        self._git_proc.readyReadStandardError.connect(
+            lambda: self._append_log(
+                bytes(self._git_proc.readAllStandardError()).decode("utf-8", "ignore")
+            )
+        )
+        self._git_proc.finished.connect(self._on_git_finished)
+
+        self.update_btn.clicked.connect(self._on_update_clicked)
+        self.restart_btn.clicked.connect(self._on_restart_clicked)
+
+    # ------------------------------------------------------------------
+    def _append_log(self, text: str) -> None:
+        txt = text.strip()
+        if txt:
+            self.log_edit.append(txt)
+
+    # ------------------------------------------------------------------
+    @Slot()
+    def _on_update_clicked(self) -> None:
+        root = Path(PROJECT_ROOT)
+        if not (root / ".git").exists():
+            QMessageBox.critical(
+                self, "Mettre à jour", f"Aucun dépôt Git détecté dans :\n{root}"
+            )
+            return
+
+        self.update_btn.setEnabled(False)
+        self.update_btn.setText("Mise à jour en cours…")
+        self._append_log(f"> git pull origin main (cwd={root})")
+        self._git_proc.setWorkingDirectory(str(root))
+        self._git_proc.start("git", ["pull", "origin", "main"])
+
+        if not self._git_proc.waitForStarted(2000):
+            self.update_btn.setEnabled(True)
+            self.update_btn.setText("Mettre à jour")
+            QMessageBox.critical(
+                self,
+                "Mettre à jour",
+                "Impossible de démarrer Git. Est-il installé et dans le PATH ?",
+            )
+
+    # ------------------------------------------------------------------
+    def _on_git_finished(self, code: int, status) -> None:
+        self.update_btn.setEnabled(True)
+        self.update_btn.setText("Mettre à jour")
+        if code == 0:
+            QMessageBox.information(self, "Mettre à jour", "Mise à jour réussie.")
+        else:
+            QMessageBox.critical(
+                self,
+                "Mettre à jour",
+                f"Échec du 'git pull' (code {code}). Consulte les logs.",
+            )
+
+    # ------------------------------------------------------------------
+    @Slot()
+    def _on_restart_clicked(self) -> None:
+        ret = QMessageBox.question(
+            self,
+            "Redémarrer",
+            "Voulez-vous vraiment redémarrer l’application ?",
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
+        )
+        if ret != QMessageBox.Yes:
+            return
+        relaunch_current_process(delay_sec=0.3)
+        QCoreApplication.quit()

--- a/gpt/copy.txt
+++ b/gpt/copy.txt
@@ -2311,6 +2311,8 @@ from MOTEUR.compta.ventes.widget import VenteWidget
 from MOTEUR.compta.accounting.widget import AccountWidget
 from MOTEUR.scraping.widgets.profile_widget import ProfileWidget
 from MOTEUR.compta.dashboard.widget import DashboardWidget
+from MOTEUR.ui.settings_widget import SettingsWidget
+from MOTEUR.ui.theme import load_theme, apply_theme
 
 BASE_DIR = Path(__file__).resolve().parent
 
@@ -2669,7 +2671,7 @@ class MainWindow(QMainWindow):
         self.ventes_page = VenteWidget()
         self.stack.addWidget(self.ventes_page)
 
-        self.settings_page = ScrapingSettingsWidget(show_maintenance=True)
+        self.settings_page = SettingsWidget()
         self.stack.addWidget(self.settings_page)
 
         main_layout.addWidget(sidebar_container, 1)
@@ -2765,6 +2767,7 @@ class MainWindow(QMainWindow):
 
 if __name__ == "__main__":
     app = QApplication(sys.argv)
+    apply_theme(load_theme())
     interface = MainWindow()
     interface.show()
     sys.exit(app.exec())
@@ -3602,4 +3605,241 @@ def test_fill_multiple_times_no_duplicates(tmp_path, monkeypatch):
     assert len(rows) - 1 == first_count
     widget.close()
     storage.close()
+```
+
+
+# MOTEUR/ui/theme.py
+Description: Source code for MOTEUR/ui/theme.py
+```python
+from __future__ import annotations
+
+from pathlib import Path
+import json
+
+from PySide6.QtWidgets import QApplication
+from PySide6.QtGui import QPalette, QColor
+
+THEME_FILE = Path(__file__).resolve().parents[2] / "settings.json"
+
+
+def load_theme() -> str:
+    """Return the persisted theme name ("light" or "dark")."""
+    try:
+        if THEME_FILE.exists():
+            data = json.loads(THEME_FILE.read_text(encoding="utf-8") or "{}")
+            theme = (data.get("theme") or "light").lower()
+            return "dark" if theme == "dark" else "light"
+    except Exception:
+        pass
+    return "light"
+
+
+def save_theme(name: str) -> None:
+    """Persist the theme name into :data:`THEME_FILE`."""
+    name = "dark" if name.lower() == "dark" else "light"
+    THEME_FILE.write_text(
+        json.dumps({"theme": name}, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+
+def _dark_palette() -> QPalette:
+    palette = QPalette()
+    palette.setColor(QPalette.Window, QColor("#2b2b2b"))
+    palette.setColor(QPalette.WindowText, QColor("#eeeeee"))
+    palette.setColor(QPalette.Base, QColor("#3c3f41"))
+    palette.setColor(QPalette.AlternateBase, QColor("#2f3234"))
+    palette.setColor(QPalette.ToolTipBase, QColor("#2b2b2b"))
+    palette.setColor(QPalette.ToolTipText, QColor("#ffffff"))
+    palette.setColor(QPalette.Text, QColor("#eeeeee"))
+    palette.setColor(QPalette.Button, QColor("#3c3f41"))
+    palette.setColor(QPalette.ButtonText, QColor("#eeeeee"))
+    palette.setColor(QPalette.BrightText, QColor("#ff6b6b"))
+    palette.setColor(QPalette.Highlight, QColor("#4c78ff"))
+    palette.setColor(QPalette.HighlightedText, QColor("#ffffff"))
+    palette.setColor(QPalette.Link, QColor("#62a8ff"))
+    return palette
+
+
+def _light_palette() -> QPalette:
+    app = QApplication.instance()
+    if app:
+        palette = app.style().standardPalette()
+    else:
+        palette = QPalette()
+    palette.setColor(QPalette.Highlight, QColor("#3d6cff"))
+    palette.setColor(QPalette.HighlightedText, QColor("#ffffff"))
+    palette.setColor(QPalette.Link, QColor("#0b61ff"))
+    return palette
+
+
+def apply_theme(name: str) -> None:
+    """Apply the given theme to the running :class:`QApplication`."""
+    app = QApplication.instance()
+    if not app:
+        return
+    app.setStyle("Fusion")
+    if name.lower() == "dark":
+        palette = _dark_palette()
+        app.setPalette(palette)
+        app.setStyleSheet(
+            "QToolTip { color: #ffffff; background-color: #2b2b2b; border: 0px; }"
+        )
+    else:
+        palette = _light_palette()
+        app.setPalette(palette)
+        app.setStyleSheet("")
+```
+
+# MOTEUR/ui/settings_widget.py
+Description: Source code for MOTEUR/ui/settings_widget.py
+```python
+from __future__ import annotations
+
+from pathlib import Path
+
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QRadioButton,
+    QPushButton,
+    QTextEdit,
+    QMessageBox,
+)
+from PySide6.QtCore import Slot, QProcess, QCoreApplication
+
+from .theme import load_theme, save_theme, apply_theme
+from MOTEUR.scraping.utils.restart import relaunch_current_process
+from MOTEUR.scraping.utils.update import PROJECT_ROOT
+
+
+class SettingsWidget(QWidget):
+    """General application settings."""
+
+    def __init__(self) -> None:
+        super().__init__()
+
+        self.light_radio = QRadioButton("Clair")
+        self.dark_radio = QRadioButton("Sombre")
+
+        current = load_theme()
+        (self.dark_radio if current == "dark" else self.light_radio).setChecked(True)
+
+        self.light_radio.toggled.connect(lambda _: self._apply())
+        self.dark_radio.toggled.connect(lambda _: self._apply())
+
+        self.apply_btn = QPushButton("Appliquer")
+        self.apply_btn.clicked.connect(self._apply)
+
+        radios = QHBoxLayout()
+        radios.addWidget(self.light_radio)
+        radios.addWidget(self.dark_radio)
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("Thème de l’application"))
+        layout.addLayout(radios)
+        layout.addWidget(self.apply_btn)
+        layout.addWidget(
+            QLabel("Appliqué à toute l’application. Persistant dans settings.json")
+        )
+
+        self._build_maintenance_ui(layout)
+
+    @Slot()
+    def _apply(self) -> None:
+        name = "dark" if self.dark_radio.isChecked() else "light"
+        apply_theme(name)
+        save_theme(name)
+
+    # ------------------------------------------------------------------
+    def _build_maintenance_ui(self, layout: QVBoxLayout) -> None:
+        row = QHBoxLayout()
+        self.update_btn = QPushButton("Mettre à jour")
+        self.update_btn.setObjectName("btn_update")
+        self.restart_btn = QPushButton("Redémarrer")
+        self.restart_btn.setObjectName("btn_restart")
+        row.addWidget(self.update_btn)
+        row.addWidget(self.restart_btn)
+        layout.addLayout(row)
+
+        self.log_edit = QTextEdit()
+        self.log_edit.setReadOnly(True)
+        layout.addWidget(self.log_edit)
+
+        self._git_proc = QProcess(self)
+        self._git_proc.readyReadStandardOutput.connect(
+            lambda: self._append_log(
+                bytes(self._git_proc.readAllStandardOutput()).decode("utf-8", "ignore")
+            )
+        )
+        self._git_proc.readyReadStandardError.connect(
+            lambda: self._append_log(
+                bytes(self._git_proc.readAllStandardError()).decode("utf-8", "ignore")
+            )
+        )
+        self._git_proc.finished.connect(self._on_git_finished)
+
+        self.update_btn.clicked.connect(self._on_update_clicked)
+        self.restart_btn.clicked.connect(self._on_restart_clicked)
+
+    # ------------------------------------------------------------------
+    def _append_log(self, text: str) -> None:
+        txt = text.strip()
+        if txt:
+            self.log_edit.append(txt)
+
+    # ------------------------------------------------------------------
+    @Slot()
+    def _on_update_clicked(self) -> None:
+        root = Path(PROJECT_ROOT)
+        if not (root / ".git").exists():
+            QMessageBox.critical(
+                self, "Mettre à jour", f"Aucun dépôt Git détecté dans :\n{root}"
+            )
+            return
+
+        self.update_btn.setEnabled(False)
+        self.update_btn.setText("Mise à jour en cours…")
+        self._append_log(f"> git pull origin main (cwd={root})")
+        self._git_proc.setWorkingDirectory(str(root))
+        self._git_proc.start("git", ["pull", "origin", "main"])
+
+        if not self._git_proc.waitForStarted(2000):
+            self.update_btn.setEnabled(True)
+            self.update_btn.setText("Mettre à jour")
+            QMessageBox.critical(
+                self,
+                "Mettre à jour",
+                "Impossible de démarrer Git. Est-il installé et dans le PATH ?",
+            )
+
+    # ------------------------------------------------------------------
+    def _on_git_finished(self, code: int, status) -> None:
+        self.update_btn.setEnabled(True)
+        self.update_btn.setText("Mettre à jour")
+        if code == 0:
+            QMessageBox.information(self, "Mettre à jour", "Mise à jour réussie.")
+        else:
+            QMessageBox.critical(
+                self,
+                "Mettre à jour",
+                f"Échec du 'git pull' (code {code}). Consulte les logs.",
+            )
+
+    # ------------------------------------------------------------------
+    @Slot()
+    def _on_restart_clicked(self) -> None:
+        ret = QMessageBox.question(
+            self,
+            "Redémarrer",
+            "Voulez-vous vraiment redémarrer l’application ?",
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
+        )
+        if ret != QMessageBox.Yes:
+            return
+        relaunch_current_process(delay_sec=0.3)
+        QCoreApplication.quit()
 ```

--- a/localapp/app.py
+++ b/localapp/app.py
@@ -36,6 +36,8 @@ from MOTEUR.compta.ventes.widget import VenteWidget
 from MOTEUR.compta.accounting.widget import AccountWidget
 from MOTEUR.scraping.widgets.profile_widget import ProfileWidget
 from MOTEUR.compta.dashboard.widget import DashboardWidget
+from MOTEUR.ui.settings_widget import SettingsWidget
+from MOTEUR.ui.theme import load_theme, apply_theme
 
 BASE_DIR = Path(__file__).resolve().parent
 
@@ -394,7 +396,7 @@ class MainWindow(QMainWindow):
         self.ventes_page = VenteWidget()
         self.stack.addWidget(self.ventes_page)
 
-        self.settings_page = ScrapingSettingsWidget(show_maintenance=True)
+        self.settings_page = SettingsWidget()
         self.stack.addWidget(self.settings_page)
 
         main_layout.addWidget(sidebar_container, 1)
@@ -490,6 +492,7 @@ class MainWindow(QMainWindow):
 
 if __name__ == "__main__":
     app = QApplication(sys.argv)
+    apply_theme(load_theme())
     interface = MainWindow()
     interface.show()
     sys.exit(app.exec())


### PR DESCRIPTION
## Summary
- display general settings widget so users can toggle light/dark mode
- add update and restart buttons back into settings
- refresh copy.txt to include new UI modules

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899cd44d1b08330b02dd634999293c5