### PR TITLE
Update copy.txt with OpenAPI specification

### DIFF
--- a/gpt/copy.txt
+++ b/gpt/copy.txt
@@ -4139,3 +4139,88 @@ def test_fill_multiple_times_no_duplicates(tmp_path, monkeypatch):
 
 ```
 
+# gpt/openapi.yaml
+Description: Source code for gpt/openapi.yaml
+```yaml
+openapi: 3.0.3
+info:
+  title: Flask Bridge API
+  version: '1.0'
+paths:
+  /files/list:
+    get:
+      summary: List images in a folder (alias or absolute path)
+      operationId: listFiles
+      security:
+        - apiKey: []
+      parameters:
+        - name: folder
+          in: query
+          required: true
+          schema:
+            type: string
+            example: sample_folder
+      responses:
+        '200':
+          description: List of files and public URLs
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  folder:
+                    type: string
+                  count:
+                    type: integer
+                  files:
+                    type: array
+                    items:
+                      type: string
+                  urls:
+                    type: array
+                    items:
+                      type: string
+        '400':
+          description: Invalid request
+        '401':
+          description: Unauthorized
+  /files/raw:
+    get:
+      summary: Serve a single image file
+      operationId: getFile
+      security:
+        - apiKey: []
+      parameters:
+        - name: folder
+          in: query
+          required: true
+          schema:
+            type: string
+            example: sample_folder
+        - name: name
+          in: query
+          required: true
+          schema:
+            type: string
+            example: bob-avec-lacet-noir.webp
+      responses:
+        '200':
+          description: The image bytes
+          content:
+            image/*:
+              schema:
+                type: string
+                format: binary
+        '400':
+          description: Invalid request
+        '401':
+          description: Unauthorized
+        '404':
+          description: File not found
+components:
+  securitySchemes:
+    apiKey:
+      type: apiKey
+      in: header
+      name: X-API-KEY
+```


### PR DESCRIPTION
## Summary
- sync `copy.txt` with latest changes by adding the OpenAPI specification for the Flask Bridge API.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a317aa9a08330bbf807c5ede6d0c5