### PR TITLE
Normalize sample_images alias to mirror sample_folder

### DIFF
--- a/tests/test_aliases_and_validation.py
+++ b/tests/test_aliases_and_validation.py
@@ -33,9 +33,13 @@ def test_aliases_and_image_edit(tmp_path):
         headers={"X-API-KEY": "k"},
     )
     assert resp.status_code == 200
+    assert resp.get_json() == {
+        "sample_folder": str(img_dir),
+        "sample_images": str(img_dir),
+    }
 
     payload = {
-        "source": {"folder": "sample_folder"},
+        "source": {"folder": "sample_images"},
         "operations": [{"op": "resize", "width": 5, "height": 5}],
     }
     resp = client.post(


### PR DESCRIPTION
## Summary
- Add `_normalize_aliases` to map `sample_images` to `sample_folder` when missing
- Normalize aliases in constructor, POST `/aliases`, and server start
- Cover new alias mapping with updated image edit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a26358cb08330bc76b54a555d6387