### PR TITLE
fix(ui): importer QGraphicsOpacityEffect depuis QtWidgets (PySide6) + fallback optionnel

### DIFF
--- a/localapp/ui_animations.py
+++ b/localapp/ui_animations.py
@@ -1,11 +1,23 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
-from PySide6.QtCore import QEasingCurve, QPropertyAnimation, QParallelAnimationGroup, QPoint, QTimer, Qt
-from PySide6.QtWidgets import QWidget, QStackedWidget, QLabel
-from PySide6.QtGui import QGraphicsOpacityEffect
+from PySide6.QtCore import (
+    QEasingCurve,
+    QParallelAnimationGroup,
+    QPropertyAnimation,
+    QPoint,
+    QTimer,
+    Qt,
+)
+from PySide6.QtWidgets import QLabel, QStackedWidget, QWidget
+try:
+    from PySide6.QtWidgets import QGraphicsOpacityEffect
+except Exception:  # pragma: no cover - gracefully degrade when Qt widgets missing
+    QGraphicsOpacityEffect = None
 
 
 def fade_in(w: QWidget, msec=180):
+    if QGraphicsOpacityEffect is None:
+        return  # pas d'animation si indisponible
     eff = QGraphicsOpacityEffect(w)
     w.setGraphicsEffect(eff)
     anim = QPropertyAnimation(eff, b"opacity", w)
@@ -23,7 +35,7 @@ class AnimatedStack(QStackedWidget):
         old = self.currentWidget()
         super().setCurrentIndex(index)
         new = self.currentWidget()
-        if not new:
+        if not new or QGraphicsOpacityEffect is None:
             return
         eff = QGraphicsOpacityEffect(new)
         new.setGraphicsEffect(eff)


### PR DESCRIPTION
## Summary
- import QGraphicsOpacityEffect depuis QtWidgets avec repli en cas d'absence
- neutralise les animations si QGraphicsOpacityEffect indisponible

## Testing
- `pytest`
- `python localapp/app.py` *(échoue: Could not load the Qt platform plugin "xcb"...)*

------
https://chatgpt.com/codex/tasks/task_e_689d3a5afbac83308df6051d1bcc7307