### PR TITLE
chore(config): make IMAGES_JOINER configurable via .env (+CSV_DELIM, DECIMAL_COMMA)

### DIFF
--- a/tests/test_woocommerce_export.py
+++ b/tests/test_woocommerce_export.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import sys
+import pytest
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
@@ -188,3 +189,19 @@ def test_decimal_comma_toggle(tmp_path, monkeypatch):
     we.write_woocommerce_csv(rows, path)
     content = path.read_text(encoding="utf-8")
     assert "29.9" in content
+
+
+def test_env_overrides(tmp_path):
+    pytest.importorskip("dotenv")
+    env_path = PROJECT_ROOT / ".env"
+    env_path.write_text("CSV_DELIM=,\nIMAGES_JOINER=,\nDECIMAL_COMMA=0\n", encoding="utf-8")
+    import importlib
+    import woocommerce_export as we
+    importlib.reload(we)
+    try:
+        assert we.CSV_DELIM == ","
+        assert we.IMAGES_JOINER == ","
+        assert we.DECIMAL_COMMA is False
+    finally:
+        env_path.unlink()
+        importlib.reload(we)

--- a/woocommerce_export.py
+++ b/woocommerce_export.py
@@ -43,6 +43,12 @@ import unicodedata
 from collections import defaultdict
 from decimal import Decimal
 from typing import Dict, Iterable, List
+from contextlib import suppress
+
+# .env facultatif (global / par projet)
+with suppress(Exception):
+    from dotenv import load_dotenv
+    load_dotenv()
 
 # Columns expected by WooCommerce in the desired order.
 COLUMNS: List[str] = [
@@ -78,14 +84,10 @@ _ADJECTIVE_MAP = {
 }
 
 
-# Configuration constants (can be overridden via environment variables).
+# Defaults (overridable via environment variables)
 CSV_DELIM: str = os.getenv("CSV_DELIM", ";")
 IMAGES_JOINER: str = os.getenv("IMAGES_JOINER", ";")
-DECIMAL_COMMA: bool = os.getenv("DECIMAL_COMMA", "True").lower() in {
-    "1",
-    "true",
-    "yes",
-}
+DECIMAL_COMMA: bool = bool(int(os.getenv("DECIMAL_COMMA", "1")))
 
 
 def _fix_encoding(text: str) -> str:


### PR DESCRIPTION
## Summary
- load optional project-specific .env files for export configuration
- make CSV delimiter, parent image joiner, and decimal comma configurable
- add test ensuring .env overrides are honoured

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e1e61a56083309d9ab8de9a9ae900