### PR TITLE
feat: add dedicated settings page

### DIFF
--- a/localapp/pages/settings_page.py
+++ b/localapp/pages/settings_page.py
@@ -1,0 +1,124 @@
+# localapp/pages/settings_page.py
+from pathlib import Path
+import os, sys
+from PySide6.QtWidgets import (
+    QWidget, QVBoxLayout, QHBoxLayout, QPushButton, QPlainTextEdit, QLabel, QCheckBox, QGroupBox
+)
+from PySide6.QtCore import QProcess, Qt
+from localapp.utils_copytxt import regenerate_copy_txt
+
+class SettingsPage(QWidget):
+    def __init__(self, app_ctx, parent=None):
+        """
+        app_ctx: objet contenant au moins:
+          - root_dir (Path): racine du projet (cwd du git pull)
+          - copy_txt_path (str): chemin du copy.txt
+          - apply_theme(theme: str): applique 'dark' ou 'light' à l'app et persiste dans settings.json
+          - current_theme() -> str: retourne 'dark' ou 'light'
+          - log(msg: str): (optionnel) fonction de log globale
+        """
+        super().__init__(parent)
+        self.app_ctx = app_ctx
+        self.proc = None
+
+        root = QVBoxLayout(self)
+
+        # --- Ligne boutons d'action ---
+        actions = QGroupBox("Actions")
+        a_layout = QHBoxLayout(actions)
+
+        self.btn_update_app = QPushButton("Mettre à jour l’app")
+        self.btn_restart    = QPushButton("Redémarrer")
+        self.btn_update_txt = QPushButton("Mettre à jour le txt")
+
+        a_layout.addWidget(self.btn_update_app)
+        a_layout.addWidget(self.btn_restart)
+        a_layout.addWidget(self.btn_update_txt)
+
+        # --- Switch thème dans Paramètres ---
+        theme_box = QGroupBox("Apparence")
+        t_layout = QHBoxLayout(theme_box)
+        self.chk_dark = QCheckBox("Mode sombre")
+        self.lbl_theme = QLabel("")  # affichera "Mode sombre" / "Mode clair"
+        self.chk_dark.setChecked(self.app_ctx.current_theme() == "dark")
+        self._update_theme_label()
+        t_layout.addWidget(self.chk_dark)
+        t_layout.addWidget(self.lbl_theme)
+        t_layout.addStretch(1)
+
+        # --- Console ---
+        console_box = QGroupBox("Console")
+        c_layout = QVBoxLayout(console_box)
+        self.console = QPlainTextEdit()
+        self.console.setReadOnly(True)
+        c_layout.addWidget(self.console)
+
+        # Assemblage
+        root.addWidget(actions)
+        root.addWidget(theme_box)
+        root.addWidget(console_box)
+        root.addStretch(1)
+
+        # Signals
+        self.btn_update_app.clicked.connect(self._on_update_app)
+        self.btn_restart.clicked.connect(self._on_restart)
+        self.btn_update_txt.clicked.connect(self._on_update_txt)
+        self.chk_dark.stateChanged.connect(self._on_theme_toggled)
+
+    # ==== Actions ====
+    def _append(self, text: str):
+        self.console.appendPlainText(text)
+
+    def _run_process(self, program: str, args: list[str], cwd: Path):
+        # Lance un QProcess et pipe stdout/stderr vers la console
+        if self.proc:
+            self.proc.kill()
+            self.proc = None
+        self.proc = QProcess(self)
+        self.proc.setProgram(program)
+        self.proc.setArguments(args)
+        self.proc.setWorkingDirectory(str(cwd))
+        self.proc.setProcessChannelMode(QProcess.MergedChannels)
+        self.proc.readyReadStandardOutput.connect(
+            lambda: self._append(bytes(self.proc.readAllStandardOutput()).decode(errors="replace"))
+        )
+        self.proc.readyReadStandardError.connect(
+            lambda: self._append(bytes(self.proc.readAllStandardError()).decode(errors="replace"))
+        )
+        self.proc.started.connect(lambda: self._append(f"> {program} {' '.join(args)} (cwd={cwd})"))
+        self.proc.finished.connect(lambda code, _status: self._append(f"[exit {code}]"))
+        self.proc.start()
+
+    def _on_update_app(self):
+        # git pull origin main dans la racine du projet
+        root = self.app_ctx.root_dir
+        git = "git.exe" if os.name == "nt" else "git"
+        self._run_process(git, ["pull", "origin", "main"], root)
+
+    def _on_restart(self):
+        self._append("Redémarrage en cours…")
+        # Flush puis relance le process
+        self._restart_app()
+
+    def _on_update_txt(self):
+        try:
+            msg = regenerate_copy_txt(self.app_ctx.copy_txt_path)
+            self._append(msg)
+        except Exception as e:
+            self._append(f"Erreur: {e}")
+
+    # ==== Thème ====
+    def _update_theme_label(self):
+        self.lbl_theme.setText("Mode sombre" if self.chk_dark.isChecked() else "Mode clair")
+
+    def _on_theme_toggled(self, state):
+        theme = "dark" if self.chk_dark.isChecked() else "light"
+        self.app_ctx.apply_theme(theme)
+        self._update_theme_label()
+        self._append(f"Thème appliqué: {theme}")
+
+    # ==== Restart ====
+    def _restart_app(self):
+        # relance le processus Python courant avec les mêmes arguments
+        python = sys.executable
+        os.execl(python, python, *sys.argv)


### PR DESCRIPTION
## Summary
- add `SettingsPage` with update, restart, copy.txt regeneration and theme switch
- integrate settings page into sidebar and persist theme in `settings.json`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d492741a88330ab21993f0f903219