### PR TITLE
docs: update API spec and examples

### DIFF
--- a/README_flask_bridge.md
+++ b/README_flask_bridge.md
@@ -31,42 +31,20 @@ Les fichiers générés sont attendus aux emplacements suivants :
 - `export/products_export.csv`
 - `generated.json`
 
-## Test de l'API
-Une fois le serveur lancé, l'endpoint `/health` répond sans authentification.
+### Exemples API (tests rapides)
 
 ```bash
-# Vérification basique
-curl http://localhost:5001/health
+# Lister les fichiers d'un alias (images_root)
+curl -H "X-API-KEY: dev-key" "https://YOUR_PUBLIC_DOMAIN/files/list?folder=images_root"
 
-# Liste des fichiers d'un dossier
-curl -H "X-API-KEY: $SCRAPER_API_KEY" \
-     "http://localhost:5001/files/list?folder=sample_folder"
+# Lister les produits (dossiers)
+curl -H "X-API-KEY: dev-key" "https://YOUR_PUBLIC_DOMAIN/products"
 
-# Récupération d'une image
-curl -H "X-API-KEY: $SCRAPER_API_KEY" \
-     "http://localhost:5001/files/raw?folder=sample_folder&name=exemple.jpg" \
-     --output exemple.jpg
+# Images d'un produit (ex: 'bob avec lacet' → slug 'bob-avec-lacet')
+curl -H "X-API-KEY: dev-key" "https://YOUR_PUBLIC_DOMAIN/products/bob-avec-lacet/images"
 
-# Lecture d'une fiche produit sauvegardée
-curl -H "X-API-KEY: $SCRAPER_API_KEY" \
-     "http://localhost:5001/products?path=generated.json"
-# ou pour un export CSV
-# curl -H "X-API-KEY: $SCRAPER_API_KEY" \
-#      "http://localhost:5001/products?path=export/products_export.csv"
-
-# Lancement d'un scraping
-curl -X POST -H "Content-Type: application/json" -H "X-API-KEY: $SCRAPER_API_KEY" \
-     -d '{"url": "https://exemple.com", "selector": "img"}' \
-     http://localhost:5001/scrape
-
-# Vérification d'un job
-curl -H "X-API-KEY: $SCRAPER_API_KEY" http://localhost:5001/jobs/<job_id>
-
-# Traitement d'images
-curl -X POST http://localhost:5001/actions/image-edit \
-     -H "X-API-KEY: $SCRAPER_API_KEY" -H "Content-Type: application/json" \
-     -d '{"source":{"folder":"/path/images"},"operations":[{"op":"resize","width":1024,"height":1024,"keep_ratio":true}]}'
+# Sauvegarder une fiche produit
+curl -X POST -H "Content-Type: application/json" -H "X-API-KEY: dev-key" \
+  -d '{ "name":"Bob avec lacet jaune", "short_description":"...", "description":"...", "categories":["Bobs"], "tags":["lacet","été"], "regular_price":"", "sale_price":"", "slug":"bob-avec-lacet", "focus_keyword":"bob avec lacet jaune", "meta_title":"Bob avec lacet jaune", "meta_description":"", "internal_link":"" }' \
+  "https://YOUR_PUBLIC_DOMAIN/products/bob-avec-lacet/descriptions"
 ```
-
-Les réponses pour les autres endpoints (`/scrape`, `/jobs`, `/profiles`,
-`/history`) nécessitent le header `X-API-KEY`.

--- a/gpt/openapi.yaml
+++ b/gpt/openapi.yaml
@@ -1,81 +1,130 @@
-openapi: 3.0.3
+openapi: 3.1.0
 info:
-  title: Flask Bridge API
-  version: '1.0'
+  title: Lamine Bridge (Files + Products)
+  version: "1.0"
+servers:
+  - url: https://YOUR_PUBLIC_DOMAIN
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-KEY
+security:
+  - ApiKeyAuth: []
 paths:
   /files/list:
     get:
-      summary: List images in a folder (alias or absolute path)
       operationId: listFiles
-      security:
-        - apiKey: []
+      summary: Liste les fichiers d'un dossier (alias ou chemin absolu)
       parameters:
-        - name: folder
-          in: query
+        - in: query
+          name: folder
           required: true
-          schema:
-            type: string
-            example: sample_folder
+          schema: { type: string }
       responses:
-        '200':
-          description: List of files and public URLs
+        "200":
+          description: OK (fichiers + urls + folder absolu)
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  folder:
-                    type: string
-                  count:
-                    type: integer
-                  files:
-                    type: array
-                    items:
-                      type: string
-                  urls:
-                    type: array
-                    items:
-                      type: string
-        '400':
-          description: Invalid request
-        '401':
-          description: Unauthorized
+                  folder: { type: string }
+                  count:  { type: integer }
+                  files:  { type: array, items: { type: string } }
+                  urls:   { type: array, items: { type: string } }
   /files/raw:
     get:
-      summary: Serve a single image file
-      operationId: getFile
-      security:
-        - apiKey: []
+      operationId: getRawFile
+      summary: Sert un fichier binaire (image) depuis un dossier
       parameters:
-        - name: folder
-          in: query
+        - in: query
+          name: folder
           required: true
-          schema:
-            type: string
-            example: sample_folder
-        - name: name
-          in: query
+          schema: { type: string }
+        - in: query
+          name: name
           required: true
-          schema:
-            type: string
-            example: bob-avec-lacet-noir.webp
+          schema: { type: string }
       responses:
-        '200':
-          description: The image bytes
+        "200": { description: Image bytes }
+  /products:
+    get:
+      operationId: listProducts
+      summary: Liste les produits (1 dossier = 1 produit)
+      responses:
+        "200":
+          description: OK
           content:
-            image/*:
+            application/json:
               schema:
-                type: string
-                format: binary
-        '400':
-          description: Invalid request
-        '401':
-          description: Unauthorized
-        '404':
-          description: File not found
-components:
-  securitySchemes:
-    apiKey:
-      type: apiKey
-      in: header
-      name: X-API-KEY
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        slug: { type: string }
+                        name: { type: string }
+                        images_count: { type: integer }
+  /products/{slug}/images:
+    get:
+      operationId: getProductImages
+      summary: URLs publiques des images d’un produit (via /files/raw)
+      parameters:
+        - in: path
+          name: slug
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  product: { type: string }
+                  slug:    { type: string }
+                  images:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name: { type: string }
+                        url: { type: string }
+                        preview_url: { type: string }
+        "404": { description: Not found }
+  /products/{slug}/descriptions:
+    post:
+      operationId: saveProductDescription
+      summary: Enregistre la fiche produit (CSV Woo + trace JSON)
+      parameters:
+        - in: path
+          name: slug
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name: { type: string }
+                short_description: { type: string }
+                description: { type: string }
+                categories: { type: array, items: { type: string } }
+                tags: { type: array, items: { type: string } }
+                regular_price: { type: string }
+                sale_price: { type: string }
+                slug: { type: string }
+                focus_keyword: { type: string }
+                meta_title: { type: string }
+                meta_description: { type: string }
+                internal_link: { type: string }
+      responses:
+        "200": { description: OK }
+        "401": { description: Unauthorized }

--- a/server_config.json
+++ b/server_config.json
@@ -10,5 +10,8 @@
   "path_aliases": {
     "sample_folder": "",
     "images_root": "C:\\Users\\Lamine\\Desktop\\scrap\\projet\\images"
+  },
+  "aliases": {
+    "images_root": "C:\\Users\\Lamine\\Desktop\\scrap\\projet\\images"
   }
 }


### PR DESCRIPTION
## Summary
- add `images_root` alias in server config
- replace OpenAPI spec with combined files and products endpoints
- refresh README examples to match final API

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d31500c748330b737be4a4f1193e8