### PR TITLE
Add GPT Builder behavior placeholder and docs

### DIFF
--- a/gpt/README.md
+++ b/gpt/README.md
@@ -1,0 +1,8 @@
+# GPT Integration Assets
+
+Ce dossier contient les ressources nécessaires à l'intégration du projet avec GPT Builder.
+
+- `openapi.yaml` décrit l'API REST exposée par le serveur Flask.
+- `product_bridge_behavior.txt` contient le prompt système utilisé par GPT Builder pour configurer le comportement du pont produit. **Remplacer le texte de ce fichier par le bloc "Behavior GPT Builder (système)" fourni par l'équipe produit.**
+
+Ces fichiers peuvent être importés dans GPT Builder afin de générer un assistant personnalisé capable d'interagir avec l'API du projet.

--- a/gpt/product_bridge_behavior.txt
+++ b/gpt/product_bridge_behavior.txt
@@ -1,0 +1,1 @@
+[PLACEHOLDER] Remplacer ce texte par le bloc exact "Behavior GPT Builder (système)" lorsque disponible.


### PR DESCRIPTION
## Summary
- add placeholder for GPT Builder system behavior
- document GPT integration assets in `gpt/README.md`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d24bcf11883309750d41f49e34d72