### PR TITLE
feat: add UTF-8 bootstrap and robust logging

### DIFF
--- a/MOTEUR/common/fileio.py
+++ b/MOTEUR/common/fileio.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Iterable
-from log_safe import open_utf8
+
+try:
+    from localapp.log_safe import open_utf8
+except ImportError:
+    from log_safe import open_utf8
 
 
 def write_lines_txt(path: str | Path, lines: Iterable[str]) -> str:

--- a/MOTEUR/scraping/history.py
+++ b/MOTEUR/scraping/history.py
@@ -2,7 +2,11 @@ import json
 from pathlib import Path
 from datetime import datetime
 from typing import List, Dict
-from log_safe import open_utf8
+
+try:
+    from localapp.log_safe import open_utf8
+except ImportError:
+    from log_safe import open_utf8
 
 # Path to the history log file at project root
 HISTORY_FILE = Path(__file__).resolve().parents[2] / "scraping_history.json"

--- a/MOTEUR/scraping/image_scraper.py
+++ b/MOTEUR/scraping/image_scraper.py
@@ -7,7 +7,11 @@ from urllib.parse import urljoin, urlparse, unquote
 import unicodedata
 
 from datetime import datetime
-from log_safe import print_safe
+
+try:
+    from localapp.log_safe import print_safe
+except ImportError:
+    from log_safe import print_safe
 
 import requests
 from selenium import webdriver

--- a/MOTEUR/scraping/profile_manager.py
+++ b/MOTEUR/scraping/profile_manager.py
@@ -1,7 +1,11 @@
 import json
 from pathlib import Path
 from typing import List, Dict
-from log_safe import open_utf8
+
+try:
+    from localapp.log_safe import open_utf8
+except ImportError:
+    from log_safe import open_utf8
 
 # Path to the JSON file storing profiles. By default it is located at the
 # project root but can be overridden in tests by changing this variable.

--- a/MOTEUR/scraping/utils/restart.py
+++ b/MOTEUR/scraping/utils/restart.py
@@ -3,7 +3,11 @@ import os
 import sys
 import subprocess
 import time
-from log_safe import print_safe
+
+try:
+    from localapp.log_safe import print_safe
+except ImportError:
+    from log_safe import print_safe
 
 def _build_relaunch_argv() -> list[str]:
     py = sys.executable or "python"

--- a/MOTEUR/scraping/widgets/flask_server_widget.py
+++ b/MOTEUR/scraping/widgets/flask_server_widget.py
@@ -16,8 +16,12 @@ from PySide6.QtWidgets import (
 from PySide6.QtCore import Slot
 import json, requests
 import os
-from log_safe import open_utf8
 from pathlib import Path
+
+try:
+    from localapp.log_safe import open_utf8
+except ImportError:
+    from log_safe import open_utf8
 import secrets
 from ui_helpers import show_toast
 

--- a/MOTEUR/scraping/widgets/image_widget.py
+++ b/MOTEUR/scraping/widgets/image_widget.py
@@ -17,7 +17,10 @@ from PySide6.QtCore import Qt, Slot, QThread, QTimer, QProcess, QProcessEnvironm
 from PySide6.QtGui import QClipboard
 from pathlib import Path
 
-from log_safe import open_utf8
+try:
+    from localapp.log_safe import open_utf8
+except ImportError:
+    from log_safe import open_utf8
 from .. import profile_manager as pm
 from .. import history
 

--- a/MOTEUR/scraping/widgets/settings_widget.py
+++ b/MOTEUR/scraping/widgets/settings_widget.py
@@ -9,7 +9,11 @@ from PySide6.QtWidgets import (
 from PySide6.QtCore import Signal, Slot, QCoreApplication, QProcess
 from pathlib import Path
 import os
-from log_safe import open_utf8
+
+try:
+    from localapp.log_safe import open_utf8
+except ImportError:
+    from log_safe import open_utf8
 
 
 class ScrapingSettingsWidget(QWidget):

--- a/localapp/app.py
+++ b/localapp/app.py
@@ -1,9 +1,19 @@
-from utf8_bootstrap import force_utf8_stdio
+# --- Bootstrap UTF-8, compatible run module ET run direct ---
+try:
+    from .utf8_bootstrap import force_utf8_stdio
+except ImportError:
+    # ex: si lancé par chemin direct (pas en module)
+    from utf8_bootstrap import force_utf8_stdio
 force_utf8_stdio()
+
+# Logs robustes (print_safe)
+try:
+    from .log_safe import print_safe, open_utf8
+except ImportError:
+    from log_safe import print_safe, open_utf8
 
 from pathlib import Path
 import sys
-from log_safe import print_safe, open_utf8
 
 # Allow running this module directly by ensuring the project root is in
 # ``sys.path``.  When executed with ``python localapp/app.py`` the Python

--- a/localapp/log_safe.py
+++ b/localapp/log_safe.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# localapp/log_safe.py
+import sys
+from typing import Any
+
+
+def _safe_write(stream, text: str):
+    try:
+        stream.write(text + "\n")
+    except Exception:
+        enc = getattr(stream, "encoding", None) or "utf-8"
+        stream.write(text.encode(enc, "backslashreplace").decode(enc) + "\n")
+
+
+def print_safe(*args: Any, sep: str=" ", end: str="\n"):
+    out = getattr(sys, "stdout", None)
+    if not out:
+        return
+    s = sep.join("" if a is None else str(a) for a in args)
+    if end and not s.endswith(end):
+        s = s + end
+    try:
+        out.write(s)
+    except Exception:
+        _safe_write(out, s.rstrip("\n"))
+
+
+def open_utf8(path: str, mode: str="r"):
+    if "b" in mode:
+        return open(path, mode)
+    return open(path, mode, encoding="utf-8", errors="replace")

--- a/localapp/utf8_bootstrap.py
+++ b/localapp/utf8_bootstrap.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+# localapp/utf8_bootstrap.py
+import os, sys, io
+
+
+def _reconfig_stream(stream_name: str):
+    s = getattr(sys, stream_name, None)
+    if not s:
+        return
+    try:
+        if hasattr(s, "reconfigure"):
+            s.reconfigure(encoding="utf-8", errors="replace")
+            return
+    except Exception:
+        pass
+    try:
+        if hasattr(s, "buffer"):
+            wrapped = io.TextIOWrapper(s.buffer, encoding="utf-8", errors="replace")
+            setattr(sys, stream_name, wrapped)
+    except Exception:
+        pass
+
+
+def _set_console_cp_utf8_on_windows():
+    try:
+        import ctypes
+        kernel32 = ctypes.windll.kernel32
+        kernel32.SetConsoleOutputCP(65001)
+        kernel32.SetConsoleCP(65001)
+    except Exception:
+        pass
+
+
+def force_utf8_stdio():
+    os.environ.setdefault("PYTHONUTF8", "1")
+    os.environ.setdefault("PYTHONIOENCODING", "utf-8")
+    _set_console_cp_utf8_on_windows()
+    _reconfig_stream("stdout")
+    _reconfig_stream("stderr")

--- a/scrape_subprocess.py
+++ b/scrape_subprocess.py
@@ -1,11 +1,20 @@
-from utf8_bootstrap import force_utf8_stdio
+# --- Bootstrap UTF-8, compatible run module ET run direct ---
+try:
+    from localapp.utf8_bootstrap import force_utf8_stdio
+except ImportError:
+    from utf8_bootstrap import force_utf8_stdio
 force_utf8_stdio()
+
+# Logs robustes (print_safe)
+try:
+    from localapp.log_safe import print_safe, open_utf8
+except ImportError:
+    from log_safe import print_safe, open_utf8
 
 import sys
 import json
 from pathlib import Path
 from selenium.webdriver.common.by import By
-from log_safe import print_safe, open_utf8
 
 from MOTEUR.scraping.image_scraper import scrape_images, scrape_variants
 from MOTEUR.scraping import history


### PR DESCRIPTION
## Summary
- ensure UTF-8 stdout/stderr via bootstrap for module/direct execution
- provide print_safe and open_utf8 helpers in local package and update imports
- use local log utilities across scraping modules and subprocess

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bed7a5cac8330831f062f0b1970e5