### PR TITLE
feat(collections): export TXT en liens seuls (1 par ligne)

### DIFF
--- a/MOTEUR/scraping/widgets/collection_widget.py
+++ b/MOTEUR/scraping/widgets/collection_widget.py
@@ -150,23 +150,26 @@ class CollectionWidget(QWidget):
     @Slot()
     def _save_list(self) -> None:
         if not self._pairs:
+            QMessageBox.information(self, "Enregistrer", "Aucune donnée.")
             return
+
         path, _ = QFileDialog.getSaveFileName(
             self,
             "Enregistrer la liste",
-            "",
-            "Text files (*.txt)",
+            "liens bob.txt",
+            "Text files (*.txt)"
         )
         if not path:
             return
+
         try:
             with open(path, "w", encoding="utf-8") as f:
-                for name, href in self._pairs:
-                    f.write(f"{name}\t{href}\n")
-        except Exception as exc:
-            QMessageBox.critical(self, "Export", f"Erreur: {exc}")
-            return
-        QMessageBox.information(self, "Export", f"✅ Liste enregistrée : {path}")
+                for _, href in self._pairs:
+                    if href:
+                        f.write(f"{href}\n")
+            QMessageBox.information(self, "Enregistrer", f"✅ Liens enregistrés : {path}")
+        except Exception as e:
+            QMessageBox.critical(self, "Enregistrer", f"Erreur: {e}")
 
     # ------------------------------------------------------------------
     @Slot()


### PR DESCRIPTION
## Summary
- export collection lists as TXT containing only URLs, one per line, with default filename suggestion `liens bob.txt`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b4d06550c8330a44ce888ddaef632