### PR TITLE
feat: enforce UTF-8 I/O and safe logging

### DIFF
--- a/MOTEUR/common/fileio.py
+++ b/MOTEUR/common/fileio.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Iterable
+from log_safe import open_utf8
 
 
 def write_lines_txt(path: str | Path, lines: Iterable[str]) -> str:
@@ -28,7 +29,7 @@ def write_lines_txt(path: str | Path, lines: Iterable[str]) -> str:
             seen.add(s)
             cleaned.append(s)
 
-    with p.open("w", encoding="utf-8") as f:  # newline par défaut => CRLF sous Windows
+    with open_utf8(p, "w") as f:  # newline par défaut => CRLF sous Windows
         f.write("\n".join(cleaned))
         f.write("\n")  # s’assurer d’une dernière ligne
 

--- a/MOTEUR/scraping/history.py
+++ b/MOTEUR/scraping/history.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 from datetime import datetime
 from typing import List, Dict
+from log_safe import open_utf8
 
 # Path to the history log file at project root
 HISTORY_FILE = Path(__file__).resolve().parents[2] / "scraping_history.json"
@@ -14,14 +15,14 @@ def _read_json(path: Path) -> List[Dict]:
     if not path.exists():
         return []
     try:
-        with open(path, "r", encoding="utf-8") as f:
+        with open_utf8(path, "r") as f:
             return json.load(f) or []
     except Exception:
         return []
 
 
 def _write_json(path: Path, data) -> None:
-    with open(path, "w", encoding="utf-8") as f:
+    with open_utf8(path, "w") as f:
         json.dump(data, f, indent=2, ensure_ascii=False)
 
 
@@ -59,7 +60,7 @@ def load_last_used() -> Dict[str, str]:
     if not LAST_USED_FILE.exists():
         return {"url": "", "folder": ""}
     try:
-        with open(LAST_USED_FILE, "r", encoding="utf-8") as f:
+        with open_utf8(LAST_USED_FILE, "r") as f:
             data = json.load(f)
         if isinstance(data, dict):
             return {"url": data.get("url", ""), "folder": data.get("folder", "")}
@@ -78,7 +79,7 @@ def load_last_file() -> str:
     if not LAST_USED_FILE.exists():
         return ""
     try:
-        with open(LAST_USED_FILE, "r", encoding="utf-8") as f:
+        with open_utf8(LAST_USED_FILE, "r") as f:
             data = json.load(f)
         if isinstance(data, dict):
             return data.get("last_file", "")

--- a/MOTEUR/scraping/image_scraper.py
+++ b/MOTEUR/scraping/image_scraper.py
@@ -7,6 +7,7 @@ from urllib.parse import urljoin, urlparse, unquote
 import unicodedata
 
 from datetime import datetime
+from log_safe import print_safe
 
 import requests
 from selenium import webdriver
@@ -335,10 +336,10 @@ def _simulate_slider_interaction(driver: ChromeDriver) -> None:
         dots = driver.find_elements(By.CSS_SELECTOR, ".flickity-page-dots .dot")
         for i, dot in enumerate(dots):
             driver.execute_script("arguments[0].click();", dot)
-            print(f"🟡 Clic sur le point {i+1}/{len(dots)}")
+            print_safe(f"🟡 Clic sur le point {i+1}/{len(dots)}")
             time.sleep(1.2)
     except Exception as e:
-        print(f"⚠️ Aucun slider détecté ou erreur : {e}")
+        print_safe(f"⚠️ Aucun slider détecté ou erreur : {e}")
 
 
 def _extract_urls(driver: ChromeDriver, selector: str) -> List[str]:
@@ -383,7 +384,7 @@ def _extract_urls(driver: ChromeDriver, selector: str) -> List[str]:
 
 def _download(url: str, folder: Path) -> None:
     if url.startswith("data:image"):
-        print(f"\u26A0\uFE0F Ignoré (image base64) : {url[:50]}...")
+        print_safe(f"\u26A0\uFE0F Ignoré (image base64) : {url[:50]}...")
         return
 
     try:
@@ -393,16 +394,16 @@ def _download(url: str, folder: Path) -> None:
         # Vérifie que la réponse est bien une image
         content_type = resp.headers.get("Content-Type", "")
         if not content_type.startswith("image/"):
-            print(f"\u274c Mauvais type de contenu pour {url}: {content_type}")
+            print_safe(f"\u274c Mauvais type de contenu pour {url}: {content_type}")
             return
 
         # Ignore les contenus vides ou trop petits pour être une image réelle
         if not resp.content or len(resp.content) < 100:
-            print(f"\u26A0\uFE0F Réponse vide ou suspecte pour {url}")
+            print_safe(f"\u26A0\uFE0F Réponse vide ou suspecte pour {url}")
             return
 
     except Exception as exc:
-        print(f"\u274c Erreur lors du téléchargement de {url}: {exc}")
+        print_safe(f"\u274c Erreur lors du téléchargement de {url}: {exc}")
         return
 
     # Enregistrement avec gestion de collision de nom
@@ -448,7 +449,7 @@ def scrape_images(
     ``keep_driver`` is ``True``, the Selenium driver is returned alongside the
     image count and left open for further processing by the caller.
     """
-    print("Chargement...")
+    print_safe("Chargement...")
     driver = _create_driver()
     try:
         driver.get(page_url)
@@ -460,11 +461,11 @@ def scrape_images(
         urls = _extract_urls(driver, selector)
         total = len(urls)
         if total == 0:
-            print(
+            print_safe(
                 "⚠️ Aucune image trouvée. Vérifie si le slider charge bien dynamiquement."
             )
         else:
-            print(f"{total} images trouv\u00e9es")
+            print_safe(f"{total} images trouv\u00e9es")
     finally:
         if not keep_driver:
             driver.quit()
@@ -473,9 +474,9 @@ def scrape_images(
     images_dir = base_dir / _folder_from_url(page_url)
     images_dir.mkdir(parents=True, exist_ok=True)
     for i, url in enumerate(urls, 1):
-        print(f"T\u00e9l\u00e9chargement de l'image n\u00b0{i}/{total}")
+        print_safe(f"T\u00e9l\u00e9chargement de l'image n\u00b0{i}/{total}")
         _download(url, images_dir)
-    print("\u2705 Termin\u00e9")
+    print_safe("\u2705 Termin\u00e9")
 
     if keep_driver:
         return total, driver
@@ -571,7 +572,7 @@ def scrape_variants(driver: ChromeDriver) -> dict[str, str]:
                 url = build_uploads_url(product_slug, variant_slug)
                 mapping[value] = url
     except Exception as exc:
-        print(f"⚠️ Erreur lors du scraping des variantes: {exc}")
+        print_safe(f"⚠️ Erreur lors du scraping des variantes: {exc}")
 
     return mapping
 

--- a/MOTEUR/scraping/profile_manager.py
+++ b/MOTEUR/scraping/profile_manager.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 from typing import List, Dict
+from log_safe import open_utf8
 
 # Path to the JSON file storing profiles. By default it is located at the
 # project root but can be overridden in tests by changing this variable.
@@ -15,7 +16,7 @@ def load_profiles() -> List[Dict[str, str]]:
     if not PROFILES_FILE.exists():
         return []
     try:
-        with open(PROFILES_FILE, "r", encoding="utf-8") as f:
+        with open_utf8(PROFILES_FILE, "r") as f:
             data = json.load(f)
         if isinstance(data, list):
             return [p for p in data if isinstance(p, dict)]
@@ -26,7 +27,7 @@ def load_profiles() -> List[Dict[str, str]]:
 
 def save_profiles(profiles: List[Dict[str, str]]) -> None:
     """Write ``profiles`` to :data:`PROFILES_FILE` in JSON format."""
-    with open(PROFILES_FILE, "w", encoding="utf-8") as f:
+    with open_utf8(PROFILES_FILE, "w") as f:
         json.dump(profiles, f, indent=2, ensure_ascii=False)
 
 

--- a/MOTEUR/scraping/utils/restart.py
+++ b/MOTEUR/scraping/utils/restart.py
@@ -3,6 +3,7 @@ import os
 import sys
 import subprocess
 import time
+from log_safe import print_safe
 
 def _build_relaunch_argv() -> list[str]:
     py = sys.executable or "python"
@@ -19,12 +20,12 @@ def _build_relaunch_argv() -> list[str]:
 def relaunch_current_process(delay_sec: float = 0.25, *, cwd: str | None = None) -> None:
     argv = _build_relaunch_argv()
     try:
-        print(f"[restart] sys.executable = {sys.executable}")
-        print(f"[restart] sys.argv       = {sys.argv}")
-        print(f"[restart] relaunch argv  = {argv}")
+        print_safe(f"[restart] sys.executable = {sys.executable}")
+        print_safe(f"[restart] sys.argv       = {sys.argv}")
+        print_safe(f"[restart] relaunch argv  = {argv}")
         if cwd is None:
             cwd = os.getcwd()
-        print(f"[restart] cwd            = {cwd}")
+        print_safe(f"[restart] cwd            = {cwd}")
 
         popen_kwargs = dict(
             cwd=cwd,
@@ -37,5 +38,5 @@ def relaunch_current_process(delay_sec: float = 0.25, *, cwd: str | None = None)
             popen_kwargs["creationflags"] = DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP
         subprocess.Popen(argv, **popen_kwargs)
     except Exception as e:
-        print(f"[restart] Erreur au relancement: {e}")
+        print_safe(f"[restart] Erreur au relancement: {e}")
     time.sleep(delay_sec)

--- a/MOTEUR/scraping/widgets/flask_server_widget.py
+++ b/MOTEUR/scraping/widgets/flask_server_widget.py
@@ -16,6 +16,7 @@ from PySide6.QtWidgets import (
 from PySide6.QtCore import Slot
 import json, requests
 import os
+from log_safe import open_utf8
 from pathlib import Path
 import secrets
 from ui_helpers import show_toast
@@ -164,7 +165,7 @@ class FlaskServerWidget(QWidget):
     def _load_cfg(self) -> None:
         try:
             if os.path.exists(CFG_FILE):
-                with open(CFG_FILE, "r", encoding="utf-8") as f:
+                with open_utf8(CFG_FILE, "r") as f:
                     cfg = json.load(f)
                 self.port.setText(str(cfg.get("port", 5001)))
                 self.api_key.setText(cfg.get("api_key", ""))
@@ -194,7 +195,7 @@ class FlaskServerWidget(QWidget):
         cfg["path_aliases"] = {
             "sample_folder": self.sample_alias.text().strip()
         }
-        with open(CFG_FILE, "w", encoding="utf-8") as f:
+        with open_utf8(CFG_FILE, "w") as f:
             json.dump(cfg, f, indent=2, ensure_ascii=False)
         return cfg
 

--- a/MOTEUR/scraping/widgets/settings_widget.py
+++ b/MOTEUR/scraping/widgets/settings_widget.py
@@ -9,6 +9,7 @@ from PySide6.QtWidgets import (
 from PySide6.QtCore import Signal, Slot, QCoreApplication, QProcess
 from pathlib import Path
 import os
+from log_safe import open_utf8
 
 
 class ScrapingSettingsWidget(QWidget):
@@ -135,7 +136,7 @@ class ScrapingSettingsWidget(QWidget):
         max_size = 800_000  # ignore fichiers texte > 800 KB
 
         try:
-            with open(out, "w", encoding="utf-8") as w:   # <= ÉCRASE à chaque clic
+            with open_utf8(out, "w") as w:   # <= ÉCRASE à chaque clic
                 for dirpath, dirnames, filenames in os.walk(root):
                     dn = os.path.basename(dirpath)
                     if dn in ignore_dirs:

--- a/localapp/app.py
+++ b/localapp/app.py
@@ -1,5 +1,9 @@
+from utf8_bootstrap import force_utf8_stdio
+force_utf8_stdio()
+
 from pathlib import Path
 import sys
+from log_safe import print_safe, open_utf8
 
 # Allow running this module directly by ensuring the project root is in
 # ``sys.path``.  When executed with ``python localapp/app.py`` the Python
@@ -26,7 +30,7 @@ try:
     from PySide6.QtCore import Qt, QPropertyAnimation, Slot, QEasingCurve
     from PySide6.QtGui import QIcon, QKeySequence, QShortcut
 except ModuleNotFoundError:
-    print("Install dependencies with pip install -r requirements.txt")
+    print_safe("Install dependencies with pip install -r requirements.txt")
     sys.exit(1)
 
 from MOTEUR.scraping.widgets.scrap_widget import ScrapWidget
@@ -542,7 +546,7 @@ if __name__ == "__main__":
     path = pathlib.Path("crash.log")
     try:
         faulthandler.enable(all_threads=True)
-        faulthandler.dump_traceback_later(30, repeat=True, file=open(path, "a", encoding="utf-8"))
+        faulthandler.dump_traceback_later(30, repeat=True, file=open_utf8(path, "a"))
     except Exception:
         pass
 

--- a/log_safe.py
+++ b/log_safe.py
@@ -1,0 +1,30 @@
+import sys
+from typing import Any
+
+def _safe_write(stream, text: str):
+    # Écrit en gérant les caractères non encodables (remplacement)
+    try:
+        stream.write(text + "\n")
+    except Exception:
+        enc = getattr(stream, "encoding", None) or "utf-8"
+        # backslashreplace évite les plantages même en cp1252
+        stream.write(text.encode(enc, "backslashreplace").decode(enc) + "\n")
+
+def print_safe(*args: Any, sep: str=" ", end: str="\n"):
+    # Équivalent print, mais robuste à l'encodage
+    out = getattr(sys, "stdout", None)
+    if not out:
+        return
+    s = sep.join("" if a is None else str(a) for a in args)
+    if end and not s.endswith(end):
+        s = s + end
+    try:
+        out.write(s)
+    except Exception:
+        _safe_write(out, s.rstrip("\n"))
+
+def open_utf8(path: str, mode: str="r"):
+    # Ouvre un fichier texte en UTF-8 avec remplacement robuste
+    if "b" in mode:
+        return open(path, mode)  # binaire: inchangé
+    return open(path, mode, encoding="utf-8", errors="replace")

--- a/utf8_bootstrap.py
+++ b/utf8_bootstrap.py
@@ -1,0 +1,42 @@
+import os, sys, io
+
+def _reconfig_stream(stream_name: str):
+    s = getattr(sys, stream_name, None)
+    if not s:
+        return
+    try:
+        # Python 3.7+: reconfigure si dispo
+        if hasattr(s, "reconfigure"):
+            s.reconfigure(encoding="utf-8", errors="replace")
+            return
+    except Exception:
+        pass
+    # Fallback: ré-enrouler le buffer (si possible)
+    try:
+        if hasattr(s, "buffer"):
+            wrapped = io.TextIOWrapper(s.buffer, encoding="utf-8", errors="replace")
+            setattr(sys, stream_name, wrapped)
+    except Exception:
+        pass
+
+def _set_console_cp_utf8_on_windows():
+    # Optionnel: bascule code page de la console Windows en UTF-8 (si console présente)
+    try:
+        import ctypes
+        kernel32 = ctypes.windll.kernel32
+        kernel32.SetConsoleOutputCP(65001)  # UTF-8
+        kernel32.SetConsoleCP(65001)
+    except Exception:
+        pass
+
+def force_utf8_stdio():
+    # Variables d'env pour les sous-processus Python
+    os.environ.setdefault("PYTHONUTF8", "1")
+    os.environ.setdefault("PYTHONIOENCODING", "utf-8")
+
+    # Console Windows si présente
+    _set_console_cp_utf8_on_windows()
+
+    # Reconfig streams du process courant (si existent)
+    _reconfig_stream("stdout")
+    _reconfig_stream("stderr")


### PR DESCRIPTION
## Summary
- force UTF-8 streams and environment on startup
- add print_safe and open_utf8 helpers
- replace prints with print_safe and propagate UTF-8 to QProcess

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689be7965fc88330ae9db9da2e688dfe