### PR TITLE
Handle Shopify image deduplication

### DIFF
--- a/copy.txt
+++ b/copy.txt
@@ -1,0 +1,31075 @@
+# copy.txt regénéré automatiquement
+# 2025-08-15T10:49:17
+
+### >>> MOTEUR/__init__.py (0 lignes)
+
+
+### >>> MOTEUR/common/__init__.py (0 lignes)
+
+
+### >>> MOTEUR/common/fileio.py (40 lignes)
+from __future__ import annotations
+from pathlib import Path
+from typing import Iterable
+
+try:
+    from localapp.log_safe import open_utf8
+except ImportError:
+    from log_safe import open_utf8
+
+
+def write_lines_txt(path: str | Path, lines: Iterable[str]) -> str:
+    """
+    Écrit des lignes texte en UTF-8, avec des retours Windows (CRLF)
+    pour une compat Notepad parfaite. Ajoute un retour final.
+    Retourne le chemin normalisé.
+    """
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+
+    # IMPORTANT:
+    # - ne PAS fixer newline="\n" (forcerait LF)
+    # - laisser le default (newline=None) pour traduire '\n' -> CRLF sous Windows
+    cleaned: list[str] = []
+    seen: set[str] = set()
+    for s in lines:
+        s = (s or "").strip()
+        if not s:
+            continue
+        if not s.startswith("http"):
+            # on ignore ce qui n’est pas un lien absolu
+            continue
+        if s not in seen:
+            seen.add(s)
+            cleaned.append(s)
+
+    with open_utf8(p, "w") as f:  # newline par défaut => CRLF sous Windows
+        f.write("\n".join(cleaned))
+        f.write("\n")  # s’assurer d’une dernière ligne
+
+    return str(p)
+
+### >>> MOTEUR/compta/__init__.py (0 lignes)
+
+
+### >>> MOTEUR/compta/accounting/__init__.py (0 lignes)
+
+
+### >>> MOTEUR/compta/accounting/widget.py (6 lignes)
+from PySide6.QtWidgets import QWidget
+from PySide6.QtCore import Signal
+
+
+class AccountWidget(QWidget):
+    accounts_updated = Signal()
+
+### >>> MOTEUR/compta/achats/__init__.py (0 lignes)
+
+
+### >>> MOTEUR/compta/achats/widget.py (6 lignes)
+from PySide6.QtWidgets import QWidget
+
+
+class AchatWidget(QWidget):
+    def refresh_accounts(self) -> None:
+        pass
+
+### >>> MOTEUR/compta/dashboard/__init__.py (0 lignes)
+
+
+### >>> MOTEUR/compta/dashboard/widget.py (16 lignes)
+from PySide6.QtWidgets import QWidget, QLabel, QVBoxLayout
+from PySide6.QtCore import Signal
+
+
+class DashboardWidget(QWidget):
+    journal_requested = Signal()
+    grand_livre_requested = Signal()
+    scraping_summary_requested = Signal()
+
+    def __init__(self) -> None:
+        super().__init__()
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("Dashboard"))
+
+    def refresh(self) -> None:
+        pass
+
+### >>> MOTEUR/compta/parameters.py (5 lignes)
+from PySide6.QtWidgets import QWidget
+
+
+class JournalsWidget(QWidget):
+    pass
+
+### >>> MOTEUR/compta/revision.py (5 lignes)
+from PySide6.QtWidgets import QWidget
+
+
+class RevisionTab(QWidget):
+    pass
+
+### >>> MOTEUR/compta/suppliers.py (5 lignes)
+from PySide6.QtWidgets import QWidget
+
+
+class SupplierTab(QWidget):
+    pass
+
+### >>> MOTEUR/compta/ventes/__init__.py (0 lignes)
+
+
+### >>> MOTEUR/compta/ventes/widget.py (5 lignes)
+from PySide6.QtWidgets import QWidget
+
+
+class VenteWidget(QWidget):
+    pass
+
+### >>> MOTEUR/scraping/__init__.py (0 lignes)
+
+
+### >>> MOTEUR/scraping/bus/__init__.py (0 lignes)
+
+
+### >>> MOTEUR/scraping/bus/event_bus.py (10 lignes)
+from PySide6.QtCore import QObject, Signal
+
+
+class EventBus(QObject):
+    profiles_changed = Signal()
+    history_changed = Signal()
+
+
+# singleton
+bus = EventBus()
+
+### >>> MOTEUR/scraping/history.py (92 lignes)
+import json
+from pathlib import Path
+from datetime import datetime
+from typing import List, Dict
+
+try:
+    from localapp.log_safe import open_utf8
+except ImportError:
+    from log_safe import open_utf8
+
+# Path to the history log file at project root
+HISTORY_FILE = Path(__file__).resolve().parents[2] / "scraping_history.json"
+
+# Path to file storing last used url/folder
+LAST_USED_FILE = Path(__file__).resolve().parents[2] / "scraping_last_used.json"
+
+
+def _read_json(path: Path) -> List[Dict]:
+    if not path.exists():
+        return []
+    try:
+        with open_utf8(path, "r") as f:
+            return json.load(f) or []
+    except Exception:
+        return []
+
+
+def _write_json(path: Path, data) -> None:
+    with open_utf8(path, "w") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+
+
+def log_scrape(url: str, profile: str, images: int, folder: str) -> None:
+    """Append a scraping entry to :data:`HISTORY_FILE`."""
+    entries = _read_json(HISTORY_FILE)
+    entries.append(
+        {
+            "date": datetime.now().isoformat(timespec="seconds"),
+            "url": url,
+            "profile": profile,
+            "images": images,
+            "folder": folder,
+        }
+    )
+    _write_json(HISTORY_FILE, entries)
+    save_last_used(url, folder)
+
+
+def load_history() -> List[Dict]:
+    """Return the list of logged scraping entries."""
+    return _read_json(HISTORY_FILE)
+
+
+def save_last_used(url: str, folder: str) -> None:
+    data = {
+        "url": url,
+        "folder": folder,
+        "last_file": load_last_file(),
+    }
+    _write_json(LAST_USED_FILE, data)
+
+
+def load_last_used() -> Dict[str, str]:
+    if not LAST_USED_FILE.exists():
+        return {"url": "", "folder": ""}
+    try:
+        with open_utf8(LAST_USED_FILE, "r") as f:
+            data = json.load(f)
+        if isinstance(data, dict):
+            return {"url": data.get("url", ""), "folder": data.get("folder", "")}
+    except Exception:
+        pass
+    return {"url": "", "folder": ""}
+
+
+def save_last_file(path: str) -> None:
+    data = load_last_used()
+    data["last_file"] = path or ""
+    _write_json(LAST_USED_FILE, data)
+
+
+def load_last_file() -> str:
+    if not LAST_USED_FILE.exists():
+        return ""
+    try:
+        with open_utf8(LAST_USED_FILE, "r") as f:
+            data = json.load(f)
+        if isinstance(data, dict):
+            return data.get("last_file", "")
+    except Exception:
+        pass
+    return ""
+
+### >>> MOTEUR/scraping/image_scraper.py (978 lignes)
+import os
+import re
+import time
+import itertools
+import math
+import json
+import atexit
+import logging
+from contextlib import suppress
+from pathlib import Path
+from typing import Any, Callable, List, Set
+from urllib.parse import urljoin, urlparse, unquote
+from urllib.parse import urlunparse, quote
+from urllib.parse import urlsplit, urlunsplit, parse_qsl, urlencode
+from io import BytesIO
+import unicodedata
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from datetime import datetime
+
+try:
+    from localapp.log_safe import print_safe
+except ImportError:
+    from log_safe import print_safe
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.chrome.webdriver import WebDriver as ChromeDriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.remote.webelement import WebElement
+
+try:
+    from PIL import Image  # pour conversion WEBP (déjà utilisée)
+except Exception:
+    Image = None
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/124.0.0.0 Safari/537.36"
+)
+
+
+def _best_from_srcset(srcset: str | None) -> str | None:
+    if not srcset:
+        return None
+    parts = [p.strip() for p in srcset.split(',') if p.strip()]
+    return parts[-1].split()[0] if parts else None  # dernière = + grande largeur
+
+
+def _normalize_shopify_url(u: str, enforce_width: int | None = 1024) -> str:
+    if not u:
+        return u
+    if u.startswith('//'):
+        u = 'https:' + u
+    s = urlsplit(u)
+    q = dict(parse_qsl(s.query, keep_blank_values=True))
+    # On conserve ?v=..., on supprime width pour la clé de dédup
+    q.pop('width', None)
+    if enforce_width:
+        q['width'] = str(enforce_width)
+    return urlunsplit((s.scheme, s.netloc, s.path, urlencode(q), s.fragment))
+
+
+def _dedupe_preserve_order(urls: list[str]) -> list[str]:
+    seen = set()
+    out = []
+    for u in urls:
+        s = urlsplit(u)
+        q = dict(parse_qsl(s.query, keep_blank_values=True))
+        v = q.get('v')
+        q.pop('width', None)
+        key = (s.netloc, s.path, v)  # ignore width, garde version
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(u)
+    return out
+
+# -------------------- Performance & comportement (env overrides) --------------------
+STATIC_SCRAPE_FIRST = bool(int(os.getenv("STATIC_SCRAPE_FIRST", "1")))   # tenter requests+BS4 avant Selenium
+REQUEST_TIMEOUT     = float(os.getenv("REQUEST_TIMEOUT", "6"))           # sec
+REQUEST_RETRIES     = int(os.getenv("REQUEST_RETRIES", "2"))
+DOWNLOAD_MAX_WORKERS= int(os.getenv("DOWNLOAD_MAX_WORKERS", "6"))        # parallélisme téléchargement
+MAX_IMAGES_PER_PRODUCT = int(os.getenv("MAX_IMAGES_PER_PRODUCT", "6"))   # limite utile (1 principale + up to 5)
+
+SCROLL_STEP_PX      = int(os.getenv("SCROLL_STEP_PX", "1000"))
+SCROLL_PAUSE        = float(os.getenv("SCROLL_PAUSE", "0.10"))           # sec
+SCROLL_MAX_SEC      = float(os.getenv("SCROLL_MAX_SEC", "8"))            # stop hard après X s
+SLIDER_CLICK_DELAY  = float(os.getenv("SLIDER_CLICK_DELAY", "0.20"))     # sec
+
+# Conversion WEBP (déjà ajoutée précédemment)
+FORCE_WEBP: bool = bool(int(os.getenv("SCRAPER_FORCE_WEBP", "1")))
+WEBP_QUALITY: int = int(os.getenv("SCRAPER_WEBP_QUALITY", "90"))
+WEBP_LOSSLESS: bool = bool(int(os.getenv("SCRAPER_WEBP_LOSSLESS", "0")))
+WEBP_METHOD: int = int(os.getenv("SCRAPER_WEBP_METHOD", "4"))         # 4 pour alléger le CPU
+
+# -------------------- Cache driver global (compat keep_driver) --------------------
+_GLOBAL_DRIVER = None
+
+
+def _get_cached_driver():
+    global _GLOBAL_DRIVER
+    if _GLOBAL_DRIVER is None:
+        _GLOBAL_DRIVER = _create_driver()
+    return _GLOBAL_DRIVER
+
+
+def _release_cached_driver():
+    global _GLOBAL_DRIVER
+    if _GLOBAL_DRIVER is not None:
+        with suppress(Exception):
+            _GLOBAL_DRIVER.quit()
+    _GLOBAL_DRIVER = None
+
+
+atexit.register(_release_cached_driver)
+
+# -------------------- URL utils (normalisation/validation) --------------------
+_DISALLOWED_SCHEMES = ("blob", "javascript", "mailto", "tel", "about", "chrome")
+
+def _clean_str(s: str) -> str:
+    # retire CR/LF et espaces parasites
+    return (s or "").strip().replace("\r", "").replace("\n", "")
+
+def _is_http_like(u: str) -> bool:
+    pu = urlparse(u)
+    return pu.scheme in ("http", "https")
+
+def _is_disallowed(u: str) -> bool:
+    pu = urlparse(u)
+    if pu.scheme in _DISALLOWED_SCHEMES:
+        return True
+    # évite les ancres pures et vides
+    if not pu.scheme and not pu.netloc and pu.path.startswith("#"):
+        return True
+    return False
+
+def _requote(u: str) -> str:
+    """Encodage sûr des caractères spéciaux dans path/query/fragment."""
+    pu = urlparse(u)
+    # encode path et query proprement (préserve schéma/host)
+    path = quote(pu.path or "", safe="/:@&=+$,;~*'()!-._")
+    query = quote(pu.query or "", safe="=&?:/+!$,;'@()*[]")
+    frag  = quote(pu.fragment or "", safe="=&?:/+!$,;'@()*[]")
+    return urlunparse((pu.scheme, pu.netloc, path, pu.params, query, frag))
+
+def _normalize_url(u: str, *, default_scheme: str = "https") -> str | None:
+    """Retourne une URL http(s) propre ou None si impossible."""
+    if not isinstance(u, str):
+        return None
+    u = _clean_str(u)
+    if not u:
+        return None
+    if _is_disallowed(u):
+        return None
+    pu = urlparse(u)
+    # si schéma manquant, préfixe par défaut (https://)
+    if not pu.scheme:
+        u = f"{default_scheme}://{u}"
+        pu = urlparse(u)
+    # si toujours pas http(s) -> rejet
+    if pu.scheme not in ("http", "https"):
+        return None
+    # encodage sûr
+    return _requote(u)
+
+def driver_get_safe(driver, url: str) -> bool:
+    """Tente driver.get(url) avec normalisation + retry; False si échec."""
+    try_urls = []
+    u1 = _normalize_url(url)
+    if u1:
+        try_urls.append(u1)
+    # deuxième tentative: forcer https si la 1ère échoue et qu'on n'a pas déjà https
+    if u1 and not u1.startswith("https://"):
+        try_urls.append("https://" + _clean_str(url).lstrip("/"))
+    elif not u1:
+        try_urls.append("https://" + _clean_str(url).lstrip("/"))
+    for u in try_urls:
+        try:
+            driver.get(u)
+            return True
+        except Exception as e:
+            # log allégé; on tente la suivante
+            print_safe(f"⚠️ driver.get retry failed for {repr(u)} → {e}")
+            continue
+    return False
+
+UPLOADS_BASE_URL = "https://www.planetebob.fr/wp-content/uploads/"
+
+
+def _make_http_session() -> requests.Session:
+    s = requests.Session()
+    retries = Retry(
+        total=REQUEST_RETRIES,
+        backoff_factor=0.4,
+        status_forcelist=(429, 500, 502, 503, 504),
+        allowed_methods=["GET", "HEAD"],
+    )
+    adapter = HTTPAdapter(max_retries=retries, pool_connections=20, pool_maxsize=20)
+    s.mount("http://", adapter)
+    s.mount("https://", adapter)
+    s.headers.update({"User-Agent": DEFAULT_USER_AGENT})
+    return s
+
+
+_DROP_PATTERNS = (
+    "-150x150", "-300x300", "-600x600",  # tailles WP courantes
+    "thumbnail", "thumb", "mini", "small",
+)
+
+
+def _is_useful_image_url(u: str) -> bool:
+    if not u:
+        return False
+    lu = _clean_str(u).lower()
+    if any(p in lu for p in _DROP_PATTERNS):
+        return False
+    if lu.startswith("data:") or lu.endswith(".svg"):
+        return False
+    # évite schémas non http(s)
+    if _is_disallowed(lu):
+        return False
+    if not _is_http_like(lu) and not lu.startswith("//"):
+        return False
+    return True
+
+
+def _collect_images_static(url: str, selector: str | None, session: requests.Session) -> list[str]:
+    """Retourne une liste d'URLs d'images en mode statique (sans JS).
+    Si selector est donné, on l'applique; sinon heuristique pour WooCommerce."""
+    try:
+        norm = _normalize_url(url)
+        if not norm:
+            return []
+        r = session.get(norm, timeout=REQUEST_TIMEOUT)
+        r.raise_for_status()
+    except Exception:
+        return []
+    html = r.text
+    with suppress(Exception):
+        from bs4 import BeautifulSoup
+
+        soup = BeautifulSoup(html, "html.parser")
+        # Ne viser que le carrousel principal, pas les thumbnails
+        gallery_imgs = soup.select('.product-gallery__media img, [data-media-type="image"] img')
+        gallery_imgs = [
+            img
+            for img in gallery_imgs
+            if 'product-gallery__thumbnail' not in ' '.join(img.get('class', []))
+        ]
+
+        collected: list[str] = []
+        for img in gallery_imgs:
+            url = img.get('src') or _best_from_srcset(img.get('srcset')) or img.get('data-src')
+            if not url:
+                continue
+            url = _normalize_shopify_url(url, enforce_width=1024)
+            collected.append(url)
+
+        unique_urls = _dedupe_preserve_order(collected)
+
+        limit = int(os.getenv('MAX_IMAGES_PER_PRODUCT', '6'))
+        if limit <= 0:
+            final_urls = unique_urls
+        else:
+            final_urls = unique_urls[:limit]
+
+        logger.info(
+            "Images: collected=%s, unique=%s, limited=%s",
+            len(collected),
+            len(unique_urls),
+            len(final_urls),
+        )
+
+        # >>> utiliser final_urls pour la suite du pipeline de téléchargement
+        return final_urls
+    return []
+
+
+def _scroll_quick(driver):
+    import time as _time
+
+    start = _time.perf_counter()
+    last_h = 0
+    while True:
+        driver.execute_script(f"window.scrollBy(0, {SCROLL_STEP_PX});")
+        _time.sleep(SCROLL_PAUSE)
+        h = driver.execute_script("return document.body.scrollHeight")
+        if h == last_h:
+            break
+        last_h = h
+        if _time.perf_counter() - start > SCROLL_MAX_SEC:
+            break
+
+
+def _try_slider_clicks(driver, dots_selector: str):
+    import time as _time
+
+    with suppress(Exception):
+        dots = driver.find_elements("css selector", dots_selector)
+        for d in dots[:8]:
+            with suppress(Exception):
+                d.click()
+                _time.sleep(SLIDER_CLICK_DELAY)
+
+
+def _collect_images_selenium(driver, url: str, selector: str | None) -> list[str]:
+    ok = driver_get_safe(driver, url)
+    if not ok:
+        print_safe(f"⛔️ Navigation ignorée (URL invalide): {repr(url)}")
+        return []
+    _scroll_quick(driver)
+    if selector:
+        elems = driver.find_elements("css selector", selector)
+    else:
+        elems = driver.find_elements(
+            "css selector", ".product-gallery__media img, [data-media-type='image'] img"
+        )
+
+    urls: list[str] = []
+    for e in elems:
+        classes = (e.get_attribute("class") or "")
+        if "product-gallery__thumbnail" in classes.split():
+            continue
+        u = (
+            e.get_attribute("src")
+            or _best_from_srcset(e.get_attribute("srcset"))
+            or e.get_attribute("data-src")
+        )
+        if not u:
+            continue
+        urls.append(_normalize_shopify_url(u, enforce_width=1024))
+
+    unique_urls = _dedupe_preserve_order(urls)
+
+    limit = int(os.getenv('MAX_IMAGES_PER_PRODUCT', '6'))
+    if limit <= 0:
+        final_urls = unique_urls
+    else:
+        final_urls = unique_urls[:limit]
+
+    logger.info(
+        "Images: collected=%s, unique=%s, limited=%s",
+        len(urls),
+        len(unique_urls),
+        len(final_urls),
+    )
+
+    return final_urls
+
+def build_uploads_url(
+    product_slug: str,
+    variant_slug: str,
+    *,
+    year=None,
+    month=None,
+    ext: str | None = None,
+) -> str:
+    if year is None or month is None:
+        now = datetime.now()
+        year, month = now.year, now.month
+    # Détermine l'extension par défaut selon le feature flag, sans casser les appels existants.
+    if ext is None:
+        ext = ".webp" if FORCE_WEBP else ".jpg"
+    if not ext.startswith("."):
+        ext = "." + ext
+    return f"{UPLOADS_BASE_URL}{year}/{month:02d}/{product_slug}-{variant_slug}{ext}"
+
+
+def _create_driver(user_agent: str = DEFAULT_USER_AGENT) -> ChromeDriver:
+    opts = Options()
+    opts.add_argument("--headless=new")
+    opts.add_argument("--disable-gpu")
+    opts.add_argument("--no-sandbox")
+    opts.add_argument("--disable-dev-shm-usage")
+    opts.add_argument("--disable-software-rasterizer")
+    opts.add_argument("--window-size=1366,768")
+    opts.add_argument("--disable-extensions")
+    opts.add_argument("--disable-notifications")
+    opts.add_argument("--disable-background-timer-throttling")
+    opts.add_argument(f"--user-agent={user_agent}")
+    opts.add_argument("--disable-blink-features=AutomationControlled")
+    opts.add_experimental_option("excludeSwitches", ["enable-automation"])
+    opts.add_experimental_option("useAutomationExtension", False)
+
+    opts.page_load_strategy = "eager"
+
+    driver = webdriver.Chrome(options=opts)
+    driver.set_page_load_timeout(30)
+    driver.execute_cdp_cmd(
+        "Page.addScriptToEvaluateOnNewDocument",
+        {"source": "Object.defineProperty(navigator, 'webdriver', {get: () => undefined});"},
+    )
+    return driver
+
+
+def _scroll_page(driver: ChromeDriver, pause: float = 0.5) -> None:
+    last_height = driver.execute_script("return document.body.scrollHeight")
+    position = 0
+    while position < last_height:
+        position += 600
+        driver.execute_script(f"window.scrollTo(0, {position});")
+        time.sleep(pause)
+        last_height = driver.execute_script("return document.body.scrollHeight")
+
+
+def infer_pagination_template(url: str) -> tuple[str | None, int]:
+    """
+    Retourne (template, start_page) si détecté, sinon (None, 1).
+    """
+    m = re.search(r"([?&](?:page|paged)=(\d+))", url)
+    if m:
+        full, num = m.groups()
+        tpl = url.replace(full, full.split("=")[0] + "={page}")
+        return tpl, int(num)
+    m = re.search(r"/page/(\d+)", url)
+    if m:
+        num = m.group(1)
+        tpl = re.sub(r"/page/\d+", "/page/{page}", url)
+        return tpl, int(num)
+    return None, 1
+
+
+def generate_page_urls(template: str, start: int, end: int) -> list[str]:
+    return [template.replace("{page}", str(i)) for i in range(start, end + 1)]
+
+
+def find_next_link(driver) -> str | None:
+    selectors = [
+        "a[rel='next']",
+        "link[rel='next']",
+        "nav .pagination a.next",
+        ".pagination [aria-label*='Suivant']",
+        ".pagination [aria-label*='Next']",
+        "a.next",
+    ]
+    for sel in selectors:
+        try:
+            el = driver.find_element(By.CSS_SELECTOR, sel)
+            href = (el.get_attribute("href") or "").strip()
+            if href:
+                if href.startswith("/"):
+                    return urljoin(driver.current_url, href)
+                return href
+        except Exception:
+            continue
+    return None
+
+
+def scrape_collection_products_paginated(
+    page_urls: list[str],
+    on_driver_ready: Callable[[Any], None],
+    is_cancelled: Callable[[], bool],
+    log: Callable[[str], None] | None,
+    link_cb: Callable[[str], None] | None,
+    page_cb: Callable[[int, int, int, int], None] | None = None,
+    *,
+    auto_follow: bool = False,
+    max_pages: int = 20,
+) -> list[str]:
+    """
+    Parcourt chaque URL de collection, extrait les liens produits (href),
+    déduplique globalement, annulation coopérative.
+    """
+    driver = _create_driver()
+    on_driver_ready(driver)
+    seen: set[str] = set()
+    try:
+        idx = 0
+        while idx < len(page_urls):
+            if is_cancelled():
+                raise RuntimeError("cancelled")
+            url = page_urls[idx]
+            driver.get(url)
+            if log:
+                log(f"📄 {idx+1}/{len(page_urls)} — {url}")
+            WebDriverWait(driver, 20).until(
+                EC.presence_of_element_located(
+                    (
+                        By.CSS_SELECTOR,
+                        "product-card,.product-card,[data-product-card],ul#product-grid li,.collection .grid .grid__item",
+                    )
+                )
+            )
+            _scroll_page(driver, pause=0.5)
+
+            for _ in range(3):
+                if is_cancelled():
+                    raise RuntimeError("cancelled")
+                try:
+                    btn = driver.find_element(
+                        By.CSS_SELECTOR,
+                        "button#product-grid-load-more,a.load-more,button.load-more",
+                    )
+                    if not btn.is_displayed() or not btn.is_enabled():
+                        break
+                    driver.execute_script("arguments[0].click();", btn)
+                    time.sleep(0.8)
+                    _scroll_page(driver, pause=0.3)
+                except Exception:
+                    break
+
+            cards = driver.find_elements(
+                By.CSS_SELECTOR,
+                "product-card,.product-card,[data-product-card],ul#product-grid li,.collection .grid .grid__item",
+            )
+            before = len(seen)
+            for card in cards:
+                if is_cancelled():
+                    raise RuntimeError("cancelled")
+                a = None
+                for sel in (
+                    ".product-card__title a",
+                    "a[href^='/products/']",
+                    "a.card-information__link",
+                ):
+                    try:
+                        a = card.find_element(By.CSS_SELECTOR, sel)
+                        break
+                    except Exception:
+                        continue
+                if not a:
+                    continue
+                href = (
+                    a.get_attribute("href")
+                    or a.get_attribute("data-href")
+                    or ""
+                ).strip()
+                if href.startswith("/"):
+                    href = urljoin(url, href)
+                if href.startswith("http") and href not in seen:
+                    seen.add(href)
+                    if link_cb:
+                        link_cb(href)
+            new = len(seen) - before
+            if page_cb:
+                page_cb(idx + 1, len(page_urls), new, len(seen))
+
+            idx += 1
+            if auto_follow and len(page_urls) < max_pages:
+                nxt = find_next_link(driver)
+                if nxt and nxt not in page_urls:
+                    page_urls.append(nxt)
+
+        return sorted(seen)
+    except Exception as exc:
+        if str(exc) == "cancelled":
+            raise
+        raise RuntimeError(f"paginated scrape failed: {exc}") from exc
+    finally:
+        try:
+            driver.quit()
+        except Exception:
+            pass
+
+
+def scrape_collection_products_cancelable(
+    page_url: str,
+    on_driver_ready: Callable[[Any], None],
+    is_cancelled: Callable[[], bool],
+    log: Callable[[str], None] | None = None,
+) -> list[tuple[str, str]]:
+    """
+    Variante annulable. on_driver_ready(driver) est appelé après création.
+    is_cancelled() est consulté régulièrement (avant/pendant les waits, boucles, scrolls).
+    """
+    driver = _create_driver()
+    if on_driver_ready:
+        on_driver_ready(driver)
+    try:
+        out: list[tuple[str, str]] = []
+
+        if is_cancelled():
+            raise RuntimeError("cancelled")
+        driver.set_page_load_timeout(25)
+        driver.get(page_url)
+        if log:
+            log("🌐 Page chargée.")
+
+        selectors = [
+            "product-card, .product-card",
+            "[data-product-card]",
+            "ul#product-grid li, .collection .grid .grid__item",
+        ]
+        WebDriverWait(driver, 20).until(
+            EC.presence_of_element_located((By.CSS_SELECTOR, ",".join(selectors)))
+        )
+
+        if is_cancelled():
+            raise RuntimeError("cancelled")
+        _scroll_page(driver, pause=0.5)
+
+        clicks = 0
+        while clicks < 5:
+            if is_cancelled():
+                raise RuntimeError("cancelled")
+            try:
+                load_more = driver.find_element(
+                    By.CSS_SELECTOR,
+                    "button#product-grid-load-more, a.load-more, button.load-more",
+                )
+                if not load_more.is_displayed() or not load_more.is_enabled():
+                    break
+                driver.execute_script("arguments[0].click();", load_more)
+                clicks += 1
+                if log:
+                    log(f"↻ Voir plus… ({clicks})")
+                time.sleep(1.0)
+                _scroll_page(driver, pause=0.3)
+            except Exception:
+                break
+
+        if is_cancelled():
+            raise RuntimeError("cancelled")
+        cards = driver.find_elements(By.CSS_SELECTOR, ",".join(selectors))
+
+        for card in cards:
+            if is_cancelled():
+                raise RuntimeError("cancelled")
+            a = None
+            for sel in (
+                ".product-card__title a",
+                "a[href^='/products/']",
+                "a.card-information__link",
+            ):
+                try:
+                    a = card.find_element(By.CSS_SELECTOR, sel)
+                    if a:
+                        break
+                except Exception:
+                    continue
+            if not a:
+                continue
+            name = (a.text or "").strip()
+            href = (a.get_attribute("href") or a.get_attribute("data-href") or "").strip()
+            if href.startswith("/"):
+                href = urljoin(page_url, href)
+            if name and href and href.startswith("http"):
+                out.append((name, href))
+
+        unique: list[tuple[str, str]] = []
+        seen: set[str] = set()
+        for name, href in out:
+            if href not in seen:
+                seen.add(href)
+                unique.append((name, href))
+        return unique
+    except Exception as exc:
+        if str(exc) == "cancelled":
+            raise
+        raise RuntimeError(
+            f"scrape_collection_products failed for '{page_url}': {exc}"
+        ) from exc
+    finally:
+        try:
+            driver.quit()
+        except Exception:
+            pass
+
+
+def scrape_collection_products(page_url: str) -> list[tuple[str, str]]:
+    return scrape_collection_products_cancelable(page_url, lambda d: None, lambda: False, None)
+
+
+def _simulate_slider_interaction(driver: ChromeDriver) -> None:
+    try:
+        dots = driver.find_elements(By.CSS_SELECTOR, ".flickity-page-dots .dot")
+        for i, dot in enumerate(dots):
+            driver.execute_script("arguments[0].click();", dot)
+            print_safe(f"🟡 Clic sur le point {i+1}/{len(dots)}")
+            time.sleep(1.2)
+    except Exception as e:
+        print_safe(f"⚠️ Aucun slider détecté ou erreur : {e}")
+
+
+def _extract_urls(driver: ChromeDriver, selector: str) -> List[str]:
+    elements = driver.find_elements(By.CSS_SELECTOR, selector)
+    urls: Set[str] = set()
+
+    for el in elements:
+        tag = el.tag_name.lower()
+
+        # Si c'est une balise <a>, on essaie de récupérer l'attribut href
+        if tag == "a":
+            href = el.get_attribute("href")
+            if href and href.endswith((".jpg", ".jpeg", ".png", ".webp")):
+                urls.add(href)
+                continue
+
+        # Si c'est une balise <img> ou autre avec data-photoswipe-src / src / data-src
+        src = (
+            el.get_attribute("data-photoswipe-src")
+            or el.get_attribute("src")
+            or el.get_attribute("data-src")
+        )
+        if src:
+            if src.startswith("//"):
+                src = "https:" + src
+            elif src.startswith("/"):
+                src = urljoin(driver.current_url, src)
+        if src and not src.startswith("data:image"):
+            urls.add(src)
+            continue
+
+        # Vérifie aussi dans le style (cas d'image en background)
+        style = el.get_attribute("style") or ""
+        match = re.search(r"url\(['\"]?(.*?)['\"]?\)", style)
+        if match:
+            url = match.group(1)
+            if not url.startswith("data:image"):
+                urls.add(url)
+
+    return list(urls)
+
+
+def _download(url: str, folder: Path, session: requests.Session | None = None) -> None:
+    if url.startswith("data:image"):
+        print_safe(f"\u26A0\uFE0F Ignoré (image base64) : {url[:50]}...")
+        return
+
+    try:
+        s = session or _make_http_session()
+        resp = s.get(url, timeout=REQUEST_TIMEOUT)
+        resp.raise_for_status()
+
+        # Vérifie que la réponse est bien une image
+        content_type = resp.headers.get("Content-Type", "")
+        if not content_type.startswith("image/"):
+            print_safe(f"\u274c Mauvais type de contenu pour {url}: {content_type}")
+            return
+
+        # Ignore les contenus vides ou trop petits pour être une image réelle
+        if not resp.content or len(resp.content) < 100:
+            print_safe(f"\u26A0\uFE0F Réponse vide ou suspecte pour {url}")
+            return
+
+    except Exception as exc:
+        print_safe(f"\u274c Erreur lors du téléchargement de {url}: {exc}")
+        return
+
+    # --- Normalisation du nom et de l'extension ---
+    orig_name = os.path.basename(url.split("?")[0]) or "image"
+    stem, orig_ext = os.path.splitext(orig_name)
+    stem = re.sub(r"-\d+$", "", stem)  # nettoie suffixes type "-409"
+
+    # Choix de l'extension cible
+    target_ext = ".webp" if FORCE_WEBP else (orig_ext or ".jpg")
+    path = folder / f"{stem}{target_ext}"
+    base, _ = os.path.splitext(path)
+    idx = 1
+    while path.exists():
+        path = Path(f"{base}_{idx}{target_ext}")
+        idx += 1
+
+    # Récupération du Content-Type pour fallback intelligent
+    content_type = resp.headers.get("Content-Type", "").lower()
+
+    if FORCE_WEBP:
+        if Image is None:
+            print_safe("⚠️ Pillow non installé : conversion WEBP impossible, écriture brute à l’extension source.")
+            # fallback : on écrit le flux tel quel avec l’extension d’origine si dispo, sinon .jpg
+            raw_ext = orig_ext if orig_ext else ".jpg"
+            raw_path = folder / f"{stem}{raw_ext}"
+            raw_base, _ = os.path.splitext(raw_path)
+            i = 1
+            while raw_path.exists():
+                raw_path = Path(f"{raw_base}_{i}{raw_ext}")
+                i += 1
+            with open(raw_path, "wb") as f:
+                f.write(resp.content)
+            return
+
+        try:
+            im = Image.open(BytesIO(resp.content))
+            # Normalise le mode couleur pour éviter les erreurs d’enregistrement
+            if im.mode in ("P", "LA"):
+                im = im.convert("RGBA")
+            elif im.mode not in ("RGB", "RGBA"):
+                im = im.convert("RGB")
+
+            save_kwargs = {"format": "WEBP", "method": WEBP_METHOD}
+            if WEBP_LOSSLESS:
+                save_kwargs.update(lossless=True, quality=100)
+            else:
+                save_kwargs.update(quality=WEBP_QUALITY)
+            im.save(path, **save_kwargs)
+        except Exception as e:
+            # Fallback: si la source était déjà webp ou que Pillow échoue, écrit brut
+            if "image/webp" in content_type or (orig_ext.lower() == ".webp"):
+                with open(path, "wb") as f:
+                    f.write(resp.content)
+            else:
+                print_safe(f"❌ Erreur conversion WEBP pour {url}: {e}")
+                # ne pas lever d’exception dure : on log et on continue le lot
+                return
+    else:
+        # Mode legacy : écrit tel quel
+        with open(path, "wb") as f:
+            f.write(resp.content)
+
+
+def download_many(urls: list[str], folder: Path, session: requests.Session | None = None):
+    if not urls:
+        return
+    folder.mkdir(parents=True, exist_ok=True)
+    with ThreadPoolExecutor(max_workers=DOWNLOAD_MAX_WORKERS) as ex:
+        futures = [ex.submit(_download, u, folder, session) for u in urls]
+        for _ in as_completed(futures):
+            pass
+
+def _folder_from_url(url: str) -> Path:
+    """Return a folder name derived from ``url``.
+
+    The last segment of the path is used, hyphens are replaced with spaces and
+    unsafe characters are removed.
+    """
+    from urllib.parse import urlparse, unquote
+
+    path = unquote(urlparse(url).path)
+    name = Path(path).name.replace("-", " ")
+    # keep alphanumeric characters, spaces and underscores only
+    name = re.sub(r"[^\w\s]", "", name).strip()
+    return Path(name or "images")
+
+
+def scrape_images(
+    url: str,
+    selector: str | None,
+    folder: Path,
+    *,
+    keep_driver: bool = False,
+    **_unused,
+) -> int | tuple[int, ChromeDriver]:
+    """Scrape les images pour une URL et retourne le nombre téléchargé.
+
+    - ``keep_driver=True``  => réutilise un driver global entre appels (cache) et le
+      retourne avec le total téléchargé.
+    - ``keep_driver=False`` => crée/ferme un driver si Selenium est nécessaire et
+      retourne uniquement le total.
+    """
+
+    session = _make_http_session()
+    driver = None
+    total = 0
+    try:
+        if keep_driver:
+            driver = _GLOBAL_DRIVER  # peut rester None tant qu'on n'a pas besoin de Selenium
+
+        url = _normalize_url(url) or url
+        images: list[str] = []
+        if STATIC_SCRAPE_FIRST:
+            images = _collect_images_static(url, selector, session)
+        if not images:
+            if driver is None:
+                driver = _get_cached_driver() if keep_driver else _create_driver()
+            images = _collect_images_selenium(driver, url, selector)
+
+        clean = []
+        for u in images:
+            nu = _normalize_url(u) if not u.startswith("//") else "https:" + _clean_str(u)
+            if nu and _is_useful_image_url(nu):
+                clean.append(nu)
+        images = list(dict.fromkeys(clean))[:MAX_IMAGES_PER_PRODUCT]
+        total = len(images)
+        dest = Path(folder) / _folder_from_url(url)
+        download_many(images, dest, session=session)
+    finally:
+        if driver is not None and not keep_driver:
+            with suppress(Exception):
+                driver.quit()
+
+    return (total, driver) if keep_driver else total
+
+
+def scrape_variants(driver: ChromeDriver) -> dict[str, str]:
+    """Extract product variant names and associated image URLs using ``driver``.
+
+    ``driver`` must already be on the product page. Each variant input is
+    expected inside the ``.variant-picker__option-values`` container.  The
+    function clicks on each corresponding label, waits for the main product
+    image to update and collects the resulting URL.
+    """
+
+    mapping: dict[str, str] = {}
+
+    def _slugify(text: str) -> str:
+        text = unicodedata.normalize('NFKD', text)
+        text = text.encode('ascii', 'ignore').decode('ascii')
+        text = re.sub(r"[^a-zA-Z0-9\s-]", "", text)
+        text = re.sub(r"[\s_-]+", "-", text).strip("-")
+        return text.lower()
+
+    product_path = unquote(urlparse(driver.current_url).path).rstrip("/")
+    product_name = Path(product_path).name
+    product_slug = _slugify(product_name)
+
+    def _img_url(el):
+        return (
+            el.get_attribute("src")
+            or el.get_attribute("data-photoswipe-src")
+            or el.get_attribute("data-src")
+        )
+
+    selectors = [
+        ".woocommerce-product-gallery__image img",
+        ".product-media img",
+        ".product-image img",
+        ".product-gallery img",
+        ".product-main img",
+    ]
+
+    def _find_main_image() -> WebElement | None:
+        for sel in selectors + ["img"]:
+            try:
+                img = driver.find_element(By.CSS_SELECTOR, sel)
+                if img.is_displayed():
+                    return img
+            except Exception:
+                continue
+        return None
+
+    try:
+        inputs = driver.find_elements(
+            By.CSS_SELECTOR, ".variant-picker__option-values input[type='radio']"
+        )
+        if not inputs:
+            return mapping
+
+        main_img = _find_main_image()
+        if main_img is None:
+            return mapping
+
+        for inp in inputs:
+            value = inp.get_attribute("value") or inp.get_attribute("data-value")
+            input_id = inp.get_attribute("id")
+            label = None
+            if input_id:
+                try:
+                    label = driver.find_element(By.CSS_SELECTOR, f"label[for='{input_id}']")
+                except Exception:
+                    label = None
+            if label is None:
+                try:
+                    label = inp.find_element(By.XPATH, "following-sibling::label[1]")
+                except Exception:
+                    continue
+
+            previous = _img_url(main_img)
+            driver.execute_script("arguments[0].click()", label)
+            try:
+                WebDriverWait(driver, 5).until(
+                    lambda d: (_img_url(_find_main_image()) or "") != (previous or "")
+                )
+            except Exception:
+                pass
+
+            new_img = _find_main_image() or main_img
+            main_img = new_img
+            if value:
+                variant_slug = _slugify(value)
+                url = build_uploads_url(product_slug, variant_slug)
+                mapping[value] = url
+    except Exception as exc:
+        print_safe(f"⚠️ Erreur lors du scraping des variantes: {exc}")
+
+    return mapping
+
+
+if __name__ == "__main__":
+    scrape_images("https://exemple.com/produit", ".product-image img")
+
+### >>> MOTEUR/scraping/profile_manager.py (77 lignes)
+import json
+from pathlib import Path
+from typing import List, Dict
+
+try:
+    from localapp.log_safe import open_utf8
+except ImportError:
+    from log_safe import open_utf8
+
+# Path to the JSON file storing profiles. By default it is located at the
+# project root but can be overridden in tests by changing this variable.
+PROFILES_FILE = Path(__file__).resolve().parents[2] / "profiles.json"
+
+
+def load_profiles() -> List[Dict[str, str]]:
+    """Load scraping profiles from :data:`PROFILES_FILE`.
+
+    Returns an empty list if the file does not exist or is empty.
+    """
+    if not PROFILES_FILE.exists():
+        return []
+    try:
+        with open_utf8(PROFILES_FILE, "r") as f:
+            data = json.load(f)
+        if isinstance(data, list):
+            return [p for p in data if isinstance(p, dict)]
+    except Exception:
+        pass
+    return []
+
+
+def save_profiles(profiles: List[Dict[str, str]]) -> None:
+    """Write ``profiles`` to :data:`PROFILES_FILE` in JSON format."""
+    with open_utf8(PROFILES_FILE, "w") as f:
+        json.dump(profiles, f, indent=2, ensure_ascii=False)
+
+
+def add_profile(name: str, selector: str) -> None:
+    """Add a new profile with ``name`` and ``selector``.
+
+    Raises ``ValueError`` if a profile with the same name already exists.
+    """
+    profiles = load_profiles()
+    if any(p.get("name") == name for p in profiles):
+        raise ValueError(f"Profile '{name}' already exists")
+    profiles.append({"name": name, "selector": selector})
+    save_profiles(profiles)
+
+
+def update_profile(name: str, selector: str) -> bool:
+    """Update an existing profile's selector.
+
+    Returns ``True`` if the profile was updated, ``False`` otherwise.
+    """
+    profiles = load_profiles()
+    updated = False
+    for profile in profiles:
+        if profile.get("name") == name:
+            profile["selector"] = selector
+            updated = True
+            break
+    if updated:
+        save_profiles(profiles)
+    return updated
+
+
+def delete_profile(name: str) -> bool:
+    """Delete the profile with ``name``.
+
+    Returns ``True`` if the profile was removed, ``False`` otherwise.
+    """
+    profiles = load_profiles()
+    new_profiles = [p for p in profiles if p.get("name") != name]
+    if len(new_profiles) == len(profiles):
+        return False
+    save_profiles(new_profiles)
+    return True
+
+### >>> MOTEUR/scraping/server/__init__.py (5 lignes)
+"""Utilities for exposing the scraping features through a Flask bridge."""
+
+from .flask_server import FlaskBridgeServer, JobManager, JobStatus
+
+__all__ = ["FlaskBridgeServer", "JobManager", "JobStatus"]
+
+### >>> MOTEUR/scraping/server/flask_server.py (767 lignes)
+from __future__ import annotations
+
+"""Small Flask server to remotely trigger scraping jobs.
+
+The module exposes :class:`FlaskBridgeServer` which wraps a Flask
+application and provides a thread based HTTP server.  The endpoints are
+minimal and secured through an API key passed in the ``X-API-KEY``
+header.  Jobs are executed in a :class:`~concurrent.futures.ThreadPoolExecutor`
+so the UI remains responsive.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+import csv
+import datetime as _dt
+from datetime import datetime
+import json
+import logging
+import os
+import re
+import threading
+import time
+import uuid
+from pathlib import Path
+from urllib.parse import quote
+from functools import wraps
+
+from flask import Flask, request, jsonify, send_file
+from werkzeug.serving import make_server
+from concurrent.futures import ThreadPoolExecutor, Future
+
+from ..image_scraper import scrape_images, scrape_variants
+from ..profile_manager import load_profiles
+from ..history import load_history
+
+
+log = logging.getLogger("flask-bridge")
+log.setLevel(logging.INFO)
+
+IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".webp"}
+
+
+@dataclass
+class JobStatus:
+    """Represents the state of a running scraping job."""
+
+    job_id: str
+    status: str = "queued"   # queued|running|done|error
+    progress: Dict[str, int] = field(
+        default_factory=lambda: {"found": 0, "downloaded": 0, "failed": 0}
+    )
+    output_dir: str = ""
+    started_at: Optional[str] = None
+    finished_at: Optional[str] = None
+    variants: Dict[str, str] = field(default_factory=dict)
+    sample_images: list[str] = field(default_factory=list)
+    errors: list[Dict[str, str]] = field(default_factory=list)
+    message: str = ""
+
+
+class JobManager:
+    """Simple registry for running scraping jobs."""
+
+    def __init__(self, max_workers: int = 2) -> None:
+        self.jobs: Dict[str, JobStatus] = {}
+        self.executor = ThreadPoolExecutor(max_workers=max_workers)
+        self.lock = threading.Lock()
+
+    def submit(self, fn, *args, **kwargs) -> JobStatus:
+        job_id = uuid.uuid4().hex[:12]
+        st = JobStatus(job_id=job_id)
+        with self.lock:
+            self.jobs[job_id] = st
+        self.executor.submit(fn, st, *args, **kwargs)
+        return st
+
+
+class StoppableWSGIServer(threading.Thread):
+    """Wrapper around Werkzeug's WSGI server allowing clean shutdown."""
+
+    def __init__(self, app: Flask, host: str, port: int) -> None:
+        super().__init__(daemon=True)
+        self.srv = make_server(host, port, app)
+        self.ctx = app.app_context()
+        self.ctx.push()
+
+    def run(self) -> None:  # pragma: no cover - simple thread runner
+        self.srv.serve_forever()
+
+    def shutdown(self) -> None:
+        self.srv.shutdown()
+        self.ctx.pop()
+
+
+class FlaskBridgeServer:
+    """Expose scraping helpers through a small Flask application."""
+
+    def __init__(self, on_log=None) -> None:
+        self.on_log = on_log
+        self.app = Flask(__name__)
+        self._server: Optional[StoppableWSGIServer] = None
+        self._ngrok_tunnel = None
+        self.public_url = ""
+        self.api_key = os.getenv("SCRAPER_API_KEY", "")
+        self.default_flags = {
+            "headless": True,
+            "ignore_robots": False,
+            "rate_limit": 0,
+            "max_workers": 1,
+        }
+        self.jobs = JobManager(max_workers=2)
+        self.path_aliases = getattr(self, "path_aliases", {"sample_folder": ""})
+        self._normalize_aliases()
+        self._mount_routes()
+
+    # ------------------------------------------------------------------
+    # helpers
+    def _log(self, msg: str) -> None:
+        log.info(msg)
+        if self.on_log:
+            self.on_log(msg)
+
+    def _resolve_folder(self, raw: str) -> str:
+        s = (raw or "").strip()
+        if not s:
+            return ""
+        if s in self.path_aliases and self.path_aliases[s]:
+            return self.path_aliases[s]
+        s = os.path.expandvars(os.path.expanduser(s))
+        return str(Path(s))
+
+    def _normalize_aliases(self) -> None:
+        """Garantit que 'sample_images' pointe sur 'sample_folder' si non défini."""
+        try:
+            sf = (self.path_aliases.get("sample_folder") or "").strip()
+            si = (self.path_aliases.get("sample_images") or "").strip()
+            if sf and not si:
+                self.path_aliases["sample_images"] = sf
+                self._log(f"Alias ajouté : sample_images -> {sf}")
+        except Exception as e:
+            self._log(f"⚠️ Normalisation alias échouée: {e}")
+
+    # ------------------------------------------------------------------
+    # Flask routes
+    def _mount_routes(self) -> None:
+        app = self.app
+
+        # CONSTANTES / CONFIG ---------------------------------------------
+        image_exts = IMAGE_EXTS
+
+        # UTILS -----------------------------------------------------------
+        # SÉCURITÉ -------------------------------------------------------
+        def require_api_key(fn):
+            @wraps(fn)
+            def wrapper(*args, **kwargs):
+                key = request.headers.get("X-API-KEY", "")
+                if not self.api_key or key != self.api_key:
+                    return jsonify({"error": "unauthorized"}), 401
+                return fn(*args, **kwargs)
+
+            return wrapper
+
+        # ENDPOINTS ------------------------------------------------------
+
+        @app.get("/health")
+        def health() -> Any:
+            return (
+                jsonify(
+                    {
+                        "ok": True,
+                        "version": "1.0",
+                        "time": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                    }
+                ),
+                200,
+            )
+
+        @app.get("/aliases")
+        @require_api_key
+        def get_aliases() -> Any:
+            return jsonify(self.path_aliases)
+
+        @app.post("/aliases")
+        @require_api_key
+        def post_aliases() -> Any:
+            data = request.get_json(force=True, silent=True) or {}
+            for k, v in (data.items() if isinstance(data, dict) else []):
+                if isinstance(v, str):
+                    self.path_aliases[k] = v.strip()
+            self._normalize_aliases()
+            return jsonify(self.path_aliases), 200
+
+        @app.get("/files/list")
+        @require_api_key
+        def files_list() -> Any:
+            raw_folder = (request.args.get("folder") or "").strip()
+            folder = (
+                self._resolve_folder(raw_folder)
+                if hasattr(self, "_resolve_folder")
+                else raw_folder
+            )
+            p = Path(folder)
+            if not p.exists() or not p.is_dir():
+                return (
+                    jsonify(
+                        {
+                            "error": "invalid_request",
+                            "detail": f"folder not found: {folder}",
+                        }
+                    ),
+                    400,
+                )
+
+            files = [
+                f.name
+                for f in p.iterdir()
+                if f.is_file() and f.suffix.lower() in image_exts
+            ]
+            base = request.host_url.rstrip("/")
+            urls = [
+                f"{base}/files/raw?folder={quote(raw_folder)}&name={quote(name)}"
+                for name in files
+            ]
+            return jsonify(
+                {
+                    "folder": raw_folder or folder,
+                    "count": len(files),
+                    "files": files,
+                    "urls": urls,
+                }
+            )
+
+        @app.get("/files/raw")
+        @require_api_key
+        def files_raw() -> Any:
+            raw_folder = (request.args.get("folder") or "").strip()
+            name = (request.args.get("name") or "").strip()
+            if not name:
+                return (
+                    jsonify({"error": "invalid_request", "detail": "name required"}),
+                    400,
+                )
+            folder = (
+                self._resolve_folder(raw_folder)
+                if hasattr(self, "_resolve_folder")
+                else raw_folder
+            )
+            p = Path(folder) / name
+            if not p.exists() or not p.is_file():
+                return (
+                    jsonify(
+                        {
+                            "error": "invalid_request",
+                            "detail": f"file not found: {p}",
+                        }
+                    ),
+                    404,
+                )
+            if p.suffix.lower() not in image_exts:
+                return (
+                    jsonify(
+                        {
+                            "error": "invalid_request",
+                            "detail": "unsupported file type",
+                        }
+                    ),
+                    400,
+                )
+            return send_file(str(p), as_attachment=False)
+
+        @app.post("/scrape")
+        @require_api_key
+        def scrape() -> Any:
+            data = request.get_json(force=True, silent=True) or {}
+            url = data.get("url")
+            selector = data.get("selector")
+            if not url or not selector:
+                return (
+                    jsonify({"error": "invalid_request", "detail": "url & selector required"}),
+                    400,
+                )
+            folder = data.get("folder") or "images"
+            opts = {**self.default_flags, **(data.get("options") or {})}
+            st = self.jobs.submit(self._run_scrape_job, url, selector, folder, opts)
+            self._log(f"Job {st.job_id} accepté pour {url}")
+            return jsonify({"job_id": st.job_id, "message": "accepted"}), 202
+
+        @app.post("/actions/image-edit")
+        @require_api_key
+        def image_edit() -> Any:
+            data = request.get_json(force=True, silent=True) or {}
+            raw_src = ((data.get("source") or {}).get("folder") or "").strip()
+            src = self._resolve_folder(raw_src)
+            ops = data.get("operations") or []
+            target_subdir = (data.get("target_subdir") or "image fait par gpt").strip()
+            if not src:
+                return (
+                    jsonify(
+                        {
+                            "error": "invalid_request",
+                            "detail": "source.folder is empty",
+                        }
+                    ),
+                    400,
+                )
+            p = Path(src)
+            if not p.exists():
+                return (
+                    jsonify(
+                        {
+                            "error": "invalid_request",
+                            "detail": f"source not found: {src}",
+                        }
+                    ),
+                    400,
+                )
+            has_images = any(
+                pp.suffix.lower() in image_exts for pp in p.iterdir() if pp.is_file()
+            )
+            if not has_images:
+                return (
+                    jsonify(
+                        {
+                            "error": "invalid_request",
+                            "detail": f"no images in: {src}",
+                        }
+                    ),
+                    400,
+                )
+            if not ops:
+                return (
+                    jsonify(
+                        {
+                            "error": "invalid_request",
+                            "detail": "operations required",
+                        }
+                    ),
+                    400,
+                )
+            st = self.jobs.submit(self._run_image_action_job, src, ops, target_subdir)
+            self._log(
+                f"Job {st.job_id} image-edit: {src} -> {target_subdir} ({len(ops)} ops)"
+            )
+            return jsonify({"job_id": st.job_id, "message": "accepted"}), 202
+
+        @app.get("/jobs/<job_id>")
+        @require_api_key
+        def job_status(job_id: str) -> Any:
+            st = self.jobs.jobs.get(job_id)
+            if not st:
+                return jsonify({"error": "not_found"}), 404
+            return jsonify(st.__dict__)
+
+        @app.get("/jobs")
+        @require_api_key
+        def list_jobs() -> Any:
+            return jsonify([j.__dict__ for j in self.jobs.jobs.values()])
+
+        @app.get("/profiles")
+        @require_api_key
+        def profiles() -> Any:
+            profs = load_profiles()
+            out = [
+                {"name": p.get("name", ""), "selector": p.get("selector", "")}
+                for p in profs
+            ]
+            out.sort(key=lambda p: p["name"])
+            return jsonify(out), 200
+
+        @app.post("/profiles")
+        @require_api_key
+        def add_profile_route() -> Any:
+            data = request.get_json(force=True, silent=True) or {}
+            name = (data.get("name") or "").strip()
+            selector = (data.get("selector") or "").strip()
+            if not name or not selector:
+                return (
+                    jsonify(
+                        {
+                            "error": "invalid_request",
+                            "detail": "name and selector required",
+                        }
+                    ),
+                    400,
+                )
+            try:
+                from .. import profile_manager as pm
+
+                pm.add_profile(name, selector)
+            except ValueError:
+                return jsonify({"error": "exists"}), 409
+
+            try:
+                from PySide6.QtCore import QMetaObject, Qt
+                from ..bus.event_bus import bus
+
+                QMetaObject.invokeMethod(bus, "profiles_changed", Qt.QueuedConnection)
+            except Exception as e:  # pragma: no cover - best effort
+                log.warning("Impossible d'émettre profiles_changed: %s", e)
+
+            self._log(f"Profil '{name}' ajouté")
+            log.info("Profil ajouté: %s -> %s", name, selector)
+            return jsonify({"name": name, "selector": selector}), 201
+
+        @app.get("/history")
+        @require_api_key
+        def hist() -> Any:
+            return jsonify(load_history())
+
+        @app.get("/debug/ping")
+        @require_api_key
+        def debug_ping() -> Any:
+            from PySide6.QtCore import QCoreApplication
+
+            return jsonify(
+                {
+                    "thread": "flask",
+                    "qt_alive": QCoreApplication.instance() is not None,
+                }
+            )
+
+        globals()["require_api_key"] = require_api_key
+        globals()["ALIASES"] = getattr(self, "path_aliases", {})
+
+        # === [CONFIG / CONSTANTES] ===
+        # Domaine public (ngrok ou prod) pour construire les URLs d'images (/files/raw).
+        BASE_URL = os.environ.get("BASE_URL", "http://127.0.0.1:5000")
+
+        # Racine des images: privilégier un alias existant, sinon chemin absolu fallback.
+        IMAGES_ROOT_ABS = r"C:\Users\Lamine\Desktop\scrap\projet\images"
+        try:
+            if "ALIASES" in globals() and isinstance(ALIASES, dict) and ALIASES.get("images_root"):
+                IMAGES_ROOT_ABS = str(ALIASES["images_root"])
+        except Exception:
+            pass
+
+        EXPORT_DIR = Path("export")
+        EXPORT_DIR.mkdir(parents=True, exist_ok=True)
+        EXPORT_CSV = EXPORT_DIR / "products_export.csv"
+
+        WC_COLUMNS = [
+            "Name","Short description","Description","Categories","Tags",
+            "Regular price","Sale price","Slug","Focus keyword",
+            "Meta title","Meta description","Internal link"
+        ]
+
+        # === [UTILS] ===
+        _slug_rm = re.compile(r"[^\w\s-]", flags=re.UNICODE)
+        def _slugify(s: str) -> str:
+            s = (s or "").strip().lower()
+            s = _slug_rm.sub("", s)
+            s = re.sub(r"[\s_-]+", "-", s, flags=re.UNICODE)
+            return s.strip("-")
+
+        def _images_root() -> Path:
+            return Path(IMAGES_ROOT_ABS).resolve()
+
+        def _is_image(p: Path) -> bool:
+            return p.suffix.lower() in (".png",".jpg",".jpeg",".webp",".avif",".gif")
+
+        def _product_dirs():
+            root = _images_root()
+            if not root.exists():
+                return []
+            return [p for p in root.iterdir() if p.is_dir()]
+
+        def _file_url_for(product_dir: Path, filename: str) -> str:
+            # Sert le fichier via l’endpoint existant /files/raw (folder + name)
+            return f"{BASE_URL}/files/raw?folder={quote(str(product_dir))}&name={quote(filename)}"
+
+        # === [SÉCURITÉ] ===
+        # Réutiliser require_api_key si présent, sinon fallback minimal.
+        if "require_api_key" not in globals():
+            API_KEY = os.environ.get("API_KEY", "dev-key")
+            def require_api_key(fn):
+                from functools import wraps
+                @wraps(fn)
+                def _wrap(*args, **kwargs):
+                    if request.headers.get("X-API-KEY") != API_KEY:
+                        return jsonify({"error":"unauthorized"}), 401
+                    return fn(*args, **kwargs)
+                return _wrap
+
+        # === [ENDPOINTS PRODUITS] ===
+        @app.get("/products")
+        @require_api_key
+        def list_products():
+            """Liste des dossiers (1 dossier = 1 produit)."""
+            items = []
+            for d in sorted(_product_dirs(), key=lambda p: p.name.lower()):
+                cnt = sum(1 for f in d.iterdir() if f.is_file() and _is_image(f))
+                items.append({"slug": _slugify(d.name), "name": d.name, "images_count": cnt})
+            offset = max(int(request.args.get("offset", 0)), 0)
+            limit = int(request.args.get("limit", 25))
+            items = items[offset:offset + limit]
+            return jsonify({"items": items})
+
+        @app.get("/products/<slug>/images")
+        @require_api_key
+        def product_images(slug):
+            """URLs publiques des images d'un produit (via /files/raw)."""
+            target = None
+            for d in _product_dirs():
+                if _slugify(d.name) == slug:
+                    target = d
+                    break
+            if not target:
+                return jsonify({"error": "not_found"}), 404
+
+            images = []
+            for f in sorted(target.iterdir(), key=lambda p: p.name.lower()):
+                if f.is_file() and _is_image(f):
+                    url = _file_url_for(target, f.name)
+                    images.append({"name": f.name, "url": url, "preview_url": url})
+            return jsonify({"product": target.name, "slug": slug, "images": images})
+
+        @app.post("/products/<slug>/descriptions")
+        @require_api_key
+        def save_product_description(slug):
+            """
+            Attendu (application/json):
+            {
+              "name": "...",
+              "short_description": "...",
+              "description": "...",
+              "categories": ["A","B"],
+              "tags": ["x","y"],
+              "regular_price": "29.90",
+              "sale_price": "",
+              "slug": "slug-override|optional",
+              "focus_keyword": "...",
+              "meta_title": "...",
+              "meta_description": "...",
+              "internal_link": "https://..."
+            }
+            """
+            data = request.get_json(force=True) or {}
+
+            row = {
+                "Name": data.get("name",""),
+                "Short description": data.get("short_description",""),
+                "Description": data.get("description",""),
+                "Categories": ", ".join(data.get("categories", []) or []),
+                "Tags": ", ".join(data.get("tags", []) or []),
+                "Regular price": data.get("regular_price",""),
+                "Sale price": data.get("sale_price",""),
+                "Slug": data.get("slug") or _slugify(data.get("name","")),
+                "Focus keyword": data.get("focus_keyword",""),
+                "Meta title": data.get("meta_title",""),
+                "Meta description": data.get("meta_description",""),
+                "Internal link": data.get("internal_link",""),
+            }
+
+            file_exists = EXPORT_CSV.exists()
+            with open(EXPORT_CSV, "a", newline="", encoding="utf-8") as fp:
+                writer = csv.DictWriter(fp, fieldnames=WC_COLUMNS)
+                if not file_exists:
+                    writer.writeheader()
+                writer.writerow(row)
+
+            # Trace JSON par produit (reprise)
+            prod_dir = None
+            for d in _product_dirs():
+                if _slugify(d.name) == slug:
+                    prod_dir = d
+                    break
+            if prod_dir:
+                (prod_dir / "generated.json").write_text(
+                    json.dumps(row, ensure_ascii=False, indent=2),
+                    encoding="utf-8"
+                )
+
+            return jsonify({"status": "ok", "saved_csv": str(EXPORT_CSV)}), 200
+
+    # ------------------------------------------------------------------
+    # job execution
+    def _run_scrape_job(
+        self,
+        st: JobStatus,
+        url: str,
+        selector: str,
+        folder: str,
+        opts: Dict[str, Any],
+    ) -> None:
+        st.status = "running"
+        st.started_at = _dt.datetime.utcnow().isoformat() + "Z"
+        try:
+            if opts.get("with_variants"):
+                total, driver = scrape_images(
+                    url,
+                    selector,
+                    folder,
+                    keep_driver=True,
+                )
+                st.variants = scrape_variants(driver)
+                driver.quit()
+            else:
+                total = scrape_images(url, selector, folder)
+            st.progress["found"] = total
+            st.progress["downloaded"] = total
+            st.output_dir = folder
+            images_dir = Path(folder)
+            if images_dir.exists():
+                files = sorted(images_dir.glob("*"))[:5]
+                st.sample_images = [f.name for f in files]
+            st.status = "done"
+        except Exception as exc:  # pragma: no cover - hard to trigger in tests
+            st.status = "error"
+            st.message = str(exc)
+            st.errors.append({"url": url, "error": str(exc)})
+        finally:
+            st.finished_at = _dt.datetime.utcnow().isoformat() + "Z"
+
+    def _run_image_action_job(
+        self, st: JobStatus, src_folder: str, ops: list[dict], target_subdir: str
+    ) -> None:
+        from pathlib import Path
+        from time import sleep
+        from PIL import Image, ImageFilter
+        import datetime as _dt
+
+        st.status = "running"
+        st.started_at = _dt.datetime.utcnow().isoformat() + "Z"
+        try:
+            rate = int(self.default_flags.get("rate_limit", 0) or 0)  # images/min
+            delay = (60.0 / rate) if rate > 0 else 0.0
+
+            src = Path(src_folder)
+            if not src.exists():
+                raise FileNotFoundError(f"source not found: {src}")
+
+            dst = src / (target_subdir or "image fait par gpt")
+            dst.mkdir(parents=True, exist_ok=True)
+
+            files = [
+                p for p in src.iterdir() if p.suffix.lower() in {".jpg", ".jpeg", ".png", ".webp"}
+            ]
+            st.progress["found"] = len(files)
+            samples: list[str] = []
+
+            def apply_ops(img: Image.Image) -> Image.Image:
+                out = img
+                for op in ops:
+                    kind = str(op.get("op", "")).lower()
+                    if kind == "resize":
+                        w = int(op.get("width", 0))
+                        h = int(op.get("height", 0))
+                        keep = bool(op.get("keep_ratio", True))
+                        if w > 0 and h > 0:
+                            if keep:
+                                out = out.copy()
+                                out.thumbnail((w, h))
+                            else:
+                                out = out.resize((w, h))
+                    elif kind == "sharpen":
+                        amt = float(op.get("amount", 0.6))
+                        out = out.filter(
+                            ImageFilter.UnsharpMask(percent=int(amt * 150), radius=2)
+                        )
+                    elif kind == "remove_bg":
+                        out = out.convert("RGBA")
+                        bg = Image.new("RGBA", out.size, (255, 255, 255, 255))
+                        bg.paste(out, mask=out.split()[-1] if out.mode == "RGBA" else None)
+                        out = bg.convert("RGB")
+                return out
+
+            for i, f in enumerate(files, 1):
+                try:
+                    with Image.open(f) as im:
+                        out = apply_ops(im)
+                        out_path = dst / f.name
+                        out.save(out_path)
+                    st.progress["downloaded"] += 1
+                    if len(samples) < 5:
+                        samples.append(out_path.name)
+                except Exception as e:
+                    st.progress["failed"] += 1
+                    st.errors.append({"file": f.name, "error": str(e)})
+                if delay:
+                    sleep(delay)
+
+            st.sample_images = samples
+            st.output_dir = str(dst)
+            st.status = "done"
+        except Exception as exc:
+            st.status = "error"
+            st.message = str(exc)
+            st.errors.append({"error": str(exc), "folder": src_folder})
+        finally:
+            st.finished_at = _dt.datetime.utcnow().isoformat() + "Z"
+
+    # ------------------------------------------------------------------
+    # public API
+    def start(
+        self,
+        port: int,
+        api_key: str,
+        *,
+        headless_default: bool,
+        user_agent: str | None,
+        ignore_robots_default: bool,
+        rate_limit: int,
+        max_workers: int,
+    ) -> None:
+        """Start the HTTP server."""
+
+        self.api_key = api_key or self.api_key
+        self.default_flags.update(
+            {
+                "headless": headless_default,
+                "user_agent": user_agent,
+                "ignore_robots": ignore_robots_default,
+                "rate_limit": rate_limit,
+                "max_workers": max_workers,
+            }
+        )
+        self.jobs = JobManager(max_workers=max_workers)
+        self._normalize_aliases()
+        self._server = StoppableWSGIServer(self.app, "0.0.0.0", port)
+        self._server.start()
+        self._log(f"Serveur lancé sur le port {port}")
+
+    def stop(self) -> None:
+        """Stop the HTTP server and any active ngrok tunnel."""
+
+        if self._server:
+            self._server.shutdown()
+            self._server = None
+            self._log("Serveur arrêté")
+        self.disable_ngrok()
+
+    def enable_ngrok(self, authtoken: str, port: int) -> str:
+        """Expose the local server via ngrok."""
+
+        try:
+            from pyngrok import ngrok
+
+            if authtoken:
+                ngrok.set_auth_token(authtoken)
+            self._ngrok_tunnel = ngrok.connect(port, "http")
+            self.public_url = self._ngrok_tunnel.public_url
+            self._log(f"Ngrok exposé sur {self.public_url}")
+        except Exception as exc:  # pragma: no cover - requires network
+            self._log(f"Erreur ngrok : {exc}")
+            self.public_url = ""
+        return self.public_url
+
+    def disable_ngrok(self) -> None:
+        """Close the ngrok tunnel if opened."""
+
+        try:
+            if self._ngrok_tunnel:
+                from pyngrok import ngrok
+
+                ngrok.disconnect(self._ngrok_tunnel.public_url)
+                ngrok.kill()
+                self._log("Ngrok arrêté")
+        except Exception:  # pragma: no cover - best effort
+            pass
+        finally:
+            self._ngrok_tunnel = None
+            self.public_url = ""
+
+    def is_running(self) -> bool:
+        """Return ``True`` if the server is currently running."""
+
+        return self._server is not None
+
+### >>> MOTEUR/scraping/utils/__init__.py (0 lignes)
+
+
+### >>> MOTEUR/scraping/utils/restart.py (46 lignes)
+from __future__ import annotations
+import os
+import sys
+import subprocess
+import time
+
+try:
+    from localapp.log_safe import print_safe
+except ImportError:
+    from log_safe import print_safe
+
+def _build_relaunch_argv() -> list[str]:
+    py = sys.executable or "python"
+    # Cas PyInstaller / frozen
+    if getattr(sys, "frozen", False):
+        return [py] + sys.argv[1:]
+    # Script direct
+    script = os.path.abspath(sys.argv[0]) if sys.argv and sys.argv[0] else ""
+    if script and script.lower().endswith((".py", ".pyw")):
+        return [py, script] + sys.argv[1:]
+    # Fallback (ex: python -m package)
+    return [py] + sys.argv[1:]
+
+def relaunch_current_process(delay_sec: float = 0.25, *, cwd: str | None = None) -> None:
+    argv = _build_relaunch_argv()
+    try:
+        print_safe(f"[restart] sys.executable = {sys.executable}")
+        print_safe(f"[restart] sys.argv       = {sys.argv}")
+        print_safe(f"[restart] relaunch argv  = {argv}")
+        if cwd is None:
+            cwd = os.getcwd()
+        print_safe(f"[restart] cwd            = {cwd}")
+
+        popen_kwargs = dict(
+            cwd=cwd,
+            close_fds=(os.name != "nt"),
+            start_new_session=(os.name != "nt"),
+        )
+        if os.name == "nt":
+            CREATE_NEW_PROCESS_GROUP = 0x00000200
+            DETACHED_PROCESS = 0x00000008
+            popen_kwargs["creationflags"] = DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP
+        subprocess.Popen(argv, **popen_kwargs)
+    except Exception as e:
+        print_safe(f"[restart] Erreur au relancement: {e}")
+    time.sleep(delay_sec)
+
+### >>> MOTEUR/scraping/utils/update.py (26 lignes)
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+# Determine the project root (three levels up from this file)
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+
+def pull_latest(branch: str = "main") -> subprocess.CompletedProcess:
+    """Pull the latest changes from the given branch.
+
+    Parameters
+    ----------
+    branch:
+        Name of the branch to pull from. Defaults to ``"main"``.
+
+    Returns
+    -------
+    subprocess.CompletedProcess
+        The result object from ``subprocess.run``.
+    """
+    return subprocess.run(
+        ["git", "-C", str(PROJECT_ROOT), "pull", "origin", branch],
+        capture_output=True,
+        text=True,
+    )
+
+### >>> MOTEUR/scraping/widgets/__init__.py (0 lignes)
+
+
+### >>> MOTEUR/scraping/widgets/collection_widget.py (482 lignes)
+from __future__ import annotations
+
+from PySide6.QtCore import QObject, Signal, QThread, Slot, Qt, QUrl, QTimer
+from PySide6.QtGui import QGuiApplication, QDesktopServices
+from PySide6.QtWidgets import (
+    QFileDialog,
+    QLabel,
+    QMessageBox,
+    QPushButton,
+    QLineEdit,
+    QTextEdit,
+    QVBoxLayout,
+    QHBoxLayout,
+    QWidget,
+    QGroupBox,
+    QRadioButton,
+    QSpinBox,
+    QPlainTextEdit,
+    QCheckBox,
+    QListWidget,
+    QListWidgetItem,
+    QAbstractItemView,
+)
+import csv
+
+from ...common.fileio import write_lines_txt
+from .. import history
+from ui_helpers import show_toast
+
+
+VERSION_COLLECTION_WIDGET = 3  # pagination modes + live logs
+
+
+class _CollectionWorker(QObject):
+    result = Signal(list)
+    error = Signal(str)
+    progress = Signal(str)
+    page_progress = Signal(str)
+    link_found = Signal(str)
+    cancelled = Signal()
+
+    def __init__(
+        self,
+        mode: str,
+        base_url: str,
+        template: str | None,
+        start: int,
+        end: int,
+        urls_list: list[str] | None,
+        live_logs: bool,
+        max_pages: int = 20,
+    ) -> None:
+        super().__init__()
+        self._mode = mode
+        self._base_url = base_url
+        self._template = template
+        self._start = start
+        self._end = end
+        self._urls_list = urls_list or []
+        self._live_logs = live_logs
+        self._max_pages = max_pages
+        self._cancelled = False
+        self._driver = None  # type: ignore
+
+    def cancel(self) -> None:
+        self._cancelled = True
+        try:
+            if self._driver:
+                self._driver.quit()
+        except Exception:
+            pass
+
+    @Slot()
+    def run(self) -> None:
+        try:
+            from MOTEUR.scraping.image_scraper import (
+                generate_page_urls,
+                scrape_collection_products_paginated,
+            )
+
+            if self._mode == "auto":
+                pages = [self._base_url]
+                auto = True
+            elif self._mode == "range":
+                pages = generate_page_urls(self._template or "", self._start, self._end)
+                auto = False
+            else:
+                pages = [u.strip() for u in self._urls_list if u.strip()]
+                auto = False
+
+            link_cb = self.link_found.emit if self._live_logs else None
+
+            def page_cb(idx: int, total: int, new: int, total_links: int) -> None:
+                self.page_progress.emit(
+                    f"Page {idx}/{total} — +{new} liens, total {total_links}"
+                )
+
+            urls = scrape_collection_products_paginated(
+                pages,
+                self._set_driver,
+                self._is_cancelled,
+                self.progress.emit,
+                link_cb,
+                page_cb,
+                auto_follow=auto,
+                max_pages=self._max_pages,
+            )
+            if self._cancelled:
+                self.cancelled.emit()
+                return
+            self.result.emit(urls)
+        except Exception as e:
+            if self._cancelled:
+                self.cancelled.emit()
+            else:
+                self.error.emit(str(e))
+
+    def _set_driver(self, drv) -> None:
+        self._driver = drv
+
+    def _is_cancelled(self) -> bool:
+        return self._cancelled
+
+
+class CollectionWidget(QWidget):
+    """UI widget to list products from a collection page."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._urls: list[str] = []
+
+        self.url_edit = QLineEdit()
+        self.url_edit.setPlaceholderText("URL de la page collection")
+
+        # Pagination modes -------------------------------------------------
+        self.pagination_group = QGroupBox("Pagination")
+        self.mode_auto = QRadioButton("Auto (lien Suivant)")
+        self.mode_range = QRadioButton("Plage {page}")
+        self.mode_list = QRadioButton("Liste d'URLs")
+        self.mode_auto.setChecked(True)
+        pg_layout = QVBoxLayout(self.pagination_group)
+        pg_layout.addWidget(self.mode_auto)
+        pg_layout.addWidget(self.mode_range)
+        pg_layout.addWidget(self.mode_list)
+        self.mode_auto.toggled.connect(self._update_modes)
+        self.mode_range.toggled.connect(self._on_range_mode)
+        self.mode_list.toggled.connect(self._update_modes)
+
+        # Range widgets ----------------------------------------------------
+        self.range_widget = QWidget()
+        rw_layout = QHBoxLayout(self.range_widget)
+        self.template_edit = QLineEdit()
+        self.template_edit.setPlaceholderText(
+            "ex. ...?page={page} ou /page/{page}"
+        )
+        self.start_spin = QSpinBox()
+        self.start_spin.setMinimum(1)
+        self.start_spin.setValue(1)
+        self.end_spin = QSpinBox()
+        self.end_spin.setMinimum(1)
+        self.end_spin.setValue(6)
+        self.preview_btn = QPushButton("Prévisualiser")
+        self.preview_btn.clicked.connect(self._preview_range)
+        rw_layout.addWidget(self.template_edit)
+        rw_layout.addWidget(self.start_spin)
+        rw_layout.addWidget(self.end_spin)
+        rw_layout.addWidget(self.preview_btn)
+
+        # List widgets -----------------------------------------------------
+        self.list_widget = QWidget()
+        lw_layout = QVBoxLayout(self.list_widget)
+        self.urls_edit = QPlainTextEdit()
+        lw_layout.addWidget(self.urls_edit)
+
+        # Options ----------------------------------------------------------
+        self.live_logs_cb = QCheckBox("Afficher les liens en direct")
+        self.live_logs_cb.setChecked(True)
+        self.show_live_cb = self.live_logs_cb
+
+        self.stats_lbl = getattr(self, "stats_lbl", None) or QLabel(
+            "Liens détectés : 0", self
+        )
+        self.badge_busy = getattr(self, "badge_busy", None) or QLabel("", self)
+        self.badge_busy.setVisible(False)
+        self.badge_busy.setStyleSheet(
+            "QLabel{padding:3px 8px; border-radius:9px; background:#9E9E9E; color:white; font-weight:600;}"
+        )
+
+        self.list_btn = QPushButton("Scanner la collection")
+        self.list_btn.clicked.connect(self._scan_collection)
+
+        self.cancel_btn = QPushButton("Annuler")
+        self.cancel_btn.setEnabled(False)
+        self.cancel_btn.clicked.connect(self._on_cancel_clicked)
+
+        self.save_btn = QPushButton("Enregistrer la liste…")
+        self.save_btn.setEnabled(False)
+        self.save_btn.clicked.connect(self._save_list)
+
+        self.console = QTextEdit(readOnly=True)
+        self._log_buffer: list[str] = []
+        self._log_flusher = QTimer(self)
+        self._log_flusher.setInterval(80)
+        self._log_flusher.timeout.connect(self._flush_logs)
+        self._log_flusher.start()
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("URL :"))
+        layout.addWidget(self.url_edit)
+        layout.addWidget(self.pagination_group)
+        layout.addWidget(self.range_widget)
+        layout.addWidget(self.list_widget)
+        layout.addWidget(self.live_logs_cb)
+        layout.addWidget(self.stats_lbl)
+
+        row = QHBoxLayout()
+        row.addWidget(self.list_btn)
+        row.addWidget(self.cancel_btn)
+        row.addWidget(self.save_btn)
+        row.addWidget(self.badge_busy)
+        layout.addLayout(row)
+
+        layout.addWidget(self.console)
+
+        self.live_list = getattr(self, "live_list", None) or QListWidget(self)
+        self.live_list.setSelectionMode(QAbstractItemView.SingleSelection)
+        self.live_list.itemActivated.connect(
+            lambda item: QDesktopServices.openUrl(QUrl(item.text()))
+        )
+        layout.addWidget(self.live_list)
+
+        actions = QHBoxLayout()
+        self.copy_btn = QPushButton("Tout copier")
+        self.copy_btn.clicked.connect(self._copy_links)
+        self.dedupe_btn = QPushButton("🧹 Supprimer doublons")
+        self.dedupe_btn.clicked.connect(self._dedupe_urls)
+        self.export_csv_btn = QPushButton("Exporter CSV")
+        self.export_csv_btn.clicked.connect(self._export_csv)
+        self.clear_btn = QPushButton("Effacer la console")
+        self.clear_btn.clicked.connect(self.console_clear)
+        actions.addWidget(self.copy_btn)
+        actions.addWidget(self.dedupe_btn)
+        actions.addWidget(self.export_csv_btn)
+        actions.addWidget(self.clear_btn)
+        layout.addLayout(actions)
+
+        self.range_widget.hide()
+        self.list_widget.hide()
+
+        self._thread: QThread | None = None
+        self._worker: _CollectionWorker | None = None
+
+    # ------------------------------------------------------------------
+    def showEvent(self, event):  # type: ignore[override]
+        super().showEvent(event)
+        try:
+            data = history.load_last_used()
+            if data and not self.url_edit.text().strip():
+                self.url_edit.setText(data.get("url", ""))
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    def _set_busy(self, busy: bool) -> None:
+        self.list_btn.setEnabled(not busy)
+        self.cancel_btn.setEnabled(busy)
+        self.save_btn.setEnabled((not busy) and bool(self._urls))
+        self.badge_busy.setText("EN COURS…" if busy else "")
+        self.badge_busy.setVisible(busy)
+        if busy:
+            QGuiApplication.setOverrideCursor(Qt.BusyCursor)
+        else:
+            QGuiApplication.restoreOverrideCursor()
+
+    # ------------------------------------------------------------------
+    @Slot()
+    def _scan_collection(self) -> None:
+        url = (self.url_edit.text() or "").strip()
+        if not url:
+            self.console.append("❌ Saisis une URL de collection.")
+            return
+        if self._thread and self._thread.isRunning():
+            return
+
+        mode = "auto"
+        template = None
+        start = self.start_spin.value()
+        end = self.end_spin.value()
+        urls_list = None
+        if self.mode_range.isChecked():
+            mode = "range"
+            template = (self.template_edit.text() or "").strip()
+        elif self.mode_list.isChecked():
+            mode = "list"
+            urls_list = [u.strip() for u in self.urls_edit.toPlainText().splitlines() if u.strip()]
+
+        self.console.append("▶️ Scan démarré…")
+        self._urls = []
+        self.stats_lbl.setText("Liens détectés : 0")
+        self.live_list.clear()
+        self._set_busy(True)
+
+        self._thread = QThread(self)
+        self._worker = _CollectionWorker(
+            mode,
+            url,
+            template,
+            start,
+            end,
+            urls_list,
+            self.live_logs_cb.isChecked(),
+        )
+        self._worker.moveToThread(self._thread)
+
+        self._thread.started.connect(self._worker.run)
+        self._worker.progress.connect(lambda s: self._log_buffer.append(s))
+        self._worker.page_progress.connect(self.stats_lbl.setText)
+        self._worker.link_found.connect(self._on_link_detected)
+        self._worker.result.connect(self._on_scan_ok)
+        self._worker.error.connect(self._on_scan_err)
+        self._worker.cancelled.connect(self._on_scan_cancelled)
+
+        for sig in (
+            self._worker.result,
+            self._worker.error,
+            self._worker.cancelled,
+        ):
+            sig.connect(self._thread.quit)
+        self._thread.finished.connect(lambda: self._set_busy(False))
+        self._thread.finished.connect(self._worker.deleteLater)
+        self._thread.finished.connect(self._thread.deleteLater)
+
+        self._thread.start()
+
+    @Slot()
+    def _save_list(self) -> None:
+        if not self._urls:
+            QMessageBox.information(self, "Enregistrer", "Aucune donnée.")
+            return
+
+        path, _ = QFileDialog.getSaveFileName(
+            self,
+            "Enregistrer la liste",
+            "liens bob.txt",  # nom proposé
+            "Text files (*.txt)"
+        )
+        if not path:
+            return
+        if not path.lower().endswith(".txt"):
+            path += ".txt"
+
+        urls = self._urls
+
+        try:
+            saved_path = write_lines_txt(path, urls)
+            QMessageBox.information(
+                self, "Enregistrer", f"✅ Liens enregistrés : {saved_path}"
+            )
+        except Exception as e:
+            QMessageBox.critical(self, "Enregistrer", f"Erreur: {e}")
+
+    # ------------------------------------------------------------------
+    @Slot()
+    def _on_cancel_clicked(self) -> None:
+        if self._worker:
+            self.cancel_btn.setEnabled(False)
+            self.console.append("🛑 Annulation demandée…")
+            self._worker.cancel()
+
+    @Slot(list)
+    def _on_scan_ok(self, urls: list) -> None:
+        self._urls = urls or []
+        self.stats_lbl.setText(f"Liens détectés : {len(self._urls)}")
+        if not urls:
+            self.console.append("⚠️ Aucun produit détecté.")
+            self.save_btn.setEnabled(False)
+        else:
+            self.console.append(f"✅ {len(urls)} liens trouvés.")
+            self.save_btn.setEnabled(True)
+        try:
+            data = history.load_last_used()
+            history.save_last_used(self.url_edit.text().strip(), data.get("folder", ""))
+        except Exception:
+            pass
+
+    @Slot(str)
+    def _on_scan_err(self, message: str) -> None:
+        self.console.append(f"❌ Erreur collecte: {message}")
+
+    @Slot()
+    def _on_scan_cancelled(self) -> None:
+        self.console.append("🟡 Scan annulé.")
+
+    # ------------------------------------------------------------------
+    def _update_modes(self) -> None:
+        self.range_widget.setVisible(self.mode_range.isChecked())
+        self.list_widget.setVisible(self.mode_list.isChecked())
+
+    def _on_range_mode(self, checked: bool) -> None:
+        self._update_modes()
+        if checked:
+            from MOTEUR.scraping.image_scraper import infer_pagination_template
+
+            tpl, start = infer_pagination_template(self.url_edit.text().strip())
+            if tpl:
+                self.template_edit.setText(tpl)
+                self.start_spin.setValue(start)
+
+    def _preview_range(self) -> None:
+        from MOTEUR.scraping.image_scraper import generate_page_urls
+
+        tpl = (self.template_edit.text() or "").strip()
+        if not tpl:
+            self.console.append("⚠️ Fournis un template valide.")
+            return
+        urls = generate_page_urls(tpl, self.start_spin.value(), self.end_spin.value())
+        for u in urls:
+            self.console.append(u)
+
+    def _copy_links(self) -> None:
+        if not self._urls:
+            return
+        QGuiApplication.clipboard().setText("\n".join(self._urls))
+        show_toast(self, "Liens copiés dans le presse-papiers.")
+
+    def console_clear(self) -> None:
+        self.console.clear()
+
+    # ------------------------------------------------------------------
+    def _on_link_detected(self, url: str) -> None:
+        self._urls.append(url)
+        self.stats_lbl.setText(f"Liens détectés : {len(self._urls)}")
+        self.console.append(url)
+        if self.show_live_cb.isChecked():
+            item = QListWidgetItem(url)
+            item.setToolTip(url)
+            self.live_list.addItem(item)
+
+    def _dedupe_urls(self) -> None:
+        before = len(self._urls)
+        self._urls = list(dict.fromkeys(self._urls))
+        after = len(self._urls)
+        self.stats_lbl.setText(f"Liens détectés : {after} (−{before-after} doublons)")
+        if self.show_live_cb.isChecked():
+            self.live_list.clear()
+            for u in self._urls:
+                item = QListWidgetItem(u)
+                item.setToolTip(u)
+                self.live_list.addItem(item)
+
+    def _export_csv(self) -> None:
+        if not self._urls:
+            QMessageBox.information(self, "Exporter", "Aucune donnée.")
+            return
+        path, _ = QFileDialog.getSaveFileName(
+            self,
+            "Exporter CSV",
+            "liens.csv",
+            "CSV Files (*.csv)",
+        )
+        if not path:
+            return
+        if not path.lower().endswith(".csv"):
+            path += ".csv"
+        try:
+            with open(path, "w", encoding="utf-8", newline="") as f:
+                writer = csv.writer(f)
+                writer.writerow(["url"])
+                for u in self._urls:
+                    writer.writerow([u])
+            QMessageBox.information(
+                self, "Exporter", f"✅ Liens exportés : {path}"
+            )
+        except Exception as e:
+            QMessageBox.critical(self, "Exporter", f"Erreur: {e}")
+
+    def _flush_logs(self) -> None:
+        if not self._log_buffer:
+            return
+        chunk = "\n".join(self._log_buffer)
+        self._log_buffer.clear()
+        self.console.append(chunk)
+
+### >>> MOTEUR/scraping/widgets/flask_server_widget.py (344 lignes)
+from __future__ import annotations
+
+"""Widget de contrôle pour :class:`FlaskBridgeServer`."""
+
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QCheckBox,
+    QTextEdit,
+    QApplication,
+)
+from PySide6.QtCore import Slot
+import json, requests
+import os
+from pathlib import Path
+
+try:
+    from localapp.log_safe import open_utf8
+except ImportError:
+    from log_safe import open_utf8
+import secrets
+from ui_helpers import show_toast
+
+from ..server.flask_server import FlaskBridgeServer
+
+CFG_FILE = "server_config.json"
+
+
+class FlaskServerWidget(QWidget):
+    """Interface graphique minimaliste pour démarrer le serveur Flask."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.server = FlaskBridgeServer(on_log=self._append)
+        self._build_ui()
+        self._load_cfg()
+        self._last_job_id = ""
+
+    # ------------------------------------------------------------------
+    def _build_ui(self) -> None:
+        self.port = QLineEdit("5001")
+        self.api_key = QLineEdit(os.getenv("SCRAPER_API_KEY", ""))
+        gen = QPushButton("Générer")
+        gen.clicked.connect(self._gen_key)
+        self.expose = QCheckBox("Expose via ngrok")
+        self.ngrok_token = QLineEdit(os.getenv("NGROK_AUTHTOKEN", ""))
+        self.ngrok_token.setEchoMode(QLineEdit.Password)
+        self.headless = QCheckBox("Headless par défaut")
+        self.headless.setChecked(True)
+        self.ignore_robots = QCheckBox("Ignorer robots.txt par défaut")
+        self.rate = QLineEdit("0")
+        self.maxw = QLineEdit("1")
+
+        self.start = QPushButton("Démarrer")
+        self.stop = QPushButton("Arrêter")
+        self.stop.setEnabled(False)
+        self.url_label = QLabel("URL publique : (non exposé)")
+        self.status_label = QLabel("Statut : Arrêté")
+        self.console = QTextEdit()
+        self.console.setReadOnly(True)
+        copyurl = QPushButton("Copier URL")
+        copyurl.clicked.connect(self._copy_url)
+        self.test_health_btn = QPushButton("Test health")
+        self.test_health_btn.clicked.connect(self._test_health)
+
+        # image actions
+        self.source_folder = QLineEdit()
+        self.target_subdir = QLineEdit("image fait par gpt")
+        self.sample_alias = QLineEdit()
+        self.operations_json = QLineEdit(
+            '[{"op":"resize","width":1024,"height":1024,"keep_ratio":true}]'
+        )
+        self.launch_action_btn = QPushButton("Lancer action")
+        self.launch_action_btn.clicked.connect(self._launch_action)
+        self.status_btn = QPushButton("Status job")
+        self.status_btn.clicked.connect(self._status_job)
+
+        # layouts
+        top = QHBoxLayout()
+        top.addWidget(QLabel("Port:"))
+        top.addWidget(self.port)
+
+        k = QHBoxLayout()
+        k.addWidget(QLabel("API Key:"))
+        k.addWidget(self.api_key)
+        k.addWidget(gen)
+
+        n = QHBoxLayout()
+        n.addWidget(self.expose)
+        n.addWidget(QLabel("Ngrok token:"))
+        n.addWidget(self.ngrok_token)
+
+        o = QHBoxLayout()
+        o.addWidget(self.headless)
+        o.addWidget(self.ignore_robots)
+
+        r = QHBoxLayout()
+        r.addWidget(QLabel("Rate (img/min):"))
+        r.addWidget(self.rate)
+        r.addWidget(QLabel("Max workers:"))
+        r.addWidget(self.maxw)
+
+        btn = QHBoxLayout()
+        btn.addWidget(self.start)
+        btn.addWidget(self.stop)
+        btn.addWidget(copyurl)
+        btn.addWidget(self.test_health_btn)
+
+        lay = QVBoxLayout(self)
+        for row in (top, k, n, o, r, btn):
+            lay.addLayout(row)
+
+        act1 = QHBoxLayout()
+        act1.addWidget(QLabel("Source folder"))
+        act1.addWidget(self.source_folder)
+        act2 = QHBoxLayout()
+        act2.addWidget(QLabel("Target subdir"))
+        act2.addWidget(self.target_subdir)
+        act_alias = QHBoxLayout()
+        act_alias.addWidget(QLabel("Alias 'sample_folder' →"))
+        act_alias.addWidget(self.sample_alias)
+        act3 = QHBoxLayout()
+        act3.addWidget(QLabel("Operations (JSON)"))
+        act3.addWidget(self.operations_json)
+        actb = QHBoxLayout()
+        actb.addWidget(self.launch_action_btn)
+        actb.addWidget(self.status_btn)
+
+        for row in (act1, act2, act_alias, act3, actb):
+            lay.addLayout(row)
+        lay.addWidget(self.status_label)
+        lay.addWidget(self.url_label)
+        lay.addWidget(self.console)
+
+        self.start.clicked.connect(self._start)
+        self.stop.clicked.connect(self._stop)
+
+    # ------------------------------------------------------------------
+    def _append(self, text: str) -> None:
+        self.console.append(text)
+
+    def _gen_key(self) -> None:
+        self.api_key.setText(secrets.token_urlsafe(24))
+
+    def _copy_url(self) -> None:
+        QApplication.clipboard().setText(
+            self.url_label.text().replace("URL publique : ", "")
+        )
+
+    def _request(self, method: str, url: str, **kwargs):
+        try:
+            r = requests.request(method, url, timeout=kwargs.pop("timeout", 10), **kwargs)
+            if r.status_code == 401:
+                show_toast(self, "Clé API absente ou invalide (401).", error=True)
+                return None
+            r.raise_for_status()
+            return r
+        except requests.Timeout:
+            show_toast(self, "Requête expirée (timeout).", error=True)
+        except Exception as e:
+            show_toast(self, f"Erreur API: {e}", error=True)
+        return None
+
+    # ------------------------------------------------------------------
+    def _load_cfg(self) -> None:
+        try:
+            if os.path.exists(CFG_FILE):
+                with open_utf8(CFG_FILE, "r") as f:
+                    cfg = json.load(f)
+                self.port.setText(str(cfg.get("port", 5001)))
+                self.api_key.setText(cfg.get("api_key", ""))
+                self.expose.setChecked(bool(cfg.get("expose", False)))
+                self.ngrok_token.setText(cfg.get("ngrok_token", ""))
+                self.headless.setChecked(bool(cfg.get("headless", True)))
+                self.ignore_robots.setChecked(bool(cfg.get("ignore_robots", False)))
+                self.rate.setText(str(cfg.get("rate", 0)))
+                self.maxw.setText(str(cfg.get("max_workers", 1)))
+                self.sample_alias.setText(
+                    (cfg.get("path_aliases") or {}).get("sample_folder", "")
+                )
+        except Exception:
+            pass
+
+    def _save_cfg(self) -> dict:
+        cfg = {
+            "port": int(self.port.text() or 5001),
+            "api_key": self.api_key.text().strip(),
+            "expose": self.expose.isChecked(),
+            "ngrok_token": self.ngrok_token.text().strip(),
+            "headless": self.headless.isChecked(),
+            "ignore_robots": self.ignore_robots.isChecked(),
+            "rate": int(self.rate.text() or 0),
+            "max_workers": int(self.maxw.text() or 1),
+        }
+        cfg["path_aliases"] = {
+            "sample_folder": self.sample_alias.text().strip()
+        }
+        with open_utf8(CFG_FILE, "w") as f:
+            json.dump(cfg, f, indent=2, ensure_ascii=False)
+        return cfg
+
+    # ------------------------------------------------------------------
+    @Slot()
+    def _start(self) -> None:
+        cfg = self._save_cfg()
+        try:
+            self.server.start(
+                port=cfg["port"],
+                api_key=cfg["api_key"],
+                headless_default=cfg["headless"],
+                user_agent=None,
+                ignore_robots_default=cfg["ignore_robots"],
+                rate_limit=cfg["rate"],
+                max_workers=cfg["max_workers"],
+            )
+            pub = ""
+            if cfg["expose"]:
+                pub = self.server.enable_ngrok(cfg["ngrok_token"], cfg["port"])
+            try:
+                if cfg.get("path_aliases", {}):
+                    url = f"http://localhost:{cfg['port']}/aliases"
+                    headers = {
+                        "X-API-KEY": cfg["api_key"],
+                        "Content-Type": "application/json",
+                    }
+                    requests.post(
+                        url,
+                        headers=headers,
+                        data=json.dumps(cfg["path_aliases"]),
+                        timeout=10,
+                    )
+                    self._append(f"↔︎ Aliases synced: {cfg['path_aliases']}")
+            except Exception as e:
+                self._append(f"⚠️ Alias sync error: {e}")
+            self.status_label.setText("Statut : En cours d’exécution")
+            self.url_label.setText(
+                f"URL publique : {pub or f'http://localhost:{cfg['port']}/health'}"
+            )
+            self.start.setEnabled(False)
+            self.stop.setEnabled(True)
+            self._append("🚀 Serveur démarré")
+        except Exception as e:  # pragma: no cover - UI feedback
+            self._append(f"❌ Erreur démarrage : {e}")
+
+    @Slot()
+    def _stop(self) -> None:
+        try:
+            self.server.stop()
+            self.status_label.setText("Statut : Arrêté")
+            self.url_label.setText("URL publique : (non exposé)")
+            self.start.setEnabled(True)
+            self.stop.setEnabled(False)
+            self._append("🛑 Serveur arrêté")
+        except Exception as e:  # pragma: no cover - UI feedback
+            self._append(f"❌ Erreur arrêt : {e}")
+
+    @Slot()
+    def _test_health(self) -> None:
+        try:
+            port = int(self.port.text() or 5001)
+            base = (
+                self.server.public_url.strip()
+                if self.expose.isChecked() and self.server.public_url.strip()
+                else f"http://localhost:{port}"
+            )
+            url = base.rstrip("/") + "/health"
+            r = self._request(
+                "get", url, headers={"ngrok-skip-browser-warning": "1"}
+            )
+            if r:
+                self._append(f"[health] GET {url} -> {r.status_code}")
+                self._append(r.text or "<no body>")
+        except Exception as e:
+            self._append(f"❌ health error: {e}")
+
+    # ------------------------------------------------------------------
+    @Slot()
+    def _launch_action(self) -> None:
+        try:
+            port = int(self.port.text() or 5001)
+            api_key = self.api_key.text().strip()
+            src = self.source_folder.text().strip()
+            alias = self.sample_alias.text().strip()
+            tgt = self.target_subdir.text().strip()
+            ops_text = self.operations_json.text().strip()
+            ops = json.loads(ops_text) if ops_text else []
+            if src:
+                p = Path(src)
+                if not p.exists():
+                    self._append(f"❌ Dossier introuvable : {src}")
+                    return
+                exts = {".jpg", ".jpeg", ".png", ".webp"}
+                has_img = any(
+                    pp.suffix.lower() in exts for pp in p.iterdir() if pp.is_file()
+                )
+                if not has_img:
+                    self._append(f"❌ Aucun fichier image dans : {src}")
+                    return
+            elif not alias:
+                self._append(
+                    "❌ Source folder vide et aucun alias 'sample_folder' défini."
+                )
+                return
+            if not ops:
+                self._append("❌ Operations JSON manquant")
+                return
+            url = f"http://localhost:{port}/actions/image-edit"
+            headers = {"X-API-KEY": api_key, "Content-Type": "application/json"}
+            payload = {
+                "source": {"folder": src},
+                "operations": ops,
+                "target_subdir": tgt,
+            }
+            r = self._request(
+                "post", url, headers=headers, data=json.dumps(payload), timeout=15
+            )
+            if not r or r.status_code != 202:
+                if r:
+                    self._append(f"❌ {r.status_code}: {r.text}")
+                return
+            self._last_job_id = r.json().get("job_id", "")
+            self._append(f"🚀 Action lancée — job_id: {self._last_job_id}")
+        except Exception as e:
+            self._append(f"❌ Erreur envoi action: {e}")
+
+    @Slot()
+    def _status_job(self) -> None:
+        try:
+            if not self._last_job_id:
+                self._append("ℹ️ Aucun job_id — lance d’abord une action.")
+                return
+            port = int(self.port.text() or 5001)
+            api_key = self.api_key.text().strip()
+            url = f"http://localhost:{port}/jobs/{self._last_job_id}"
+            headers = {"X-API-KEY": api_key}
+            r = self._request("get", url, headers=headers, timeout=10)
+            if r:
+                self._append(r.text)
+        except Exception as e:
+            self._append(f"❌ Erreur status: {e}")
+
+### >>> MOTEUR/scraping/widgets/history_widget.py (31 lignes)
+from PySide6.QtWidgets import QWidget, QVBoxLayout, QTextEdit, QPushButton
+from PySide6.QtCore import Slot
+
+from .. import history
+
+
+class HistoryWidget(QWidget):
+    """Display previous scraping runs."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.text = QTextEdit(readOnly=True)
+        self.refresh_btn = QPushButton("Rafraîchir")
+        self.refresh_btn.clicked.connect(self.refresh)
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(self.text)
+        layout.addWidget(self.refresh_btn)
+
+        self.refresh()
+
+    @Slot()
+    def refresh(self) -> None:
+        entries = history.load_history()
+        lines = []
+        for entry in entries:
+            lines.append(
+                f"{entry.get('date','')} - {entry.get('url','')} ("\
+                f"{entry.get('profile','')} - {entry.get('images',0)} images)"
+            )
+        self.text.setPlainText("\n".join(lines))
+
+### >>> MOTEUR/scraping/widgets/image_widget.py (317 lignes)
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QLabel,
+    QPushButton,
+    QTextEdit,
+    QProgressBar,
+    QLineEdit,
+    QFileDialog,
+    QHBoxLayout,
+    QComboBox,
+    QCheckBox,
+    QApplication,
+    QMessageBox,
+)
+from PySide6.QtCore import Qt, Slot, QThread, QTimer, QProcess, QProcessEnvironment
+from PySide6.QtGui import QClipboard
+from pathlib import Path
+
+try:
+    from localapp.log_safe import open_utf8
+except ImportError:
+    from log_safe import open_utf8
+from .. import profile_manager as pm
+from .. import history
+
+
+class ImageScraperWidget(QWidget):
+    """Simple interface to run the image scraper."""
+
+    def __init__(self, *, storage_widget=None) -> None:
+        super().__init__()
+
+        self.storage_widget = storage_widget
+
+        self.export_data: list[dict[str, str]] = []
+
+        self.file_edit = QLineEdit()
+        # ✅ Alias de compatibilité pour l'ancien code
+        self.url_edit = self.file_edit
+        self.file_edit.setPlaceholderText("Fichier texte contenant les URLs")
+        file_btn = QPushButton("Parcourir…")
+        file_btn.clicked.connect(self._choose_file)
+
+        file_layout = QHBoxLayout()
+        file_layout.addWidget(self.file_edit)
+        file_layout.addWidget(file_btn)
+
+        self.profile_combo = QComboBox()
+        self.profiles: list[dict[str, str]] = []
+        self.selected_selector: str = ""
+        self.profile_combo.currentIndexChanged.connect(self._on_profile_changed)
+
+        self.folder_edit = QLineEdit()
+        self.folder_edit.setPlaceholderText("Dossier de destination")
+
+        browse_btn = QPushButton("Parcourir…")
+        browse_btn.clicked.connect(self._choose_folder)
+
+        folder_layout = QHBoxLayout()
+        folder_layout.addWidget(self.folder_edit)
+        folder_layout.addWidget(browse_btn)
+
+        self.variants_checkbox = QCheckBox("Scraper aussi les variantes")
+        self.isolate_checkbox = QCheckBox("Isoler (QProcess)")
+
+        self.start_btn = QPushButton("Lancer")
+        self.start_btn.clicked.connect(self._start)
+        self.copy_btn = QPushButton("Copier")
+        self.copy_btn.clicked.connect(self._copy_console)
+        self.export_btn = QPushButton("Exporter")
+        self.export_btn.clicked.connect(self._export_excel)
+
+        buttons_layout = QHBoxLayout()
+        buttons_layout.addWidget(self.start_btn)
+        buttons_layout.addWidget(self.copy_btn)
+        buttons_layout.addWidget(self.export_btn)
+
+        self.console = QTextEdit()
+        self.console.setReadOnly(True)
+
+        self.progress_bar = QProgressBar()
+        self.progress_bar.hide()
+
+        self._log_buffer: list[str] = []
+        self._log_flusher = QTimer(self)
+        self._log_flusher.setInterval(80)
+        self._log_flusher.timeout.connect(self._flush_logs)
+        self._log_flusher.start()
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("Fichier :"))
+        layout.addLayout(file_layout)
+        layout.addWidget(QLabel("Profil:"))
+        layout.addWidget(self.profile_combo)
+        layout.addWidget(QLabel("Dossier:"))
+        layout.addLayout(folder_layout)
+        layout.addWidget(self.variants_checkbox)
+        layout.addWidget(self.isolate_checkbox)
+        layout.addLayout(buttons_layout)
+        layout.addWidget(self.console)
+        layout.addWidget(self.progress_bar)
+
+        self.refresh_profiles()
+        last = history.load_last_used()
+        self.file_edit.setText(history.load_last_file() or "")
+        self.folder_edit.setText(last.get("folder", ""))
+
+    # ------------------------------------------------------------------
+    def _on_profile_changed(self, index: int) -> None:
+        if 0 <= index < len(self.profiles):
+            self.selected_selector = self.profiles[index].get("selector", "")
+        else:
+            self.selected_selector = ""
+
+    def set_selected_profile(self, profile: str) -> None:
+        for i, p in enumerate(self.profiles):
+            if p.get("name") == profile:
+                self.profile_combo.setCurrentIndex(i)
+                self.selected_selector = p.get("selector", "")
+                return
+        self.profile_combo.setCurrentIndex(-1)
+        self.selected_selector = ""
+
+    def refresh_profiles(self) -> None:
+        self.profiles = pm.load_profiles()
+        current = self.profile_combo.currentText()
+        self.profile_combo.clear()
+        for p in self.profiles:
+            self.profile_combo.addItem(p.get("name", ""))
+        # restore previous selection if possible
+        if current:
+            self.set_selected_profile(current)
+        else:
+            self._on_profile_changed(self.profile_combo.currentIndex())
+
+    @Slot()
+    def _choose_folder(self) -> None:
+        path = QFileDialog.getExistingDirectory(self, "Choisir un dossier")
+        if path:
+            self.folder_edit.setText(path)
+
+    @Slot()
+    def _choose_file(self) -> None:
+        path, _ = QFileDialog.getOpenFileName(
+            self,
+            "Choisir un fichier",
+            "",
+            "Text Files (*.txt);;All Files (*)",
+        )
+        if path:
+            self.file_edit.setText(path)
+            history.save_last_file(path)
+
+    @Slot()
+    def _copy_console(self) -> None:
+        """Copy the console's contents to the clipboard."""
+        text = self.console.toPlainText()
+        QApplication.clipboard().setText(text, mode=QClipboard.Clipboard)
+        # Also populate the selection clipboard on platforms that support it.
+        QApplication.clipboard().setText(text, mode=QClipboard.Selection)
+
+    @Slot()
+    def _export_excel(self) -> None:
+        """Export scraped variant data to an Excel file."""
+        if not self.export_data:
+            QMessageBox.information(self, "Export", "Aucune donnée à exporter.")
+            return
+
+        path, _ = QFileDialog.getSaveFileName(
+            self,
+            "Enregistrer sous",
+            "",
+            "Excel Files (*.xlsx)",
+        )
+        if not path:
+            return
+
+        try:
+            from openpyxl import Workbook
+
+            wb = Workbook()
+            ws = wb.active
+            ws.append(["URL", "Variante", "Image"])
+            for row in self.export_data:
+                ws.append([row["URL"], row["Variant"], row["Image"]])
+            wb.save(path)
+        except Exception as exc:
+            QMessageBox.critical(self, "Export", f"Erreur: {exc}")
+            return
+
+        QMessageBox.information(self, "Export", "Export termin\u00e9.")
+
+    @Slot()
+    def _start(self) -> None:
+        file_path = self.file_edit.text().strip()
+        selector = self.selected_selector.strip()
+        folder = self.folder_edit.text().strip() or "images"
+        if not file_path or not selector:
+            self.console.append("❌ Fichier ou sélecteur manquant")
+            return
+
+        path = Path(file_path)
+        if not path.is_file():
+            self.console.append("❌ Fichier introuvable")
+            return
+
+        history.save_last_file(file_path)
+        with open_utf8(path) as f:
+            urls = [line.strip() for line in f if line.strip()]
+        if not urls:
+            self.console.append("❌ Aucun URL dans le fichier")
+            return
+
+        # UI prêt
+        self.start_btn.setEnabled(False)
+        self.console.clear()
+        self.progress_bar.show()
+        self.progress_bar.setRange(0, len(urls))
+        self.progress_bar.setValue(0)
+        self.export_data = []
+
+        if self.isolate_checkbox.isChecked():
+            args = [file_path, selector, folder, "1" if self.variants_checkbox.isChecked() else "0"]
+            self._start_scrape_qprocess(args)
+            return
+
+        # thread + worker
+        from .image_worker import ImageJobWorker
+        self._thread = QThread(self)
+        self._worker = ImageJobWorker(urls, selector, folder, self.variants_checkbox.isChecked())
+        self._worker.moveToThread(self._thread)
+
+        # connexions
+        self._thread.started.connect(self._worker.run)
+        self._worker.log.connect(lambda s: self._log_buffer.append(s))
+        def _on_item_done(url, total, variants):
+            self.console.append(f"✅ {url} - {total} images")
+            for name, img in (variants or {}).items():
+                self.console.append(f"  • {name}: {img}")
+                self.export_data.append({"URL": url, "Variant": name, "Image": img})
+            # Optionnel: push vers storage_widget
+            if self.storage_widget and variants:
+                self.storage_widget.add_product("", list(variants.keys()))
+        self._worker.item_done.connect(_on_item_done)
+        self._worker.progress.connect(self._on_progress)
+        def _on_finished():
+            self.progress_bar.hide()
+            self.start_btn.setEnabled(True)
+            self._thread.quit(); self._thread.wait()
+            self._worker.deleteLater(); self._thread.deleteLater()
+        self._worker.finished.connect(_on_finished)
+
+        self._thread.start()
+
+    def _start_scrape_qprocess(self, args: list[str]) -> None:
+        import sys, json
+        from pathlib import Path
+
+        script = Path(__file__).resolve().parents[3] / "scrape_subprocess.py"
+        self.proc = QProcess(self)
+        env = QProcessEnvironment.systemEnvironment()
+        env.insert("PYTHONUTF8", "1")
+        env.insert("PYTHONIOENCODING", "utf-8")
+        self.proc.setProcessEnvironment(env)
+        self.proc.setProgram(sys.executable)
+        self.proc.setArguments([str(script), *args])
+        self.proc.readyReadStandardOutput.connect(self._on_proc_stdout)
+        self.proc.finished.connect(self._on_proc_finished)
+        self.proc.start()
+
+    def _on_proc_stdout(self) -> None:
+        import json
+
+        data = bytes(self.proc.readAllStandardOutput()).decode("utf-8", errors="ignore")
+        for line in data.splitlines():
+            try:
+                evt = json.loads(line)
+            except Exception:
+                self._log_buffer.append(line)
+                continue
+            if evt.get("event") == "log":
+                self._log_buffer.append(evt.get("msg", ""))
+            elif evt.get("event") == "progress":
+                self._on_progress(int(evt.get("done", 0)), int(evt.get("total", 0)))
+            elif evt.get("event") == "item":
+                url = evt.get("url", "")
+                total = evt.get("total", 0)
+                self._log_buffer.append(f"✅ {url} - {total} images")
+                variants = evt.get("variants") or {}
+                for name, img in variants.items():
+                    self._log_buffer.append(f"  • {name}: {img}")
+                    self.export_data.append({"URL": url, "Variant": name, "Image": img})
+                if self.storage_widget and variants:
+                    self.storage_widget.add_product("", list(variants.keys()))
+            elif evt.get("event") == "done":
+                self._log_buffer.append(f"Terminé, total={evt.get('total', 0)}")
+
+    def _on_proc_finished(self, code: int, status) -> None:
+        self.progress_bar.hide()
+        self.start_btn.setEnabled(True)
+        self._log_buffer.append(f"Process scraping terminé (code={code}).")
+
+
+    def _on_progress(self, done: int, total: int) -> None:
+        self.progress_bar.setMaximum(max(1, total))
+        self.progress_bar.setValue(done)
+        if done == total or done % 3 == 0:
+            self._log_buffer.append(f"Progression {done}/{total}")
+
+    def _flush_logs(self) -> None:
+        if not self._log_buffer:
+            return
+        chunk = "\n".join(self._log_buffer)
+        self._log_buffer.clear()
+        self.console.append(chunk)
+
+
+### >>> MOTEUR/scraping/widgets/image_worker.py (59 lignes)
+from PySide6.QtCore import QObject, Signal
+import sys
+from selenium.webdriver.common.by import By
+from pathlib import Path
+from ..image_scraper import scrape_images, scrape_variants
+from .. import history
+
+
+class _SignalStream(QObject):
+    text = Signal(str)
+    def write(self, s: str):
+        s = (s or "").rstrip()
+        if s:
+            self.text.emit(s)
+    def flush(self): pass
+
+
+class ImageJobWorker(QObject):
+    log = Signal(str)
+    progress = Signal(int, int)        # done, total_urls
+    item_done = Signal(str, int, dict) # url, total_images, variants
+    finished = Signal()
+
+    def __init__(self, urls, selector, folder, with_variants: bool):
+        super().__init__()
+        self.urls = urls
+        self.selector = selector
+        self.folder = folder or "images"
+        self.with_variants = with_variants
+
+    def run(self):
+        # capture prints du scraper
+        stream = _SignalStream()
+        stream.text.connect(self.log.emit)
+        old_stdout = sys.stdout
+        sys.stdout = stream
+        try:
+            tot = len(self.urls)
+            for i, url in enumerate(self.urls, 1):
+                try:
+                    if self.with_variants:
+                        total, driver = scrape_images(url, self.selector, self.folder, keep_driver=True)
+                        try:
+                            _ = driver.find_element(By.TAG_NAME, "h1")  # warmup
+                        except Exception:
+                            pass
+                        variants = scrape_variants(driver)
+                        driver.quit()
+                    else:
+                        total = scrape_images(url, self.selector, self.folder)
+                        variants = {}
+                    history.log_scrape(url, self.selector, total, self.folder)
+                    self.item_done.emit(url, total, variants)
+                except Exception as e:
+                    self.log.emit(f"❌ Erreur sur {url}: {e}")
+                self.progress.emit(i, tot)
+        finally:
+            sys.stdout = old_stdout
+            self.finished.emit()
+
+### >>> MOTEUR/scraping/widgets/profile_widget.py (132 lignes)
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QListWidget,
+    QLineEdit,
+    QPushButton,
+    QLabel,
+)
+from PySide6.QtCore import Signal, Slot, QTimer
+
+from .. import profile_manager as pm
+from ..bus.event_bus import bus
+
+
+class ProfileWidget(QWidget):
+    """Widget to manage scraping profiles."""
+
+    profile_chosen = Signal(str)
+    profiles_updated = Signal()
+
+    def __init__(self) -> None:
+        super().__init__()
+
+        self.profile_list = QListWidget()
+        self.profile_list.itemSelectionChanged.connect(self._on_profile_selected)
+
+        self.name_edit = QLineEdit()
+        self.selector_edit = QLineEdit()
+        self.selector_edit.setText(
+            ".woocommerce-product-gallery__image a"
+        )
+
+        self.add_btn = QPushButton("Ajouter")
+        self.add_btn.clicked.connect(self._add_profile)
+        self.update_btn = QPushButton("Modifier")
+        self.update_btn.clicked.connect(self._update_profile)
+        self.delete_btn = QPushButton("Supprimer")
+        self.delete_btn.clicked.connect(self._delete_profile)
+
+        form_layout = QVBoxLayout()
+        form_layout.addWidget(QLabel("Nom:"))
+        form_layout.addWidget(self.name_edit)
+        form_layout.addWidget(QLabel("Sélecteur CSS:"))
+        form_layout.addWidget(self.selector_edit)
+
+        btn_layout = QHBoxLayout()
+        btn_layout.addWidget(self.add_btn)
+        btn_layout.addWidget(self.update_btn)
+        btn_layout.addWidget(self.delete_btn)
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("Profils existants:"))
+        layout.addWidget(self.profile_list)
+        layout.addLayout(form_layout)
+        layout.addLayout(btn_layout)
+
+        self._load_profiles()
+
+        # watch for external profile changes
+        bus.profiles_changed.connect(self._load_profiles)
+
+        self._mtime = pm.PROFILES_FILE.stat().st_mtime if pm.PROFILES_FILE.exists() else 0
+        self._timer = QTimer(self)
+        self._timer.setInterval(2500)
+        self._timer.timeout.connect(self._check_profiles_file)
+        self._timer.start()
+
+    # ------------------------------------------------------------------
+    def _load_profiles(self) -> None:
+        """Load profiles from :mod:`profile_manager` and populate the list."""
+        self.profiles = pm.load_profiles()
+        self._refresh_list()
+
+    def _refresh_list(self) -> None:
+        self.profile_list.clear()
+        for profile in self.profiles:
+            self.profile_list.addItem(profile.get("name", ""))
+
+    @Slot()
+    def _on_profile_selected(self) -> None:
+        current = self.profile_list.currentRow()
+        if current < 0 or current >= len(self.profiles):
+            return
+        profile = self.profiles[current]
+        self.name_edit.setText(profile.get("name", ""))
+        self.selector_edit.setText(profile.get("selector", ""))
+        self.profile_chosen.emit(profile.get("name", ""))
+
+    @Slot()
+    def _add_profile(self) -> None:
+        name = self.name_edit.text().strip()
+        selector = self.selector_edit.text().strip()
+        if not name or not selector:
+            return
+        try:
+            pm.add_profile(name, selector)
+        except ValueError:
+            return
+        self._load_profiles()
+        self.profiles_updated.emit()
+
+    @Slot()
+    def _update_profile(self) -> None:
+        name = self.name_edit.text().strip()
+        selector = self.selector_edit.text().strip()
+        if not name or not selector:
+            return
+        if pm.update_profile(name, selector):
+            self._load_profiles()
+
+    @Slot()
+    def _delete_profile(self) -> None:
+        current = self.profile_list.currentRow()
+        if current < 0 or current >= len(self.profiles):
+            return
+        name = self.profiles[current].get("name", "")
+        if pm.delete_profile(name):
+            self._load_profiles()
+            self.profiles_updated.emit()
+
+    # ------------------------------------------------------------------
+    def _check_profiles_file(self) -> None:
+        p = pm.PROFILES_FILE
+        try:
+            m = p.stat().st_mtime
+            if m != self._mtime:
+                self._mtime = m
+                self._load_profiles()
+        except Exception:
+            pass
+
+
+### >>> MOTEUR/scraping/widgets/scrap_widget.py (53 lignes)
+import logging
+
+from PySide6.QtWidgets import QWidget, QVBoxLayout, QTabWidget
+
+from MOTEUR.ui.theme import load_theme, apply_theme
+
+from .image_widget import ImageScraperWidget
+from MOTEUR.scraping.widgets.collection_widget import CollectionWidget, VERSION_COLLECTION_WIDGET
+from .history_widget import HistoryWidget
+from .woocommerce_widget import WooCommerceProductWidget
+from .storage_widget import StorageWidget
+from .flask_server_widget import FlaskServerWidget
+
+
+class ScrapWidget(QWidget):
+    def __init__(self) -> None:
+        super().__init__()
+        apply_theme(load_theme())
+        self.modules_order = [
+            "images",
+            "collections",
+            "flask",
+            "history",
+            "woocommerce",
+            "stockage",
+        ]
+        self.storage_widget = StorageWidget()
+        self.images_widget = ImageScraperWidget(storage_widget=self.storage_widget)
+        self.collections_widget = CollectionWidget()
+        self.flask_widget = FlaskServerWidget()
+        self.history_widget = HistoryWidget()
+        self.woocommerce_widget = WooCommerceProductWidget(
+            storage_widget=self.storage_widget
+        )
+        self.tabs = QTabWidget()
+        self.tabs.addTab(self.images_widget, "Images")
+        self.tabs.addTab(self.collections_widget, "Collections")
+        logging.getLogger(__name__).debug(
+            "Collections widget v%s loaded", VERSION_COLLECTION_WIDGET
+        )
+        self.tabs.addTab(self.flask_widget, "Serveur Flask")
+        self.tabs.addTab(self.history_widget, "Historique")
+        self.tabs.addTab(self.woocommerce_widget, "Fiche Produit WooCommerce")
+        self.tabs.addTab(self.storage_widget, "Stockage")
+        layout = QVBoxLayout(self)
+        layout.addWidget(self.tabs)
+
+    def toggle_module(self, name: str, enabled: bool) -> None:
+        pass
+
+    def set_rename(self, enabled: bool) -> None:
+        pass
+
+
+### >>> MOTEUR/scraping/widgets/settings_widget.py (182 lignes)
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QPushButton,
+    QMessageBox,
+    QTextEdit,
+)
+from PySide6.QtCore import Signal, Slot, QCoreApplication, QProcess
+from pathlib import Path
+import os
+
+try:
+    from localapp.log_safe import open_utf8
+except ImportError:
+    from log_safe import open_utf8
+
+
+class ScrapingSettingsWidget(QWidget):
+    module_toggled = Signal(str, bool)
+    rename_toggled = Signal(bool)
+
+    def __init__(self, modules_order=None, *, show_maintenance: bool = False):
+        super().__init__()
+        from ..utils.restart import relaunch_current_process
+        from ..utils.update import PROJECT_ROOT
+
+        layout = QVBoxLayout(self)
+        # (conserver vos éléments existants ici)
+        _ = (modules_order or [])
+
+        self._project_root = PROJECT_ROOT
+        self._relaunch_current_process = relaunch_current_process
+
+        if show_maintenance:
+            self._build_maintenance_ui(layout)
+
+    # ------------------------------------------------------------------
+    def _build_maintenance_ui(self, layout: QVBoxLayout) -> None:
+        row = QHBoxLayout()
+        self.update_btn = QPushButton("Mettre à jour")
+        self.update_btn.setObjectName("btn_update")
+        self.restart_btn = QPushButton("Redémarrer")
+        self.restart_btn.setObjectName("btn_restart")
+        row.addWidget(self.update_btn)
+        row.addWidget(self.restart_btn)
+        self.copy_btn = QPushButton("Mettre à jour le txt")
+        row.addWidget(self.copy_btn)
+        layout.addLayout(row)
+
+        # Simple log output
+        self.log_edit = QTextEdit()
+        self.log_edit.setReadOnly(True)
+        layout.addWidget(self.log_edit)
+
+        # Prepare git QProcess
+        self._git_proc = QProcess(self)
+        self._git_proc.readyReadStandardOutput.connect(
+            lambda: self._append_log(
+                bytes(self._git_proc.readAllStandardOutput()).decode("utf-8", "ignore")
+            )
+        )
+        self._git_proc.readyReadStandardError.connect(
+            lambda: self._append_log(
+                bytes(self._git_proc.readAllStandardError()).decode("utf-8", "ignore")
+            )
+        )
+        self._git_proc.finished.connect(self._on_git_finished)
+
+        self.update_btn.clicked.connect(self._on_update_clicked)
+        self.restart_btn.clicked.connect(self._on_restart_clicked)
+        self.copy_btn.clicked.connect(self._on_generate_copy_clicked)
+
+    # ------------------------------------------------------------------
+    def _append_log(self, text: str) -> None:
+        if hasattr(self, "log_edit") and self.log_edit is not None:
+            txt = text.strip()
+            if txt:
+                self.log_edit.append(txt)
+
+    # ------------------------------------------------------------------
+    @Slot()
+    def _on_update_clicked(self) -> None:
+        root = Path(self._project_root)
+        if not (root / ".git").exists():
+            QMessageBox.critical(
+                self, "Mettre à jour", f"Aucun dépôt Git détecté dans :\n{root}"
+            )
+            return
+
+        self.update_btn.setEnabled(False)
+        self.update_btn.setText("Mise à jour en cours…")
+        self._append_log(f"> git pull origin main (cwd={root})")
+        self._git_proc.setWorkingDirectory(str(root))
+        self._git_proc.start("git", ["pull", "origin", "main"])
+
+        if not self._git_proc.waitForStarted(2000):
+            self.update_btn.setEnabled(True)
+            self.update_btn.setText("Mettre à jour")
+            QMessageBox.critical(
+                self,
+                "Mettre à jour",
+                "Impossible de démarrer Git. Est-il installé et dans le PATH ?",
+            )
+
+    # ------------------------------------------------------------------
+    def _on_git_finished(self, code: int, status) -> None:
+        self.update_btn.setEnabled(True)
+        self.update_btn.setText("Mettre à jour")
+        if code == 0:
+            QMessageBox.information(self, "Mettre à jour", "Mise à jour réussie.")
+        else:
+            QMessageBox.critical(
+                self,
+                "Mettre à jour",
+                f"Échec du 'git pull' (code {code}). Consulte les logs.",
+            )
+
+    # ------------------------------------------------------------------
+    @Slot()
+    def _on_restart_clicked(self) -> None:
+        ret = QMessageBox.question(
+            self,
+            "Redémarrer",
+            "Voulez-vous vraiment redémarrer l’application ?",
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
+        )
+        if ret != QMessageBox.Yes:
+            return
+        self._relaunch_current_process(delay_sec=0.3)
+        QCoreApplication.quit()
+
+    # ------------------------------------------------------------------
+    @Slot()
+    def _on_generate_copy_clicked(self) -> None:
+        root = Path(self._project_root)  # défini dans __init__
+        out = root / "copy.txt"
+        ignore_dirs = {".git", "__pycache__", ".venv", "venv", ".mypy_cache", ".pytest_cache", "images"}
+        max_size = 800_000  # ignore fichiers texte > 800 KB
+
+        try:
+            with open_utf8(out, "w") as w:   # <= ÉCRASE à chaque clic
+                for dirpath, dirnames, filenames in os.walk(root):
+                    dn = os.path.basename(dirpath)
+                    if dn in ignore_dirs:
+                        continue
+                    for fn in sorted(filenames):
+                        p = Path(dirpath) / fn
+                        if not _is_textlike(p):
+                            continue
+                        try:
+                            if p.stat().st_size > max_size:
+                                # trop gros, on documente et skip
+                                rel = p.relative_to(root).as_posix()
+                                w.write(f"\n\n# {rel}\n")
+                                w.write(f"Description: [skipped: file too large]\n\n")
+                                continue
+                            content = p.read_text(encoding="utf-8")
+                        except Exception:
+                            rel = p.relative_to(root).as_posix()
+                            w.write(f"\n\n# {rel}\n")
+                            w.write("Description: [skipped: non-text or undecodable]\n\n")
+                            continue
+
+                        rel = p.relative_to(root).as_posix()
+                        w.write(f"\n\n# {rel}\n")
+                        w.write(f"Description: Source code for {rel}\n")
+                        w.write("```\n")
+                        w.write(content)
+                        w.write("\n```\n")
+            self._append_log(f"✅ copy.txt régénéré : {out}")
+        except Exception as e:
+            self._append_log(f"❌ Erreur génération copy.txt : {e}")
+
+
+def _is_textlike(p: Path) -> bool:
+    # Ajuste ici si besoin d’autres extensions
+    exts = {".py", ".txt", ".md", ".json", ".yml", ".yaml", ".ini", ".cfg", ".toml", ".csv"}
+    return p.suffix.lower() in exts
+
+
+
+### >>> MOTEUR/scraping/widgets/storage_widget.py (48 lignes)
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+)
+from PySide6.QtCore import Slot
+
+
+class StorageWidget(QWidget):
+    """Simple table to store scraped product names and variants."""
+
+    HEADERS = ["Nom du produit", "Variantes"]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.table = QTableWidget(0, len(self.HEADERS))
+        self.table.setHorizontalHeaderLabels(self.HEADERS)
+
+        self.clear_btn = QPushButton("Vider le stockage")
+        self.clear_btn.clicked.connect(self.clear)
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(self.table)
+        layout.addWidget(self.clear_btn)
+
+    # ------------------------------------------------------------------
+    def add_product(self, name: str, variants: list[str]) -> None:
+        row = self.table.rowCount()
+        self.table.insertRow(row)
+        self.table.setItem(row, 0, QTableWidgetItem(name))
+        self.table.setItem(row, 1, QTableWidgetItem(", ".join(variants)))
+
+    def get_products(self) -> list[dict[str, list[str]]]:
+        products: list[dict[str, list[str]]] = []
+        for row in range(self.table.rowCount()):
+            name_item = self.table.item(row, 0)
+            variants_item = self.table.item(row, 1)
+            name = name_item.text() if name_item else ""
+            variants_text = variants_item.text() if variants_item else ""
+            variants = [v.strip() for v in variants_text.split(",") if v.strip()]
+            products.append({"name": name, "variants": variants})
+        return products
+
+    @Slot()
+    def clear(self) -> None:
+        self.table.setRowCount(0)
+
+### >>> MOTEUR/scraping/widgets/woocommerce_widget.py (463 lignes)
+from __future__ import annotations
+
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QFileDialog,
+    QAbstractItemView,
+    QCheckBox,
+    QLineEdit,
+    QLabel,
+)
+from PySide6.QtCore import Slot
+import csv
+import random
+import string
+import re
+import unicodedata
+from pathlib import Path
+from datetime import datetime
+from urllib.parse import urljoin
+import requests
+import os
+
+try:
+    from MOTEUR.scraping.config import IMAGES_JOINER  # type: ignore
+except Exception:
+    IMAGES_JOINER = os.getenv("IMAGES_JOINER", ";")
+
+
+class WooCommerceProductWidget(QWidget):
+    """Widget to edit WooCommerce product data in a table."""
+
+    HEADERS = [
+        "ID",
+        "Type",
+        "SKU",
+        "Name",
+        "Published",
+        "Short description",
+        "Description",
+        "Regular price",
+        "Sale price",
+        "Categories",
+        "Tags",
+        "Images",
+        "In stock?",
+        "Stock",
+        "Tax status",
+        "Shipping class",
+        "Attribute 1 name",
+        "Attribute 1 value(s)",
+        "Attribute 1 visible",
+        "Attribute 1 global",
+    ]
+
+    # Folder containing downloaded product images. Tests monkeypatch this path.
+    IMAGES_ROOT = Path("images")
+
+
+
+    @staticmethod
+    def _slugify(text: str) -> str:
+        text = unicodedata.normalize("NFKD", text)
+        text = text.encode("ascii", "ignore").decode("ascii")
+        text = re.sub(r"[^a-zA-Z0-9\s-]", "", text)
+        text = re.sub(r"[\s_-]+", "-", text).strip("-")
+        return text.lower()
+
+    def _uploads_base(self) -> str:
+        site = (self.site_base_edit.text().strip() or "").rstrip("/")
+        if not site:
+            site = "https://www.example.com"
+        if self.auto_upload_subdir_checkbox.isChecked():
+            now = datetime.now()
+            sub = f"{now.year}/{now.month:02d}/"
+        else:
+            raw = self.upload_subdir_edit.text().strip().strip("/")
+            sub = (raw + "/") if raw else ""
+        return urljoin(site + "/", f"wp-content/uploads/{sub}")
+
+    def _clean_image_urls(self, urls: list[str]) -> list[str]:
+        """Remove duplicate image URLs using exact and prefix based checks."""
+        unique_urls: list[str] = []
+        for url in urls:
+            if url not in unique_urls:
+                unique_urls.append(url)
+
+        pattern = re.compile(self.dedup_regex_edit.text().strip() or r"(_\d+)$")
+        prefix_set: set[str] = set()
+        final_images: list[str] = []
+
+        for url in unique_urls:
+            filename = url.split("/")[-1]
+            base = filename.rsplit(".", 1)[0]
+            prefix = pattern.sub("", base).split("_")[0]
+
+            if prefix not in prefix_set:
+                final_images.append(url)
+                prefix_set.add(prefix)
+
+        return final_images
+
+    def __init__(self, *, storage_widget=None) -> None:
+        super().__init__()
+        self.storage_widget = storage_widget
+        self.table = QTableWidget(0, len(self.HEADERS))
+        self.table.setHorizontalHeaderLabels(self.HEADERS)
+        self.table.setSelectionBehavior(QAbstractItemView.SelectRows)
+
+        add_btn = QPushButton("Ajouter une ligne")
+        del_btn = QPushButton("Supprimer la ligne sélectionnée")
+        fill_btn = QPushButton("Remplir")
+        check_btn = QPushButton("Vérifier URLs")
+        import_btn = QPushButton("Importer CSV")
+        export_btn = QPushButton("Exporter CSV")
+
+        add_btn.clicked.connect(self.add_row)
+        del_btn.clicked.connect(self.delete_selected_row)
+        fill_btn.clicked.connect(self.fill_from_storage)
+        check_btn.clicked.connect(self.check_urls)
+        import_btn.clicked.connect(self.import_csv)
+        export_btn.clicked.connect(self.export_csv)
+
+        btn_layout = QHBoxLayout()
+        btn_layout.addWidget(add_btn)
+        btn_layout.addWidget(del_btn)
+        btn_layout.addWidget(fill_btn)
+        btn_layout.addWidget(check_btn)
+        btn_layout.addStretch()
+        btn_layout.addWidget(import_btn)
+        btn_layout.addWidget(export_btn)
+
+        self.clean_images_checkbox = QCheckBox("Nettoyer les images dupliquées")
+        self.clean_images_checkbox.setChecked(True)
+
+        # WooCommerce parameters panel
+        self.site_base_edit = QLineEdit()
+        self.site_base_edit.setPlaceholderText("https://www.planetebob.fr")
+        self.site_base_edit.setText("https://www.planetebob.fr")
+        self.auto_upload_subdir_checkbox = QCheckBox("Dossier Uploads auto (YYYY/MM)")
+        self.auto_upload_subdir_checkbox.setChecked(True)
+        self.upload_subdir_edit = QLineEdit()
+        self.upload_subdir_edit.setPlaceholderText("YYYY/MM")
+        self.upload_subdir_edit.setEnabled(False)
+        self.auto_upload_subdir_checkbox.toggled.connect(self.upload_subdir_edit.setDisabled)
+
+        self.dedup_regex_edit = QLineEdit()
+        self.dedup_regex_edit.setPlaceholderText(r"(_\d+)$|(-\d+cm)$")
+        self.dedup_regex_edit.setText(r"(_\d+)$")
+
+        apply_btn = QPushButton("Appliquer base uploads à scraper")
+        apply_btn.clicked.connect(self._apply_base_to_scraper)
+
+        layout = QVBoxLayout(self)
+        layout.addLayout(btn_layout)
+
+        config_layout = QHBoxLayout()
+        config_layout.addWidget(self.site_base_edit)
+        config_layout.addWidget(self.auto_upload_subdir_checkbox)
+        config_layout.addWidget(self.upload_subdir_edit)
+        config_layout.addWidget(apply_btn)
+        layout.addLayout(config_layout)
+
+        dedup_layout = QHBoxLayout()
+        dedup_layout.addWidget(QLabel("Regex dédup:"))
+        dedup_layout.addWidget(self.dedup_regex_edit)
+        layout.addLayout(dedup_layout)
+
+        layout.addWidget(self.clean_images_checkbox)
+        layout.addWidget(self.table)
+
+    # ------------------------------------------------------------------
+    @Slot()
+    def add_row(self) -> None:
+        row = self.table.rowCount()
+        self.table.insertRow(row)
+        for col in range(self.table.columnCount()):
+            self.table.setItem(row, col, QTableWidgetItem(""))
+
+    @Slot()
+    def delete_selected_row(self) -> None:
+        row = self.table.currentRow()
+        if row >= 0:
+            self.table.removeRow(row)
+
+    @Slot()
+    def import_csv(self) -> None:
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Importer CSV", "", "CSV Files (*.csv);;All Files (*)"
+        )
+        if not path:
+            return
+        try:
+            with open(path, newline="", encoding="utf-8") as f:
+                sample = f.read(2048)
+                f.seek(0)
+                dialect = csv.Sniffer().sniff(sample, delimiters=",;\t")
+                reader = csv.reader(f, dialect)
+                rows = list(reader)
+        except Exception:
+            return
+        if not rows:
+            return
+        start = 1 if rows[0][: len(self.HEADERS)] == self.HEADERS else 0
+        for data in rows[start:]:
+            row = self.table.rowCount()
+            self.table.insertRow(row)
+            for col in range(len(self.HEADERS)):
+                value = data[col] if col < len(data) else ""
+                self.table.setItem(row, col, QTableWidgetItem(value))
+
+    @Slot()
+    def export_csv(self) -> None:
+        path, _ = QFileDialog.getSaveFileName(
+            self, "Exporter CSV", "", "CSV Files (*.csv);;All Files (*)"
+        )
+        if not path:
+            return
+        if not path.lower().endswith(".csv"):
+            path += ".csv"
+        with open(path, "w", newline="", encoding="utf-8") as f:
+            writer = csv.writer(f, delimiter=";")
+            writer.writerow(self.HEADERS)
+            for row in range(self.table.rowCount()):
+                data = []
+                for col in range(self.table.columnCount()):
+                    item = self.table.item(row, col)
+                    data.append(item.text() if item else "")
+                writer.writerow(data)
+
+    @Slot()
+    def check_urls(self) -> None:
+        """Check that image URLs in the table are reachable and export a CSV."""
+        path, _ = QFileDialog.getSaveFileName(
+            self, "Exporter résultat", "", "CSV Files (*.csv);;All Files (*)"
+        )
+        if not path:
+            return
+
+        img_col = self.HEADERS.index("Images")
+        urls: list[str] = []
+        for row in range(self.table.rowCount()):
+            item = self.table.item(row, img_col)
+            if not item:
+                continue
+            urls.extend(u.strip() for u in item.text().split(IMAGES_JOINER) if u.strip())
+
+        results: list[tuple[str, str]] = []
+        for url in urls:
+            ok = False
+            try:
+                resp = requests.head(url, timeout=5, allow_redirects=True)
+                ok = 200 <= resp.status_code < 400
+                if not ok:
+                    resp = requests.get(
+                        url,
+                        timeout=5,
+                        stream=True,
+                        headers={"Range": "bytes=0-0"},
+                    )
+                    ok = 200 <= resp.status_code < 400
+            except Exception:
+                ok = False
+            results.append((url, "oui" if ok else "non"))
+
+        with open(path, "w", newline="", encoding="utf-8") as f:
+            writer = csv.writer(f, delimiter=";")
+            writer.writerow(["URL", "OK"])
+            writer.writerows(results)
+
+    def _apply_base_to_scraper(self) -> None:
+        try:
+            import MOTEUR.scraping.image_scraper as S
+
+            base = self._uploads_base().rsplit("/", 3)[0] + "/"
+            S.UPLOADS_BASE_URL = base
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    @Slot()
+    def fill_from_storage(self) -> None:
+        """Create new rows from the linked storage widget."""
+        if not self.storage_widget:
+            return
+        products = self.storage_widget.get_products()
+        # Clear any previously populated rows before filling again so
+        # repeated calls don't accumulate duplicates.
+        self.table.setRowCount(0)
+        type_col = self.HEADERS.index("Type")
+        sku_col = self.HEADERS.index("SKU")
+        name_col = self.HEADERS.index("Name")
+        img_col = self.HEADERS.index("Images")
+        regular_price_col = self.HEADERS.index("Regular price")
+        published_col = self.HEADERS.index("Published")
+        instock_col = self.HEADERS.index("In stock?")
+        stock_col = self.HEADERS.index("Stock")
+        tax_status_col = self.HEADERS.index("Tax status")
+        attr_name_col = self.HEADERS.index("Attribute 1 name")
+        attr_value_col = self.HEADERS.index("Attribute 1 value(s)")
+        attr_visible_col = self.HEADERS.index("Attribute 1 visible")
+        attr_global_col = self.HEADERS.index("Attribute 1 global")
+
+        used_skus: set[str] = set()
+
+        def _gen_sku() -> str:
+            """Generate a unique random SKU."""
+            while True:
+                sku = "SKU-" + "".join(
+                    random.choices(string.ascii_uppercase + string.digits, k=8)
+                )
+                if sku not in used_skus:
+                    used_skus.add(sku)
+                    return sku
+
+        base = self._uploads_base()
+
+        for prod in products:
+            product_name = prod["name"]
+            variants = prod["variants"]
+            product_slug = self._slugify(product_name)
+            folder = self.IMAGES_ROOT / product_name
+            local_images: list[str] = []
+            if folder.is_dir():
+                for p in sorted(folder.iterdir()):
+                    if p.suffix.lower() in {".webp", ".jpg", ".jpeg", ".png"}:
+                        local_images.append(p.name)
+
+            display_name = product_name or product_slug.replace("-", " ").strip()
+
+            def _pick_variant_file(var_name: str, *, local_images: list[str], product_slug: str) -> str:
+                var_slug = self._slugify(var_name)
+                for ext in (".webp", ".jpg", ".jpeg", ".png"):
+                    candidate = f"{product_slug}-{var_slug}{ext}"
+                    if candidate in local_images:
+                        return candidate
+                return f"{product_slug}-{var_slug}.webp"
+
+            variant_files = [
+                _pick_variant_file(v, local_images=local_images, product_slug=product_slug)
+                for v in variants
+            ]
+            generic_images = [img for img in local_images if img not in variant_files]
+
+            is_variable = len(variants) > 1
+
+            if is_variable:
+                row = self.table.rowCount()
+                self.table.insertRow(row)
+                for col in range(self.table.columnCount()):
+                    self.table.setItem(row, col, QTableWidgetItem(""))
+
+                parent_sku = _gen_sku()
+                self.table.setItem(row, type_col, QTableWidgetItem("variable"))
+                self.table.setItem(row, sku_col, QTableWidgetItem(parent_sku))
+                self.table.setItem(row, name_col, QTableWidgetItem(display_name))
+                self.table.setItem(row, published_col, QTableWidgetItem("1"))
+                self.table.setItem(row, instock_col, QTableWidgetItem("1"))
+                self.table.setItem(row, stock_col, QTableWidgetItem("999"))
+                self.table.setItem(row, tax_status_col, QTableWidgetItem("taxable"))
+                if attr_name_col is not None and attr_value_col is not None:
+                    item = self.table.item(row, attr_name_col)
+                    if not item or not item.text():
+                        self.table.setItem(row, attr_name_col, QTableWidgetItem("Couleur"))
+                    item = self.table.item(row, attr_value_col)
+                    if not item or not item.text():
+                        if variants:
+                            self.table.setItem(
+                                row,
+                                attr_value_col,
+                                QTableWidgetItem(", ".join(variants)),
+                            )
+                self.table.setItem(row, attr_visible_col, QTableWidgetItem("1"))
+                self.table.setItem(row, attr_global_col, QTableWidgetItem("1"))
+
+                urls: list[str] = []
+                generic_name = None
+                for ext in (".webp", ".jpg", ".jpeg", ".png"):
+                    candidate = f"{product_slug}{ext}"
+                    if candidate in generic_images:
+                        generic_name = candidate
+                        break
+                if generic_name:
+                    urls.append(base + generic_name)
+                for file_name in variant_files:
+                    urls.append(base + file_name)
+                seen: set[str] = set()
+                urls_dedup: list[str] = []
+                for u in urls:
+                    if u not in seen:
+                        urls_dedup.append(u)
+                        seen.add(u)
+                if self.clean_images_checkbox.isChecked():
+                    urls_dedup = self._clean_image_urls(urls_dedup)
+                if urls_dedup:
+                    parent_images_cell = IMAGES_JOINER.join(urls_dedup)
+                    self.table.setItem(row, img_col, QTableWidgetItem(parent_images_cell))
+
+                current_row = row
+                parent_regular_item = self.table.item(row, regular_price_col)
+                parent_regular = parent_regular_item.text() if parent_regular_item else ""
+                for variant in variants:
+                    current_row += 1
+                    self.table.insertRow(current_row)
+                    for c in range(self.table.columnCount()):
+                        self.table.setItem(current_row, c, QTableWidgetItem(""))
+                    self.table.setItem(current_row, type_col, QTableWidgetItem("variation"))
+                    var_slug = self._slugify(variant)
+                    sku_var = f"{parent_sku}-{var_slug}"
+                    used_skus.add(sku_var)
+                    name_var = f"{display_name} {variant}".strip()
+                    self.table.setItem(current_row, sku_col, QTableWidgetItem(sku_var))
+                    self.table.setItem(current_row, name_col, QTableWidgetItem(name_var))
+                    self.table.setItem(current_row, published_col, QTableWidgetItem("1"))
+                    self.table.setItem(current_row, instock_col, QTableWidgetItem("1"))
+                    self.table.setItem(current_row, stock_col, QTableWidgetItem("999"))
+                    self.table.setItem(current_row, tax_status_col, QTableWidgetItem("taxable"))
+                    self.table.setItem(current_row, attr_name_col, QTableWidgetItem("Couleur"))
+                    self.table.setItem(current_row, attr_value_col, QTableWidgetItem(variant))
+                    self.table.setItem(current_row, attr_visible_col, QTableWidgetItem("1"))
+                    self.table.setItem(current_row, attr_global_col, QTableWidgetItem("1"))
+                    file_name = _pick_variant_file(
+                        variant, local_images=local_images, product_slug=product_slug
+                    )
+                    self.table.setItem(
+                        current_row, img_col, QTableWidgetItem(base + file_name)
+                    )
+                    var_price_item = self.table.item(current_row, regular_price_col)
+                    if (not var_price_item or not var_price_item.text()) and parent_regular:
+                        self.table.setItem(
+                            current_row,
+                            regular_price_col,
+                            QTableWidgetItem(parent_regular),
+                        )
+            else:
+                row = self.table.rowCount()
+                self.table.insertRow(row)
+                for col in range(self.table.columnCount()):
+                    self.table.setItem(row, col, QTableWidgetItem(""))
+
+                sku_val = _gen_sku()
+                self.table.setItem(row, type_col, QTableWidgetItem("simple"))
+                self.table.setItem(row, sku_col, QTableWidgetItem(sku_val))
+                self.table.setItem(row, name_col, QTableWidgetItem(display_name))
+                self.table.setItem(row, published_col, QTableWidgetItem("1"))
+                self.table.setItem(row, instock_col, QTableWidgetItem("1"))
+                self.table.setItem(row, stock_col, QTableWidgetItem("999"))
+                self.table.setItem(row, tax_status_col, QTableWidgetItem("taxable"))
+                images = [base + img for img in generic_images + variant_files]
+                if self.clean_images_checkbox.isChecked():
+                    images = self._clean_image_urls(images)
+                if images:
+                    self.table.setItem(
+                        row,
+                        img_col,
+                        QTableWidgetItem(IMAGES_JOINER.join(images)),
+                    )
+
+
+
+### >>> MOTEUR/ui/settings_widget.py (55 lignes)
+from __future__ import annotations
+
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QRadioButton,
+    QPushButton,
+    QGroupBox,
+)
+from PySide6.QtCore import Slot
+
+from .theme import load_theme, save_theme, apply_theme
+
+
+class SettingsWidget(QWidget):
+    """General application settings."""
+
+    def __init__(self) -> None:
+        super().__init__()
+
+        layout = QVBoxLayout(self)
+
+        maint_group = QGroupBox("Maintenance")
+        maint_layout = QVBoxLayout(maint_group)
+        self.btn_update_txt = QPushButton("Mettre à jour le txt")
+        self.btn_update_txt.setObjectName("btn_update_txt")
+        maint_layout.addWidget(self.btn_update_txt)
+        maint_layout.addWidget(QLabel("Régénère copy.txt"))
+        layout.addWidget(maint_group)
+
+        theme_group = QGroupBox("Thème de l’application")
+        t_layout = QVBoxLayout(theme_group)
+        radios = QHBoxLayout()
+        self.light_radio = QRadioButton("Clair")
+        self.dark_radio = QRadioButton("Sombre")
+        current = load_theme()
+        (self.dark_radio if current == "dark" else self.light_radio).setChecked(True)
+        self.light_radio.toggled.connect(lambda _: self._apply())
+        self.dark_radio.toggled.connect(lambda _: self._apply())
+        radios.addWidget(self.light_radio)
+        radios.addWidget(self.dark_radio)
+        t_layout.addLayout(radios)
+        self.apply_btn = QPushButton("Appliquer")
+        self.apply_btn.clicked.connect(self._apply)
+        t_layout.addWidget(self.apply_btn)
+        layout.addWidget(theme_group)
+        layout.addWidget(QLabel("Appliqué à toute l’application. Persistant dans settings.json"))
+
+    @Slot()
+    def _apply(self) -> None:
+        name = "dark" if self.dark_radio.isChecked() else "light"
+        apply_theme(name)
+        save_theme(name)
+
+### >>> MOTEUR/ui/theme.py (79 lignes)
+from __future__ import annotations
+
+from pathlib import Path
+import json
+
+from PySide6.QtWidgets import QApplication
+from PySide6.QtGui import QPalette, QColor
+
+
+THEME_FILE = Path(__file__).resolve().parents[2] / "settings.json"
+
+
+def load_theme() -> str:
+    """Return the persisted theme name ("light" or "dark")."""
+    try:
+        if THEME_FILE.exists():
+            data = json.loads(THEME_FILE.read_text(encoding="utf-8") or "{}")
+            theme = (data.get("theme") or "light").lower()
+            return "dark" if theme == "dark" else "light"
+    except Exception:
+        pass
+    return "light"
+
+
+def save_theme(name: str) -> None:
+    """Persist the theme name into :data:`THEME_FILE`."""
+    name = "dark" if name.lower() == "dark" else "light"
+    THEME_FILE.write_text(
+        json.dumps({"theme": name}, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+
+def _dark_palette() -> QPalette:
+    palette = QPalette()
+    palette.setColor(QPalette.Window, QColor("#2b2b2b"))
+    palette.setColor(QPalette.WindowText, QColor("#eeeeee"))
+    palette.setColor(QPalette.Base, QColor("#3c3f41"))
+    palette.setColor(QPalette.AlternateBase, QColor("#2f3234"))
+    palette.setColor(QPalette.ToolTipBase, QColor("#2b2b2b"))
+    palette.setColor(QPalette.ToolTipText, QColor("#ffffff"))
+    palette.setColor(QPalette.Text, QColor("#eeeeee"))
+    palette.setColor(QPalette.Button, QColor("#3c3f41"))
+    palette.setColor(QPalette.ButtonText, QColor("#eeeeee"))
+    palette.setColor(QPalette.BrightText, QColor("#ff6b6b"))
+    palette.setColor(QPalette.Highlight, QColor("#4c78ff"))
+    palette.setColor(QPalette.HighlightedText, QColor("#ffffff"))
+    palette.setColor(QPalette.Link, QColor("#62a8ff"))
+    return palette
+
+
+def _light_palette() -> QPalette:
+    app = QApplication.instance()
+    if app:
+        palette = app.style().standardPalette()
+    else:
+        palette = QPalette()
+    palette.setColor(QPalette.Highlight, QColor("#3d6cff"))
+    palette.setColor(QPalette.HighlightedText, QColor("#ffffff"))
+    palette.setColor(QPalette.Link, QColor("#0b61ff"))
+    return palette
+
+
+def apply_theme(name: str) -> None:
+    """Apply the given theme to the running :class:`QApplication`."""
+    app = QApplication.instance()
+    if not app:
+        return
+    app.setStyle("Fusion")
+    if name.lower() == "dark":
+        palette = _dark_palette()
+        app.setPalette(palette)
+        app.setStyleSheet(
+            "QToolTip { color: #ffffff; background-color: #2b2b2b; border: 0px; }"
+        )
+    else:
+        palette = _light_palette()
+        app.setPalette(palette)
+        app.setStyleSheet("")
+
+### >>> README_flask_bridge.md (50 lignes)
+# Flask Bridge
+
+Ce module ajoute un petit serveur Flask permettant de piloter le scraping à
+l'aide d'appels HTTP.  Il peut être lancé depuis l'onglet **Serveur Flask** de
+l'application.
+
+## Démarrage
+1. Lancez l'application graphique `app.py`.
+2. Rendez-vous dans l'onglet *Serveur Flask*.
+3. Choisissez un port et une clé API puis cliquez sur **Démarrer**.
+4. Optionnel : cochez *Expose via ngrok* pour obtenir une URL publique.
+
+L'API key est également lue depuis la variable d'environnement
+``SCRAPER_API_KEY``.  Pour ngrok, la variable ``NGROK_AUTHTOKEN`` est prise en
+compte si aucun jeton n'est saisi.
+
+## Configuration en ligne de commande
+1. Installez les dépendances : `pip install -r requirements.txt`.
+2. Définissez les variables d'environnement :
+   ```bash
+   export SCRAPER_API_KEY=VOTRE_CLE
+   export NGROK_AUTHTOKEN=VOTRE_JETON  # optionnel
+   ```
+3. Lancez le serveur :
+   ```bash
+   python localapp/app.py
+   ```
+   Dans l'onglet **Serveur Flask**, cliquez sur **Démarrer**.
+
+Les fichiers générés sont attendus aux emplacements suivants :
+- `export/products_export.csv`
+- `generated.json`
+
+### Exemples API (tests rapides)
+
+```bash
+# Lister les fichiers d'un alias (images_root)
+curl -H "X-API-KEY: dev-key" "https://YOUR_PUBLIC_DOMAIN/files/list?folder=images_root"
+
+# Lister les produits (dossiers)
+curl -H "X-API-KEY: dev-key" "https://YOUR_PUBLIC_DOMAIN/products"
+
+# Images d'un produit (ex: 'bob avec lacet' → slug 'bob-avec-lacet')
+curl -H "X-API-KEY: dev-key" "https://YOUR_PUBLIC_DOMAIN/products/bob-avec-lacet/images"
+
+# Sauvegarder une fiche produit
+curl -X POST -H "Content-Type: application/json" -H "X-API-KEY: dev-key" \
+  -d '{ "name":"Bob avec lacet jaune", "short_description":"...", "description":"...", "categories":["Bobs"], "tags":["lacet","été"], "regular_price":"", "sale_price":"", "slug":"bob-avec-lacet", "focus_keyword":"bob avec lacet jaune", "meta_title":"Bob avec lacet jaune", "meta_description":"", "internal_link":"" }' \
+  "https://YOUR_PUBLIC_DOMAIN/products/bob-avec-lacet/descriptions"
+```
+
+### >>> app.py (1 lignes)
+
+
+### >>> assets/icons/check.svg (13 lignes)
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M20 6 9 17l-5-5" />
+</svg>
+
+### >>> assets/icons/download.svg (15 lignes)
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M12 15V3" />
+  <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+  <path d="m7 10 5 5 5-5" />
+</svg>
+
+### >>> assets/icons/image.svg (15 lignes)
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="18" height="18" x="3" y="3" rx="2" ry="2" />
+  <circle cx="9" cy="9" r="2" />
+  <path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21" />
+</svg>
+
+### >>> assets/icons/info.svg (15 lignes)
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <circle cx="12" cy="12" r="10" />
+  <path d="M12 16v-4" />
+  <path d="M12 8h.01" />
+</svg>
+
+### >>> assets/icons/layout-dashboard.svg (16 lignes)
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="7" height="9" x="3" y="3" rx="1" />
+  <rect width="7" height="5" x="14" y="3" rx="1" />
+  <rect width="7" height="9" x="14" y="12" rx="1" />
+  <rect width="7" height="5" x="3" y="16" rx="1" />
+</svg>
+
+### >>> assets/icons/link-2.svg (15 lignes)
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M9 17H7A5 5 0 0 1 7 7h2" />
+  <path d="M15 7h2a5 5 0 1 1 0 10h-2" />
+  <line x1="8" x2="16" y1="12" y2="12" />
+</svg>
+
+### >>> assets/icons/moon.svg (13 lignes)
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M20.985 12.486a9 9 0 1 1-9.473-9.472c.405-.022.617.46.402.803a6 6 0 0 0 8.268 8.268c.344-.215.825-.004.803.401" />
+</svg>
+
+### >>> assets/icons/scan.svg (16 lignes)
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M3 7V5a2 2 0 0 1 2-2h2" />
+  <path d="M17 3h2a2 2 0 0 1 2 2v2" />
+  <path d="M21 17v2a2 2 0 0 1-2 2h-2" />
+  <path d="M7 21H5a2 2 0 0 1-2-2v-2" />
+</svg>
+
+### >>> assets/icons/server.svg (16 lignes)
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="20" height="8" x="2" y="2" rx="2" ry="2" />
+  <rect width="20" height="8" x="2" y="14" rx="2" ry="2" />
+  <line x1="6" x2="6.01" y1="6" y2="6" />
+  <line x1="6" x2="6.01" y1="18" y2="18" />
+</svg>
+
+### >>> assets/icons/settings.svg (14 lignes)
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0 2.34 2.34 0 0 0 3.319 1.915 2.34 2.34 0 0 1 2.33 4.033 2.34 2.34 0 0 0 0 3.831 2.34 2.34 0 0 1-2.33 4.033 2.34 2.34 0 0 0-3.319 1.915 2.34 2.34 0 0 1-4.659 0 2.34 2.34 0 0 0-3.32-1.915 2.34 2.34 0 0 1-2.33-4.033 2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915" />
+  <circle cx="12" cy="12" r="3" />
+</svg>
+
+### >>> assets/icons/sun.svg (21 lignes)
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <circle cx="12" cy="12" r="4" />
+  <path d="M12 2v2" />
+  <path d="M12 20v2" />
+  <path d="m4.93 4.93 1.41 1.41" />
+  <path d="m17.66 17.66 1.41 1.41" />
+  <path d="M2 12h2" />
+  <path d="M20 12h2" />
+  <path d="m6.34 17.66-1.41 1.41" />
+  <path d="m19.07 4.93-1.41 1.41" />
+</svg>
+
+### >>> assets/icons/x.svg (14 lignes)
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M18 6 6 18" />
+  <path d="m6 6 12 12" />
+</svg>
+
+### >>> assets/resources.qrc (19 lignes)
+<RCC>
+  <qresource prefix="/">
+    <file>icons/image.svg</file>
+    <file>icons/scan.svg</file>
+    <file>icons/download.svg</file>
+    <file>icons/settings.svg</file>
+    <file>icons/moon.svg</file>
+    <file>icons/sun.svg</file>
+    <file>icons/info.svg</file>
+    <file>icons/check.svg</file>
+    <file>icons/x.svg</file>
+    <file>icons/server.svg</file>
+    <file>icons/link-2.svg</file>
+    <file>icons/layout-dashboard.svg</file>
+    <file>themes/dark.qss</file>
+    <file>themes/light.qss</file>
+    <file>fonts/Inter-Regular.ttf</file>
+  </qresource>
+</RCC>
+
+### >>> assets/themes/dark.qss (39 lignes)
+/* Typo & base */
+* { font-family: "Inter", "Segoe UI", Arial; }
+QWidget { background: #0f1115; color: #e7eaf0; }
+
+/* Boutons */
+QPushButton {
+  background: #1b1f2a; color: #e7eaf0; border: 1px solid #232838;
+  padding: 7px 12px; border-radius: 10px;
+}
+QPushButton:hover { background: #232838; }
+QPushButton:disabled { color:#7c8190; border-color:#1b2030; }
+
+/* LineEdit/Combo */
+QLineEdit, QPlainTextEdit, QComboBox, QSpinBox, QTextEdit {
+  background: #0c0f14; color: #e7eaf0; border:1px solid #232838;
+  border-radius: 8px; padding: 6px 8px;
+}
+
+/* Tabs */
+QTabBar::tab {
+  background: transparent; padding: 8px 14px; margin: 0 4px; border-radius: 10px;
+}
+QTabBar::tab:selected { background: #1b1f2a; }
+QTabWidget::pane { border-top: 1px solid #232838; }
+
+/* Table */
+QHeaderView::section {
+  background:#121621; color:#cfd6e6; border:1px solid #232838; padding:6px 8px;
+}
+QTableView { gridline-color:#232838; selection-background-color:#22314a; }
+
+/* Progress */
+QProgressBar { background:#0c0f14; border:1px solid #232838; border-radius:8px; text-align:center; }
+QProgressBar::chunk { background:#3f8cff; border-radius:8px; }
+
+/* Scrollbar */
+QScrollBar:vertical { background: #0f1115; width: 12px; margin:0; }
+QScrollBar::handle:vertical { background:#22314a; border-radius:6px; min-height: 24px; }
+QScrollBar::handle:vertical:hover { background:#2a3a59; }
+
+### >>> assets/themes/light.qss (17 lignes)
+* { font-family: "Inter", "Segoe UI", Arial; }
+QWidget { background:#f7f8fb; color:#0e1726; }
+QPushButton { background:#ffffff; color:#0e1726; border:1px solid #e2e6ef; padding:7px 12px; border-radius:10px; }
+QPushButton:hover { background:#f1f3f9; }
+QLineEdit, QPlainTextEdit, QComboBox, QSpinBox, QTextEdit {
+  background:#ffffff; color:#0e1726; border:1px solid #e2e6ef; border-radius:8px; padding:6px 8px;
+}
+QTabBar::tab { background:transparent; padding:8px 14px; margin:0 4px; border-radius:10px; }
+QTabBar::tab:selected { background:#ffffff; border:1px solid #e2e6ef; }
+QTabWidget::pane { border-top:1px solid #e2e6ef; }
+QHeaderView::section { background:#ffffff; color:#223; border:1px solid #e2e6ef; padding:6px 8px; }
+QTableView { gridline-color:#e2e6ef; selection-background-color:#e5efff; }
+QProgressBar { background:#ffffff; border:1px solid #e2e6ef; border-radius:8px; text-align:center; }
+QProgressBar::chunk { background:#2463eb; border-radius:8px; }
+QScrollBar:vertical { background:#f7f8fb; width:12px; margin:0; }
+QScrollBar::handle:vertical { background:#dbe3f3; border-radius:6px; min-height:24px; }
+QScrollBar::handle:vertical:hover { background:#cbd7f0; }
+
+### >>> gallery_widget.py (204 lignes)
+import traceback
+import requests
+from typing import List
+from urllib.parse import quote
+from PySide6.QtCore import Qt, QSize
+from PySide6.QtGui import QPixmap, QDesktopServices
+from PySide6.QtWidgets import (
+    QWidget, QVBoxLayout, QHBoxLayout, QLineEdit, QPushButton, QSpinBox,
+    QLabel, QScrollArea, QGridLayout, QDialog
+)
+from ui_helpers import show_toast, busy_dialog
+
+
+class ImagePreviewDialog(QDialog):
+    def __init__(self, parent=None, title="Aperçu", pixmap: QPixmap = None):
+        super().__init__(parent)
+        self.setWindowTitle(title)
+        lay = QVBoxLayout(self)
+        lbl = QLabel(self)
+        lbl.setAlignment(Qt.AlignCenter)
+        if pixmap:
+            lbl.setPixmap(pixmap)
+        lay.addWidget(lbl)
+        self.resize(900, 700)
+
+
+class GalleryWidget(QWidget):
+    def __init__(self, parent=None, base_url: str = "", api_key: str | None = None):
+        super().__init__(parent)
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self._files: List[str] = []
+        self._setup_ui()
+
+    def _setup_ui(self):
+        main = QVBoxLayout(self)
+
+        top = QHBoxLayout()
+        self.input_edit = QLineEdit(self)
+        self.input_edit.setPlaceholderText("Alias ou chemin (ex: images_produit)")
+        self.limit_spin = QSpinBox(self)
+        self.limit_spin.setRange(1, 500)
+        self.limit_spin.setValue(80)
+        self.list_btn = QPushButton("Lister", self)
+        self.open_dir_btn = QPushButton("Ouvrir dossier (via OS)", self)
+        self.open_dir_btn.setEnabled(False)
+
+        top.addWidget(self.input_edit, 2)
+        top.addWidget(QLabel("Max:", self))
+        top.addWidget(self.limit_spin)
+        top.addWidget(self.list_btn)
+        top.addWidget(self.open_dir_btn)
+        main.addLayout(top)
+
+        self.scroll = QScrollArea(self)
+        self.scroll.setWidgetResizable(True)
+        self.grid_host = QWidget(self.scroll)
+        self.grid = QGridLayout(self.grid_host)
+        self.grid.setAlignment(Qt.AlignTop)
+        self.scroll.setWidget(self.grid_host)
+        main.addWidget(self.scroll)
+
+        self.status_lbl = QLabel("Aucune liste chargée.", self)
+        main.addWidget(self.status_lbl)
+
+        self.list_btn.clicked.connect(self.on_list_clicked)
+        self.open_dir_btn.clicked.connect(self.on_open_dir_clicked)
+
+    # --- API helpers ---
+    def _headers(self):
+        h = {}
+        if self.api_key:
+            h["X-API-KEY"] = self.api_key
+        return h
+
+    def _api_get(self, path, params=None):
+        url = f"{self.base_url}{path}"
+        try:
+            r = requests.get(url, params=params or {}, headers=self._headers(), timeout=20)
+            if r.status_code == 401:
+                show_toast(self, "Clé API absente ou invalide (401).", error=True)
+                return None
+            r.raise_for_status()
+            return r
+        except requests.Timeout:
+            show_toast(self, "Requête expirée (timeout).", error=True)
+        except Exception as ex:
+            show_toast(self, f"Erreur de requête: {ex}", error=True)
+        return None
+
+    # --- Actions ---
+    def on_open_dir_clicked(self):
+        show_toast(self, "Ouverture dossier côté OS non disponible.", error=True)
+
+    def on_list_clicked(self):
+        """
+        Appelle /files/list avec 'folder' (alias OU chemin absolu),
+        consomme 'urls' du backend et affiche les vignettes à partir de ces URLs.
+        """
+        target = (
+            self.input_edit.text().strip()
+            if hasattr(self, "input_edit")
+            else "images_root"
+        )
+        r = self._api_get("/files/list", params={"folder": target})
+        if r is None:
+            return
+        r.raise_for_status()
+        data = r.json()
+
+        self._raw_folder = data.get("folder", target)
+        files = data.get("files", [])
+        urls = data.get("urls", [])
+
+        # Mémoriser la liste structurée pour l'UI
+        self._items = []
+        for name, url in zip(files, urls):
+            self._items.append({"name": name, "url": url})
+
+        self._items = self._items[: self.limit_spin.value()]
+        self._render_thumbs(self._items)
+        self.status_lbl.setText(
+            f"{len(self._items)} fichiers affichés (sur {len(files)})."
+        )
+        self.open_dir_btn.setEnabled(True)
+
+    def _render_thumbs(self, items):
+        while self.grid.count():
+            w = self.grid.takeAt(0).widget()
+            if w:
+                w.deleteLater()
+
+        col_count = 5
+        row = col = 0
+        for item in items:
+            card = self._make_thumb_card(item)
+            self.grid.addWidget(card, row, col)
+            col += 1
+            if col >= col_count:
+                col = 0
+                row += 1
+
+    def _make_thumb_card(self, item):
+        """
+        item = {"name": "...", "url": "..."}
+        Utilise l'URL directe. En fallback, reconstruit /files/raw?folder=...&name=...
+        """
+        name = item.get("name", "")
+        url = item.get("url") or ""
+        if not url:
+            base = self.base_url.rstrip("/")
+            url = (
+                f"{base}/files/raw?folder={quote(str(getattr(self, '_raw_folder', '')))}"
+                f"&name={quote(name)}"
+            )
+
+        w = QWidget(self)
+        v = QVBoxLayout(w)
+        lbl_img = QLabel(w)
+        lbl_img.setAlignment(Qt.AlignCenter)
+        lbl_img.setFixedSize(QSize(180, 140))
+        lbl_img.setText("Chargement…")
+
+        try:
+            rr = requests.get(url, headers=self._headers(), timeout=20)
+            if rr.status_code == 200:
+                pm = QPixmap()
+                pm.loadFromData(rr.content)
+                if not pm.isNull():
+                    pm = pm.scaled(
+                        lbl_img.size(), Qt.KeepAspectRatio, Qt.SmoothTransformation
+                    )
+                    lbl_img.setPixmap(pm)
+                else:
+                    lbl_img.setText("Non image")
+            else:
+                lbl_img.setText("Erreur")
+        except Exception:
+            lbl_img.setText("Erreur")
+
+        lbl_name = QLabel(name, w)
+        btn_view = QPushButton("Aperçu", w)
+        btn_view.clicked.connect(lambda: self._open_preview(name, url))
+
+        v.addWidget(lbl_img)
+        v.addWidget(lbl_name)
+        v.addWidget(btn_view)
+        return w
+
+    def _open_preview(self, name: str, url: str):
+        try:
+            rr = requests.get(url, headers=self._headers(), timeout=20)
+            if rr.status_code != 200:
+                show_toast(self, "Erreur", error=True)
+                return
+            pm = QPixmap()
+            pm.loadFromData(rr.content)
+            if pm.isNull():
+                show_toast(self, "Fichier non image.", error=True)
+                return
+            dlg = ImagePreviewDialog(self, title=name, pixmap=pm)
+            dlg.exec()
+        except Exception as ex:
+            show_toast(self, f"Impossible d’ouvrir l’aperçu: {ex}", error=True)
+
+### >>> gpt/README.md (8 lignes)
+# GPT Integration Assets
+
+Ce dossier contient les ressources nécessaires à l'intégration du projet avec GPT Builder.
+
+- `openapi.yaml` décrit l'API REST exposée par le serveur Flask.
+- `product_bridge_behavior.txt` contient le prompt système utilisé par GPT Builder pour configurer le comportement du pont produit. **Remplacer le texte de ce fichier par le bloc "Behavior GPT Builder (système)" fourni par l'équipe produit.**
+
+Ces fichiers peuvent être importés dans GPT Builder afin de générer un assistant personnalisé capable d'interagir avec l'API du projet.
+
+### >>> gpt/behavior_product_writer.txt (12 lignes)
+Tu es un générateur de fiches produits FR (fr-FR), SEO “pur”.
+Règles par produit :
+- Utilise 3 à 5 images renvoyées par l’API pour déduire matière, couleur, style, lacet/ficelle, etc.
+- Génère : Name, Short description (60–80 mots), Description (230–240 mots, lisible), Categories (2–4), Tags (2–4), Slug, Focus keyword, Meta title (55–60 car), Meta description (140–160), Internal link.
+- Densité mot-clé 1–1,5%, pas d’emoji, pas de promesses médicales.
+- Renvoyer via POST /products/{slug}/descriptions exactement le JSON attendu.
+
+Procédure d’appel :
+1) GET /products → récupérer la liste (jusqu’à 20 premiers items).
+2) Pour chaque slug → GET /products/{slug}/images → choisir 3–5 images.
+3) Générer la fiche et POST /products/{slug}/descriptions.
+4) Ignorer les produits qui ont déjà un generated.json (si l’API le signale dans le futur).
+
+### >>> gpt/copy.txt (4226 lignes)
+# .gitignore
+Description: Source code for .gitignore
+```
+__pycache__/
+*.pyc
+images/
+
+```
+
+# MOTEUR/__init__.py
+Description: Source code for MOTEUR/__init__.py
+```python
+
+```
+
+# MOTEUR/compta/__init__.py
+Description: Source code for MOTEUR/compta/__init__.py
+```python
+
+```
+
+# MOTEUR/compta/accounting/__init__.py
+Description: Source code for MOTEUR/compta/accounting/__init__.py
+```python
+
+```
+
+# MOTEUR/compta/accounting/widget.py
+Description: Source code for MOTEUR/compta/accounting/widget.py
+```python
+from PySide6.QtWidgets import QWidget
+from PySide6.QtCore import Signal
+
+
+class AccountWidget(QWidget):
+    accounts_updated = Signal()
+
+```
+
+# MOTEUR/compta/achats/__init__.py
+Description: Source code for MOTEUR/compta/achats/__init__.py
+```python
+
+```
+
+# MOTEUR/compta/achats/widget.py
+Description: Source code for MOTEUR/compta/achats/widget.py
+```python
+from PySide6.QtWidgets import QWidget
+
+
+class AchatWidget(QWidget):
+    def refresh_accounts(self) -> None:
+        pass
+
+```
+
+# MOTEUR/compta/dashboard/__init__.py
+Description: Source code for MOTEUR/compta/dashboard/__init__.py
+```python
+
+```
+
+# MOTEUR/compta/dashboard/widget.py
+Description: Source code for MOTEUR/compta/dashboard/widget.py
+```python
+from PySide6.QtWidgets import QWidget, QLabel, QVBoxLayout
+from PySide6.QtCore import Signal
+
+
+class DashboardWidget(QWidget):
+    journal_requested = Signal()
+    grand_livre_requested = Signal()
+    scraping_summary_requested = Signal()
+
+    def __init__(self) -> None:
+        super().__init__()
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("Dashboard"))
+
+    def refresh(self) -> None:
+        pass
+
+```
+
+# MOTEUR/compta/parameters.py
+Description: Source code for MOTEUR/compta/parameters.py
+```python
+from PySide6.QtWidgets import QWidget
+
+
+class JournalsWidget(QWidget):
+    pass
+
+```
+
+# MOTEUR/compta/revision.py
+Description: Source code for MOTEUR/compta/revision.py
+```python
+from PySide6.QtWidgets import QWidget
+
+
+class RevisionTab(QWidget):
+    pass
+
+```
+
+# MOTEUR/compta/suppliers.py
+Description: Source code for MOTEUR/compta/suppliers.py
+```python
+from PySide6.QtWidgets import QWidget
+
+
+class SupplierTab(QWidget):
+    pass
+
+```
+
+# MOTEUR/compta/ventes/__init__.py
+Description: Source code for MOTEUR/compta/ventes/__init__.py
+```python
+
+```
+
+# MOTEUR/compta/ventes/widget.py
+Description: Source code for MOTEUR/compta/ventes/widget.py
+```python
+from PySide6.QtWidgets import QWidget
+
+
+class VenteWidget(QWidget):
+    pass
+
+```
+
+# MOTEUR/scraping/__init__.py
+Description: Source code for MOTEUR/scraping/__init__.py
+```python
+
+```
+
+# MOTEUR/scraping/bus/__init__.py
+Description: Source code for MOTEUR/scraping/bus/__init__.py
+```python
+
+```
+
+# MOTEUR/scraping/bus/event_bus.py
+Description: Source code for MOTEUR/scraping/bus/event_bus.py
+```python
+from PySide6.QtCore import QObject, Signal
+
+
+class EventBus(QObject):
+    profiles_changed = Signal()
+    history_changed = Signal()
+
+
+# singleton
+bus = EventBus()
+
+```
+
+# MOTEUR/scraping/history.py
+Description: Source code for MOTEUR/scraping/history.py
+```python
+import json
+from pathlib import Path
+from datetime import datetime
+from typing import List, Dict
+
+# Path to the history log file at project root
+HISTORY_FILE = Path(__file__).resolve().parents[2] / "scraping_history.json"
+
+# Path to file storing last used url/folder
+LAST_USED_FILE = Path(__file__).resolve().parents[2] / "scraping_last_used.json"
+
+
+def _read_json(path: Path) -> List[Dict]:
+    if not path.exists():
+        return []
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f) or []
+    except Exception:
+        return []
+
+
+def _write_json(path: Path, data) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+
+
+def log_scrape(url: str, profile: str, images: int, folder: str) -> None:
+    """Append a scraping entry to :data:`HISTORY_FILE`."""
+    entries = _read_json(HISTORY_FILE)
+    entries.append(
+        {
+            "date": datetime.now().isoformat(timespec="seconds"),
+            "url": url,
+            "profile": profile,
+            "images": images,
+            "folder": folder,
+        }
+    )
+    _write_json(HISTORY_FILE, entries)
+    save_last_used(url, folder)
+
+
+def load_history() -> List[Dict]:
+    """Return the list of logged scraping entries."""
+    return _read_json(HISTORY_FILE)
+
+
+def save_last_used(url: str, folder: str) -> None:
+    _write_json(LAST_USED_FILE, {"url": url, "folder": folder})
+
+
+def load_last_used() -> Dict[str, str]:
+    if not LAST_USED_FILE.exists():
+        return {"url": "", "folder": ""}
+    try:
+        with open(LAST_USED_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if isinstance(data, dict):
+            return {"url": data.get("url", ""), "folder": data.get("folder", "")}
+    except Exception:
+        pass
+    return {"url": "", "folder": ""}
+
+```
+
+# MOTEUR/scraping/image_scraper.py
+Description: Source code for MOTEUR/scraping/image_scraper.py
+```python
+import os
+import re
+import time
+from pathlib import Path
+from typing import List, Set
+from urllib.parse import urljoin, urlparse, unquote
+import unicodedata
+
+import requests
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.remote.webelement import WebElement
+
+DEFAULT_USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/124.0.0.0 Safari/537.36"
+)
+
+
+def _create_driver(user_agent: str = DEFAULT_USER_AGENT) -> webdriver.Chrome:
+    options = Options()
+    options.add_argument(f"--user-agent={user_agent}")
+    options.add_argument("--disable-blink-features=AutomationControlled")
+    options.add_experimental_option("excludeSwitches", ["enable-automation"])
+    options.add_experimental_option("useAutomationExtension", False)
+    driver = webdriver.Chrome(options=options)
+    driver.execute_cdp_cmd(
+        "Page.addScriptToEvaluateOnNewDocument",
+        {
+            "source": "Object.defineProperty(navigator, 'webdriver', {get: () => undefined});"
+        },
+    )
+    return driver
+
+
+def _scroll_page(driver: webdriver.Chrome, pause: float = 0.5) -> None:
+    last_height = driver.execute_script("return document.body.scrollHeight")
+    position = 0
+    while position < last_height:
+        position += 600
+        driver.execute_script(f"window.scrollTo(0, {position});")
+        time.sleep(pause)
+        last_height = driver.execute_script("return document.body.scrollHeight")
+
+
+def _simulate_slider_interaction(driver: webdriver.Chrome) -> None:
+    try:
+        dots = driver.find_elements(By.CSS_SELECTOR, ".flickity-page-dots .dot")
+        for i, dot in enumerate(dots):
+            driver.execute_script("arguments[0].click();", dot)
+            print(f"🟡 Clic sur le point {i+1}/{len(dots)}")
+            time.sleep(1.2)
+    except Exception as e:
+        print(f"⚠️ Aucun slider détecté ou erreur : {e}")
+
+
+def _extract_urls(driver: webdriver.Chrome, selector: str) -> List[str]:
+    elements = driver.find_elements(By.CSS_SELECTOR, selector)
+    urls: Set[str] = set()
+
+    for el in elements:
+        tag = el.tag_name.lower()
+
+        # Si c'est une balise <a>, on essaie de récupérer l'attribut href
+        if tag == "a":
+            href = el.get_attribute("href")
+            if href and href.endswith((".jpg", ".jpeg", ".png", ".webp")):
+                urls.add(href)
+                continue
+
+        # Si c'est une balise <img> ou autre avec data-photoswipe-src / src / data-src
+        src = (
+            el.get_attribute("data-photoswipe-src")
+            or el.get_attribute("src")
+            or el.get_attribute("data-src")
+        )
+        if src:
+            if src.startswith("//"):
+                src = "https:" + src
+            elif src.startswith("/"):
+                src = urljoin(driver.current_url, src)
+        if src and not src.startswith("data:image"):
+            urls.add(src)
+            continue
+
+        # Vérifie aussi dans le style (cas d'image en background)
+        style = el.get_attribute("style") or ""
+        match = re.search(r"url\(['\"]?(.*?)['\"]?\)", style)
+        if match:
+            url = match.group(1)
+            if not url.startswith("data:image"):
+                urls.add(url)
+
+    return list(urls)
+
+
+def _download(url: str, folder: Path) -> None:
+    if url.startswith("data:image"):
+        print(f"\u26A0\uFE0F Ignoré (image base64) : {url[:50]}...")
+        return
+
+    try:
+        resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
+
+        # Vérifie que la réponse est bien une image
+        content_type = resp.headers.get("Content-Type", "")
+        if not content_type.startswith("image/"):
+            print(f"\u274c Mauvais type de contenu pour {url}: {content_type}")
+            return
+
+        # Ignore les contenus vides ou trop petits pour être une image réelle
+        if not resp.content or len(resp.content) < 100:
+            print(f"\u26A0\uFE0F Réponse vide ou suspecte pour {url}")
+            return
+
+    except Exception as exc:
+        print(f"\u274c Erreur lors du téléchargement de {url}: {exc}")
+        return
+
+    # Enregistrement avec gestion de collision de nom
+    name = os.path.basename(url.split("?")[0]) or "image"
+    stem, ext = os.path.splitext(name)
+    stem = re.sub(r"-\d+$", "", stem)
+    name = f"{stem}{ext}"
+    path = folder / name
+    base, ext = os.path.splitext(path)
+    idx = 1
+    while path.exists():
+        path = Path(f"{base}_{idx}{ext}")
+        idx += 1
+    with open(path, "wb") as f:
+        f.write(resp.content)
+
+
+def _folder_from_url(url: str) -> Path:
+    """Return a folder name derived from ``url``.
+
+    The last segment of the path is used, hyphens are replaced with spaces and
+    unsafe characters are removed.
+    """
+    from urllib.parse import urlparse, unquote
+
+    path = unquote(urlparse(url).path)
+    name = Path(path).name.replace("-", " ")
+    # keep alphanumeric characters, spaces and underscores only
+    name = re.sub(r"[^\w\s]", "", name).strip()
+    return Path(name or "images")
+
+
+def scrape_images(
+    page_url: str,
+    selector: str,
+    folder: str | Path = "images",
+    *,
+    keep_driver: bool = False,
+) -> int | tuple[int, webdriver.Chrome]:
+    """Download images from ``page_url`` into a subfolder of ``folder``.
+
+    The subfolder name is derived from the URL's last path segment. When
+    ``keep_driver`` is ``True``, the Selenium driver is returned alongside the
+    image count and left open for further processing by the caller.
+    """
+    print("Chargement...")
+    driver = _create_driver()
+    try:
+        driver.get(page_url)
+        WebDriverWait(driver, 15).until(
+            EC.presence_of_element_located((By.CSS_SELECTOR, selector))
+        )
+        _simulate_slider_interaction(driver)
+        _scroll_page(driver)
+        urls = _extract_urls(driver, selector)
+        total = len(urls)
+        if total == 0:
+            print(
+                "⚠️ Aucune image trouvée. Vérifie si le slider charge bien dynamiquement."
+            )
+        else:
+            print(f"{total} images trouv\u00e9es")
+    finally:
+        if not keep_driver:
+            driver.quit()
+
+    base_dir = Path(folder)
+    images_dir = base_dir / _folder_from_url(page_url)
+    images_dir.mkdir(parents=True, exist_ok=True)
+    for i, url in enumerate(urls, 1):
+        print(f"T\u00e9l\u00e9chargement de l'image n\u00b0{i}/{total}")
+        _download(url, images_dir)
+    print("\u2705 Termin\u00e9")
+
+    if keep_driver:
+        return total, driver
+    return total
+
+
+def scrape_variants(driver: webdriver.Chrome) -> dict[str, str]:
+    """Extract product variant names and associated image URLs using ``driver``.
+
+    ``driver`` must already be on the product page. Each variant input is
+    expected inside the ``.variant-picker__option-values`` container.  The
+    function clicks on each corresponding label, waits for the main product
+    image to update and collects the resulting URL.
+    """
+
+    mapping: dict[str, str] = {}
+
+    def _slugify(text: str) -> str:
+        text = unicodedata.normalize('NFKD', text)
+        text = text.encode('ascii', 'ignore').decode('ascii')
+        text = re.sub(r"[^a-zA-Z0-9\s-]", "", text)
+        text = re.sub(r"[\s_-]+", "-", text).strip("-")
+        return text.lower()
+
+    product_path = unquote(urlparse(driver.current_url).path).rstrip("/")
+    product_name = Path(product_path).name
+    product_slug = _slugify(product_name)
+
+    def _img_url(el):
+        return (
+            el.get_attribute("src")
+            or el.get_attribute("data-photoswipe-src")
+            or el.get_attribute("data-src")
+        )
+
+    selectors = [
+        ".woocommerce-product-gallery__image img",
+        ".product-media img",
+        ".product-image img",
+        ".product-gallery img",
+        ".product-main img",
+    ]
+
+    def _find_main_image() -> WebElement | None:
+        for sel in selectors + ["img"]:
+            try:
+                img = driver.find_element(By.CSS_SELECTOR, sel)
+                if img.is_displayed():
+                    return img
+            except Exception:
+                continue
+        return None
+
+    try:
+        inputs = driver.find_elements(
+            By.CSS_SELECTOR, ".variant-picker__option-values input[type='radio']"
+        )
+        if not inputs:
+            return mapping
+
+        main_img = _find_main_image()
+        if main_img is None:
+            return mapping
+
+        for inp in inputs:
+            value = inp.get_attribute("value") or inp.get_attribute("data-value")
+            input_id = inp.get_attribute("id")
+            label = None
+            if input_id:
+                try:
+                    label = driver.find_element(By.CSS_SELECTOR, f"label[for='{input_id}']")
+                except Exception:
+                    label = None
+            if label is None:
+                try:
+                    label = inp.find_element(By.XPATH, "following-sibling::label[1]")
+                except Exception:
+                    continue
+
+            previous = _img_url(main_img)
+            driver.execute_script("arguments[0].click()", label)
+            try:
+                WebDriverWait(driver, 5).until(
+                    lambda d: (_img_url(_find_main_image()) or "") != (previous or "")
+                )
+            except Exception:
+                pass
+
+            new_img = _find_main_image() or main_img
+            main_img = new_img
+            if value:
+                variant_slug = _slugify(value)
+                url = (
+                    f"https://www.planetebob.fr/wp-content/uploads/2025/07/"
+                    f"{product_slug}-{variant_slug}.jpg"
+                )
+                mapping[value] = url
+    except Exception as exc:
+        print(f"⚠️ Erreur lors du scraping des variantes: {exc}")
+
+    return mapping
+
+
+if __name__ == "__main__":
+    scrape_images("https://exemple.com/produit", ".product-image img")
+
+```
+
+# MOTEUR/scraping/profile_manager.py
+Description: Source code for MOTEUR/scraping/profile_manager.py
+```python
+import json
+from pathlib import Path
+from typing import List, Dict
+
+# Path to the JSON file storing profiles. By default it is located at the
+# project root but can be overridden in tests by changing this variable.
+PROFILES_FILE = Path(__file__).resolve().parents[2] / "profiles.json"
+
+
+def load_profiles() -> List[Dict[str, str]]:
+    """Load scraping profiles from :data:`PROFILES_FILE`.
+
+    Returns an empty list if the file does not exist or is empty.
+    """
+    if not PROFILES_FILE.exists():
+        return []
+    try:
+        with open(PROFILES_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if isinstance(data, list):
+            return [p for p in data if isinstance(p, dict)]
+    except Exception:
+        pass
+    return []
+
+
+def save_profiles(profiles: List[Dict[str, str]]) -> None:
+    """Write ``profiles`` to :data:`PROFILES_FILE` in JSON format."""
+    with open(PROFILES_FILE, "w", encoding="utf-8") as f:
+        json.dump(profiles, f, indent=2, ensure_ascii=False)
+
+
+def add_profile(name: str, selector: str) -> None:
+    """Add a new profile with ``name`` and ``selector``.
+
+    Raises ``ValueError`` if a profile with the same name already exists.
+    """
+    profiles = load_profiles()
+    if any(p.get("name") == name for p in profiles):
+        raise ValueError(f"Profile '{name}' already exists")
+    profiles.append({"name": name, "selector": selector})
+    save_profiles(profiles)
+
+
+def update_profile(name: str, selector: str) -> bool:
+    """Update an existing profile's selector.
+
+    Returns ``True`` if the profile was updated, ``False`` otherwise.
+    """
+    profiles = load_profiles()
+    updated = False
+    for profile in profiles:
+        if profile.get("name") == name:
+            profile["selector"] = selector
+            updated = True
+            break
+    if updated:
+        save_profiles(profiles)
+    return updated
+
+
+def delete_profile(name: str) -> bool:
+    """Delete the profile with ``name``.
+
+    Returns ``True`` if the profile was removed, ``False`` otherwise.
+    """
+    profiles = load_profiles()
+    new_profiles = [p for p in profiles if p.get("name") != name]
+    if len(new_profiles) == len(profiles):
+        return False
+    save_profiles(new_profiles)
+    return True
+
+```
+
+# MOTEUR/scraping/server/__init__.py
+Description: Source code for MOTEUR/scraping/server/__init__.py
+```python
+"""Utilities for exposing the scraping features through a Flask bridge."""
+
+from .flask_server import FlaskBridgeServer, JobManager, JobStatus
+
+__all__ = ["FlaskBridgeServer", "JobManager", "JobStatus"]
+
+```
+
+# MOTEUR/scraping/server/flask_server.py
+Description: Source code for MOTEUR/scraping/server/flask_server.py
+```python
+from __future__ import annotations
+
+"""Small Flask server to remotely trigger scraping jobs.
+
+The module exposes :class:`FlaskBridgeServer` which wraps a Flask
+application and provides a thread based HTTP server.  The endpoints are
+minimal and secured through an API key passed in the ``X-API-KEY``
+header.  Jobs are executed in a :class:`~concurrent.futures.ThreadPoolExecutor`
+so the UI remains responsive.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+import datetime as _dt
+import os
+import threading
+import time
+import uuid
+import logging
+from pathlib import Path
+
+from flask import Flask, request, jsonify
+from werkzeug.serving import make_server
+from concurrent.futures import ThreadPoolExecutor, Future
+
+from ..image_scraper import scrape_images, scrape_variants
+from ..profile_manager import load_profiles
+from ..history import load_history
+
+
+log = logging.getLogger("flask-bridge")
+log.setLevel(logging.INFO)
+
+
+@dataclass
+class JobStatus:
+    """Represents the state of a running scraping job."""
+
+    job_id: str
+    status: str = "queued"   # queued|running|done|error
+    progress: Dict[str, int] = field(
+        default_factory=lambda: {"found": 0, "downloaded": 0, "failed": 0}
+    )
+    output_dir: str = ""
+    started_at: Optional[str] = None
+    finished_at: Optional[str] = None
+    variants: Dict[str, str] = field(default_factory=dict)
+    sample_images: list[str] = field(default_factory=list)
+    errors: list[Dict[str, str]] = field(default_factory=list)
+    message: str = ""
+
+
+class JobManager:
+    """Simple registry for running scraping jobs."""
+
+    def __init__(self, max_workers: int = 2) -> None:
+        self.jobs: Dict[str, JobStatus] = {}
+        self.executor = ThreadPoolExecutor(max_workers=max_workers)
+        self.lock = threading.Lock()
+
+    def submit(self, fn, *args, **kwargs) -> JobStatus:
+        job_id = uuid.uuid4().hex[:12]
+        st = JobStatus(job_id=job_id)
+        with self.lock:
+            self.jobs[job_id] = st
+        self.executor.submit(fn, st, *args, **kwargs)
+        return st
+
+
+class StoppableWSGIServer(threading.Thread):
+    """Wrapper around Werkzeug's WSGI server allowing clean shutdown."""
+
+    def __init__(self, app: Flask, host: str, port: int) -> None:
+        super().__init__(daemon=True)
+        self.srv = make_server(host, port, app)
+        self.ctx = app.app_context()
+        self.ctx.push()
+
+    def run(self) -> None:  # pragma: no cover - simple thread runner
+        self.srv.serve_forever()
+
+    def shutdown(self) -> None:
+        self.srv.shutdown()
+        self.ctx.pop()
+
+
+class FlaskBridgeServer:
+    """Expose scraping helpers through a small Flask application."""
+
+    def __init__(self, on_log=None) -> None:
+        self.on_log = on_log
+        self.app = Flask(__name__)
+        self._server: Optional[StoppableWSGIServer] = None
+        self._ngrok_tunnel = None
+        self.public_url = ""
+        self.api_key = os.getenv("SCRAPER_API_KEY", "")
+        self.default_flags = {
+            "headless": True,
+            "ignore_robots": False,
+            "rate_limit": 0,
+            "max_workers": 1,
+        }
+        self.jobs = JobManager(max_workers=2)
+        self._mount_routes()
+
+    # ------------------------------------------------------------------
+    # helpers
+    def _log(self, msg: str) -> None:
+        log.info(msg)
+        if self.on_log:
+            self.on_log(msg)
+
+    # ------------------------------------------------------------------
+    # Flask routes
+    def _mount_routes(self) -> None:
+        app = self.app
+
+        @app.get("/health")
+        def health() -> Any:
+            return jsonify(
+                {
+                    "ok": True,
+                    "version": "1.0",
+                    "time": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                }
+            )
+
+        def require_key():
+            key = request.headers.get("X-API-KEY", "")
+            if not self.api_key or key != self.api_key:
+                return jsonify({"error": "unauthorized"}), 401
+            return None
+
+        @app.post("/scrape")
+        def scrape() -> Any:
+            auth = require_key()
+            if auth:
+                return auth
+            data = request.get_json(force=True, silent=True) or {}
+            url = data.get("url")
+            selector = data.get("selector")
+            if not url or not selector:
+                return (
+                    jsonify({"error": "invalid_request", "detail": "url & selector required"}),
+                    400,
+                )
+            folder = data.get("folder") or "images"
+            opts = {**self.default_flags, **(data.get("options") or {})}
+            st = self.jobs.submit(self._run_scrape_job, url, selector, folder, opts)
+            self._log(f"Job {st.job_id} accepté pour {url}")
+            return jsonify({"job_id": st.job_id, "message": "accepted"}), 202
+
+        @app.post("/actions/image-edit")
+        def image_edit() -> Any:
+            auth = require_key()
+            if auth:
+                return auth
+            data = request.get_json(force=True, silent=True) or {}
+            src = ((data.get("source") or {}).get("folder") or "").strip()
+            ops = data.get("operations") or []
+            target_subdir = (data.get("target_subdir") or "image fait par gpt").strip()
+            if not src or not ops:
+                return (
+                    jsonify(
+                        {
+                            "error": "invalid_request",
+                            "detail": "source.folder & operations required",
+                        }
+                    ),
+                    400,
+                )
+            st = self.jobs.submit(self._run_image_action_job, src, ops, target_subdir)
+            self._log(
+                f"Job {st.job_id} image-edit: {src} -> {target_subdir} ({len(ops)} ops)"
+            )
+            return jsonify({"job_id": st.job_id, "message": "accepted"}), 202
+
+        @app.get("/jobs/<job_id>")
+        def job_status(job_id: str) -> Any:
+            auth = require_key()
+            if auth:
+                return auth
+            st = self.jobs.jobs.get(job_id)
+            if not st:
+                return jsonify({"error": "not_found"}), 404
+            return jsonify(st.__dict__)
+
+        @app.get("/jobs")
+        def list_jobs() -> Any:
+            auth = require_key()
+            if auth:
+                return auth
+            return jsonify([j.__dict__ for j in self.jobs.jobs.values()])
+
+        @app.get("/profiles")
+        def profiles() -> Any:
+            auth = require_key()
+            if auth:
+                return auth
+            profs = load_profiles()
+            out = [
+                {"name": p.get("name", ""), "selector": p.get("selector", "")}
+                for p in profs
+            ]
+            out.sort(key=lambda p: p["name"])
+            return jsonify(out), 200
+
+        @app.post("/profiles")
+        def add_profile_route() -> Any:
+            auth = require_key()
+            if auth:
+                return auth
+            data = request.get_json(force=True, silent=True) or {}
+            name = (data.get("name") or "").strip()
+            selector = (data.get("selector") or "").strip()
+            if not name or not selector:
+                return (
+                    jsonify(
+                        {
+                            "error": "invalid_request",
+                            "detail": "name and selector required",
+                        }
+                    ),
+                    400,
+                )
+            try:
+                from .. import profile_manager as pm
+
+                pm.add_profile(name, selector)
+            except ValueError:
+                return jsonify({"error": "exists"}), 409
+
+            try:
+                from PySide6.QtCore import QMetaObject, Qt
+                from ..bus.event_bus import bus
+
+                QMetaObject.invokeMethod(bus, "profiles_changed", Qt.QueuedConnection)
+            except Exception as e:  # pragma: no cover - best effort
+                log.warning("Impossible d'émettre profiles_changed: %s", e)
+
+            self._log(f"Profil '{name}' ajouté")
+            log.info("Profil ajouté: %s -> %s", name, selector)
+            return jsonify({"name": name, "selector": selector}), 201
+
+        @app.get("/history")
+        def hist() -> Any:
+            auth = require_key()
+            if auth:
+                return auth
+            return jsonify(load_history())
+
+        @app.get("/debug/ping")
+        def debug_ping() -> Any:
+            auth = require_key()
+            if auth:
+                return auth
+            from PySide6.QtCore import QCoreApplication
+
+            return jsonify(
+                {
+                    "thread": "flask",
+                    "qt_alive": QCoreApplication.instance() is not None,
+                }
+            )
+
+    # ------------------------------------------------------------------
+    # job execution
+    def _run_scrape_job(
+        self,
+        st: JobStatus,
+        url: str,
+        selector: str,
+        folder: str,
+        opts: Dict[str, Any],
+    ) -> None:
+        st.status = "running"
+        st.started_at = _dt.datetime.utcnow().isoformat() + "Z"
+        try:
+            if opts.get("with_variants"):
+                total, driver = scrape_images(
+                    url,
+                    selector,
+                    folder,
+                    keep_driver=True,
+                )
+                st.variants = scrape_variants(driver)
+                driver.quit()
+            else:
+                total = scrape_images(url, selector, folder)
+            st.progress["found"] = total
+            st.progress["downloaded"] = total
+            st.output_dir = folder
+            images_dir = Path(folder)
+            if images_dir.exists():
+                files = sorted(images_dir.glob("*"))[:5]
+                st.sample_images = [f.name for f in files]
+            st.status = "done"
+        except Exception as exc:  # pragma: no cover - hard to trigger in tests
+            st.status = "error"
+            st.message = str(exc)
+            st.errors.append({"url": url, "error": str(exc)})
+        finally:
+            st.finished_at = _dt.datetime.utcnow().isoformat() + "Z"
+
+    def _run_image_action_job(
+        self, st: JobStatus, src_folder: str, ops: list[dict], target_subdir: str
+    ) -> None:
+        from pathlib import Path
+        from time import sleep
+        from PIL import Image, ImageFilter
+        import datetime as _dt
+
+        st.status = "running"
+        st.started_at = _dt.datetime.utcnow().isoformat() + "Z"
+        try:
+            rate = int(self.default_flags.get("rate_limit", 0) or 0)  # images/min
+            delay = (60.0 / rate) if rate > 0 else 0.0
+
+            src = Path(src_folder)
+            if not src.exists():
+                raise FileNotFoundError(f"source not found: {src}")
+
+            dst = src / (target_subdir or "image fait par gpt")
+            dst.mkdir(parents=True, exist_ok=True)
+
+            files = [
+                p for p in src.iterdir() if p.suffix.lower() in {".jpg", ".jpeg", ".png", ".webp"}
+            ]
+            st.progress["found"] = len(files)
+            samples: list[str] = []
+
+            def apply_ops(img: Image.Image) -> Image.Image:
+                out = img
+                for op in ops:
+                    kind = str(op.get("op", "")).lower()
+                    if kind == "resize":
+                        w = int(op.get("width", 0))
+                        h = int(op.get("height", 0))
+                        keep = bool(op.get("keep_ratio", True))
+                        if w > 0 and h > 0:
+                            if keep:
+                                out = out.copy()
+                                out.thumbnail((w, h))
+                            else:
+                                out = out.resize((w, h))
+                    elif kind == "sharpen":
+                        amt = float(op.get("amount", 0.6))
+                        out = out.filter(
+                            ImageFilter.UnsharpMask(percent=int(amt * 150), radius=2)
+                        )
+                    elif kind == "remove_bg":
+                        out = out.convert("RGBA")
+                        bg = Image.new("RGBA", out.size, (255, 255, 255, 255))
+                        bg.paste(out, mask=out.split()[-1] if out.mode == "RGBA" else None)
+                        out = bg.convert("RGB")
+                return out
+
+            for i, f in enumerate(files, 1):
+                try:
+                    with Image.open(f) as im:
+                        out = apply_ops(im)
+                        out_path = dst / f.name
+                        out.save(out_path)
+                    st.progress["downloaded"] += 1
+                    if len(samples) < 5:
+                        samples.append(out_path.name)
+                except Exception as e:
+                    st.progress["failed"] += 1
+                    st.errors.append({"file": f.name, "error": str(e)})
+                if delay:
+                    sleep(delay)
+
+            st.sample_images = samples
+            st.output_dir = str(dst)
+            st.status = "done"
+        except Exception as exc:
+            st.status = "error"
+            st.message = str(exc)
+            st.errors.append({"error": str(exc), "folder": src_folder})
+        finally:
+            st.finished_at = _dt.datetime.utcnow().isoformat() + "Z"
+
+    # ------------------------------------------------------------------
+    # public API
+    def start(
+        self,
+        port: int,
+        api_key: str,
+        *,
+        headless_default: bool,
+        user_agent: str | None,
+        ignore_robots_default: bool,
+        rate_limit: int,
+        max_workers: int,
+    ) -> None:
+        """Start the HTTP server."""
+
+        self.api_key = api_key or self.api_key
+        self.default_flags.update(
+            {
+                "headless": headless_default,
+                "user_agent": user_agent,
+                "ignore_robots": ignore_robots_default,
+                "rate_limit": rate_limit,
+                "max_workers": max_workers,
+            }
+        )
+        self.jobs = JobManager(max_workers=max_workers)
+        self._server = StoppableWSGIServer(self.app, "0.0.0.0", port)
+        self._server.start()
+        self._log(f"Serveur lancé sur le port {port}")
+
+    def stop(self) -> None:
+        """Stop the HTTP server and any active ngrok tunnel."""
+
+        if self._server:
+            self._server.shutdown()
+            self._server = None
+            self._log("Serveur arrêté")
+        self.disable_ngrok()
+
+    def enable_ngrok(self, authtoken: str, port: int) -> str:
+        """Expose the local server via ngrok."""
+
+        try:
+            from pyngrok import ngrok
+
+            if authtoken:
+                ngrok.set_auth_token(authtoken)
+            self._ngrok_tunnel = ngrok.connect(port, "http")
+            self.public_url = self._ngrok_tunnel.public_url
+            self._log(f"Ngrok exposé sur {self.public_url}")
+        except Exception as exc:  # pragma: no cover - requires network
+            self._log(f"Erreur ngrok : {exc}")
+            self.public_url = ""
+        return self.public_url
+
+    def disable_ngrok(self) -> None:
+        """Close the ngrok tunnel if opened."""
+
+        try:
+            if self._ngrok_tunnel:
+                from pyngrok import ngrok
+
+                ngrok.disconnect(self._ngrok_tunnel.public_url)
+                ngrok.kill()
+                self._log("Ngrok arrêté")
+        except Exception:  # pragma: no cover - best effort
+            pass
+        finally:
+            self._ngrok_tunnel = None
+            self.public_url = ""
+
+    def is_running(self) -> bool:
+        """Return ``True`` if the server is currently running."""
+
+        return self._server is not None
+
+```
+
+# MOTEUR/scraping/utils/__init__.py
+Description: Source code for MOTEUR/scraping/utils/__init__.py
+```python
+
+```
+
+# MOTEUR/scraping/utils/restart.py
+Description: Source code for MOTEUR/scraping/utils/restart.py
+```python
+from __future__ import annotations
+import os
+import sys
+import subprocess
+import time
+
+def _build_relaunch_argv() -> list[str]:
+    py = sys.executable or "python"
+    # Cas PyInstaller / frozen
+    if getattr(sys, "frozen", False):
+        return [py] + sys.argv[1:]
+    # Script direct
+    script = os.path.abspath(sys.argv[0]) if sys.argv and sys.argv[0] else ""
+    if script and script.lower().endswith((".py", ".pyw")):
+        return [py, script] + sys.argv[1:]
+    # Fallback (ex: python -m package)
+    return [py] + sys.argv[1:]
+
+def relaunch_current_process(delay_sec: float = 0.25, *, cwd: str | None = None) -> None:
+    argv = _build_relaunch_argv()
+    try:
+        print(f"[restart] sys.executable = {sys.executable}")
+        print(f"[restart] sys.argv       = {sys.argv}")
+        print(f"[restart] relaunch argv  = {argv}")
+        if cwd is None:
+            cwd = os.getcwd()
+        print(f"[restart] cwd            = {cwd}")
+
+        popen_kwargs = dict(
+            cwd=cwd,
+            close_fds=(os.name != "nt"),
+            start_new_session=(os.name != "nt"),
+        )
+        if os.name == "nt":
+            CREATE_NEW_PROCESS_GROUP = 0x00000200
+            DETACHED_PROCESS = 0x00000008
+            popen_kwargs["creationflags"] = DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP
+        subprocess.Popen(argv, **popen_kwargs)
+    except Exception as e:
+        print(f"[restart] Erreur au relancement: {e}")
+    time.sleep(delay_sec)
+
+```
+
+# MOTEUR/scraping/utils/update.py
+Description: Source code for MOTEUR/scraping/utils/update.py
+```python
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+# Determine the project root (three levels up from this file)
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+
+def pull_latest(branch: str = "main") -> subprocess.CompletedProcess:
+    """Pull the latest changes from the given branch.
+
+    Parameters
+    ----------
+    branch:
+        Name of the branch to pull from. Defaults to ``"main"``.
+
+    Returns
+    -------
+    subprocess.CompletedProcess
+        The result object from ``subprocess.run``.
+    """
+    return subprocess.run(
+        ["git", "-C", str(PROJECT_ROOT), "pull", "origin", branch],
+        capture_output=True,
+        text=True,
+    )
+
+```
+
+# MOTEUR/scraping/widgets/__init__.py
+Description: Source code for MOTEUR/scraping/widgets/__init__.py
+```python
+
+```
+
+# MOTEUR/scraping/widgets/flask_server_widget.py
+Description: Source code for MOTEUR/scraping/widgets/flask_server_widget.py
+```python
+from __future__ import annotations
+
+"""Widget de contrôle pour :class:`FlaskBridgeServer`."""
+
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QCheckBox,
+    QTextEdit,
+    QApplication,
+)
+from PySide6.QtCore import Slot
+import json, requests
+import os
+import secrets
+
+from ..server.flask_server import FlaskBridgeServer
+
+CFG_FILE = "server_config.json"
+
+
+class FlaskServerWidget(QWidget):
+    """Interface graphique minimaliste pour démarrer le serveur Flask."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.server = FlaskBridgeServer(on_log=self._append)
+        self._build_ui()
+        self._load_cfg()
+        self._last_job_id = ""
+
+    # ------------------------------------------------------------------
+    def _build_ui(self) -> None:
+        self.port = QLineEdit("5001")
+        self.api_key = QLineEdit(os.getenv("SCRAPER_API_KEY", ""))
+        gen = QPushButton("Générer")
+        gen.clicked.connect(self._gen_key)
+        self.expose = QCheckBox("Expose via ngrok")
+        self.ngrok_token = QLineEdit(os.getenv("NGROK_AUTHTOKEN", ""))
+        self.ngrok_token.setEchoMode(QLineEdit.Password)
+        self.headless = QCheckBox("Headless par défaut")
+        self.headless.setChecked(True)
+        self.ignore_robots = QCheckBox("Ignorer robots.txt par défaut")
+        self.rate = QLineEdit("0")
+        self.maxw = QLineEdit("1")
+
+        self.start = QPushButton("Démarrer")
+        self.stop = QPushButton("Arrêter")
+        self.stop.setEnabled(False)
+        self.url_label = QLabel("URL publique : (non exposé)")
+        self.status_label = QLabel("Statut : Arrêté")
+        self.console = QTextEdit()
+        self.console.setReadOnly(True)
+        copyurl = QPushButton("Copier URL")
+        copyurl.clicked.connect(self._copy_url)
+
+        # image actions
+        self.source_folder = QLineEdit()
+        self.target_subdir = QLineEdit("image fait par gpt")
+        self.operations_json = QLineEdit(
+            '[{"op":"resize","width":1024,"height":1024,"keep_ratio":true}]'
+        )
+        self.launch_action_btn = QPushButton("Lancer action")
+        self.launch_action_btn.clicked.connect(self._launch_action)
+        self.status_btn = QPushButton("Status job")
+        self.status_btn.clicked.connect(self._status_job)
+
+        # layouts
+        top = QHBoxLayout()
+        top.addWidget(QLabel("Port:"))
+        top.addWidget(self.port)
+
+        k = QHBoxLayout()
+        k.addWidget(QLabel("API Key:"))
+        k.addWidget(self.api_key)
+        k.addWidget(gen)
+
+        n = QHBoxLayout()
+        n.addWidget(self.expose)
+        n.addWidget(QLabel("Ngrok token:"))
+        n.addWidget(self.ngrok_token)
+
+        o = QHBoxLayout()
+        o.addWidget(self.headless)
+        o.addWidget(self.ignore_robots)
+
+        r = QHBoxLayout()
+        r.addWidget(QLabel("Rate (img/min):"))
+        r.addWidget(self.rate)
+        r.addWidget(QLabel("Max workers:"))
+        r.addWidget(self.maxw)
+
+        btn = QHBoxLayout()
+        btn.addWidget(self.start)
+        btn.addWidget(self.stop)
+        btn.addWidget(copyurl)
+
+        lay = QVBoxLayout(self)
+        for row in (top, k, n, o, r, btn):
+            lay.addLayout(row)
+
+        act1 = QHBoxLayout()
+        act1.addWidget(QLabel("Source folder"))
+        act1.addWidget(self.source_folder)
+        act2 = QHBoxLayout()
+        act2.addWidget(QLabel("Target subdir"))
+        act2.addWidget(self.target_subdir)
+        act3 = QHBoxLayout()
+        act3.addWidget(QLabel("Operations (JSON)"))
+        act3.addWidget(self.operations_json)
+        actb = QHBoxLayout()
+        actb.addWidget(self.launch_action_btn)
+        actb.addWidget(self.status_btn)
+
+        for row in (act1, act2, act3, actb):
+            lay.addLayout(row)
+        lay.addWidget(self.status_label)
+        lay.addWidget(self.url_label)
+        lay.addWidget(self.console)
+
+        self.start.clicked.connect(self._start)
+        self.stop.clicked.connect(self._stop)
+
+    # ------------------------------------------------------------------
+    def _append(self, text: str) -> None:
+        self.console.append(text)
+
+    def _gen_key(self) -> None:
+        self.api_key.setText(secrets.token_urlsafe(24))
+
+    def _copy_url(self) -> None:
+        QApplication.clipboard().setText(
+            self.url_label.text().replace("URL publique : ", "")
+        )
+
+    # ------------------------------------------------------------------
+    def _load_cfg(self) -> None:
+        try:
+            if os.path.exists(CFG_FILE):
+                with open(CFG_FILE, "r", encoding="utf-8") as f:
+                    cfg = json.load(f)
+                self.port.setText(str(cfg.get("port", 5001)))
+                self.api_key.setText(cfg.get("api_key", ""))
+                self.expose.setChecked(bool(cfg.get("expose", False)))
+                self.ngrok_token.setText(cfg.get("ngrok_token", ""))
+                self.headless.setChecked(bool(cfg.get("headless", True)))
+                self.ignore_robots.setChecked(bool(cfg.get("ignore_robots", False)))
+                self.rate.setText(str(cfg.get("rate", 0)))
+                self.maxw.setText(str(cfg.get("max_workers", 1)))
+        except Exception:
+            pass
+
+    def _save_cfg(self) -> dict:
+        cfg = {
+            "port": int(self.port.text() or 5001),
+            "api_key": self.api_key.text().strip(),
+            "expose": self.expose.isChecked(),
+            "ngrok_token": self.ngrok_token.text().strip(),
+            "headless": self.headless.isChecked(),
+            "ignore_robots": self.ignore_robots.isChecked(),
+            "rate": int(self.rate.text() or 0),
+            "max_workers": int(self.maxw.text() or 1),
+        }
+        with open(CFG_FILE, "w", encoding="utf-8") as f:
+            json.dump(cfg, f, indent=2, ensure_ascii=False)
+        return cfg
+
+    # ------------------------------------------------------------------
+    @Slot()
+    def _start(self) -> None:
+        cfg = self._save_cfg()
+        try:
+            self.server.start(
+                port=cfg["port"],
+                api_key=cfg["api_key"],
+                headless_default=cfg["headless"],
+                user_agent=None,
+                ignore_robots_default=cfg["ignore_robots"],
+                rate_limit=cfg["rate"],
+                max_workers=cfg["max_workers"],
+            )
+            pub = ""
+            if cfg["expose"]:
+                pub = self.server.enable_ngrok(cfg["ngrok_token"], cfg["port"])
+            self.status_label.setText("Statut : En cours d’exécution")
+            self.url_label.setText(
+                f"URL publique : {pub or f'http://localhost:{cfg['port']}/health'}"
+            )
+            self.start.setEnabled(False)
+            self.stop.setEnabled(True)
+            self._append("🚀 Serveur démarré")
+        except Exception as e:  # pragma: no cover - UI feedback
+            self._append(f"❌ Erreur démarrage : {e}")
+
+    @Slot()
+    def _stop(self) -> None:
+        try:
+            self.server.stop()
+            self.status_label.setText("Statut : Arrêté")
+            self.url_label.setText("URL publique : (non exposé)")
+            self.start.setEnabled(True)
+            self.stop.setEnabled(False)
+            self._append("🛑 Serveur arrêté")
+        except Exception as e:  # pragma: no cover - UI feedback
+            self._append(f"❌ Erreur arrêt : {e}")
+
+    # ------------------------------------------------------------------
+    @Slot()
+    def _launch_action(self) -> None:
+        try:
+            port = int(self.port.text() or 5001)
+            api_key = self.api_key.text().strip()
+            src = self.source_folder.text().strip()
+            tgt = self.target_subdir.text().strip() or "image fait par gpt"
+            ops_text = self.operations_json.text().strip()
+            ops = json.loads(ops_text) if ops_text else []
+            if not src or not ops:
+                self._append("❌ Source folder ou operations JSON manquants")
+                return
+            url = f"http://localhost:{port}/actions/image-edit"
+            headers = {"X-API-KEY": api_key, "Content-Type": "application/json"}
+            payload = {"source": {"folder": src}, "operations": ops, "target_subdir": tgt}
+            r = requests.post(url, headers=headers, data=json.dumps(payload), timeout=15)
+            if r.status_code != 202:
+                self._append(f"❌ {r.status_code}: {r.text}")
+                return
+            self._last_job_id = r.json().get("job_id", "")
+            self._append(f"🚀 Action lancée — job_id: {self._last_job_id}")
+        except Exception as e:
+            self._append(f"❌ Erreur envoi action: {e}")
+
+    @Slot()
+    def _status_job(self) -> None:
+        try:
+            if not self._last_job_id:
+                self._append("ℹ️ Aucun job_id — lance d’abord une action.")
+                return
+            port = int(self.port.text() or 5001)
+            api_key = self.api_key.text().strip()
+            url = f"http://localhost:{port}/jobs/{self._last_job_id}"
+            headers = {"X-API-KEY": api_key}
+            r = requests.get(url, headers=headers, timeout=10)
+            self._append(r.text)
+        except Exception as e:
+            self._append(f"❌ Erreur status: {e}")
+
+```
+
+# MOTEUR/scraping/widgets/history_widget.py
+Description: Source code for MOTEUR/scraping/widgets/history_widget.py
+```python
+from PySide6.QtWidgets import QWidget, QVBoxLayout, QTextEdit, QPushButton
+from PySide6.QtCore import Slot
+
+from .. import history
+
+
+class HistoryWidget(QWidget):
+    """Display previous scraping runs."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.text = QTextEdit(readOnly=True)
+        self.refresh_btn = QPushButton("Rafraîchir")
+        self.refresh_btn.clicked.connect(self.refresh)
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(self.text)
+        layout.addWidget(self.refresh_btn)
+
+        self.refresh()
+
+    @Slot()
+    def refresh(self) -> None:
+        entries = history.load_history()
+        lines = []
+        for entry in entries:
+            lines.append(
+                f"{entry.get('date','')} - {entry.get('url','')} ("\
+                f"{entry.get('profile','')} - {entry.get('images',0)} images)"
+            )
+        self.text.setPlainText("\n".join(lines))
+
+```
+
+# MOTEUR/scraping/widgets/image_widget.py
+Description: Source code for MOTEUR/scraping/widgets/image_widget.py
+```python
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QLabel,
+    QPushButton,
+    QTextEdit,
+    QProgressBar,
+    QLineEdit,
+    QFileDialog,
+    QHBoxLayout,
+    QComboBox,
+    QCheckBox,
+    QApplication,
+    QMessageBox,
+)
+from PySide6.QtCore import Qt, Slot
+from PySide6.QtGui import QClipboard
+from selenium.webdriver.common.by import By
+
+import sys
+from pathlib import Path
+
+
+class _ConsoleStream:
+    """File-like object writing text directly to a :class:`QTextEdit`."""
+
+    def __init__(self, widget: QTextEdit) -> None:
+        self.widget = widget
+
+    def write(self, text: str) -> int:
+        if text:
+            # Qt widgets must be manipulated from the GUI thread. Using
+            # ``append`` is safe enough for short text snippets.
+            self.widget.append(text.rstrip())
+        return len(text)
+
+    def flush(self) -> None:  # pragma: no cover - required for file-like API
+        pass
+
+from .. import profile_manager as pm
+from .. import history
+
+from ..image_scraper import scrape_images, scrape_variants
+
+
+class ImageScraperWidget(QWidget):
+    """Simple interface to run the image scraper."""
+
+    def __init__(self, *, storage_widget=None) -> None:
+        super().__init__()
+
+        self.storage_widget = storage_widget
+
+        self.export_data: list[dict[str, str]] = []
+
+        self.file_edit = QLineEdit()
+        # ✅ Alias de compatibilité pour l'ancien code
+        self.url_edit = self.file_edit
+        self.file_edit.setPlaceholderText("Fichier texte contenant les URLs")
+        file_btn = QPushButton("Parcourir…")
+        file_btn.clicked.connect(self._choose_file)
+
+        file_layout = QHBoxLayout()
+        file_layout.addWidget(self.file_edit)
+        file_layout.addWidget(file_btn)
+
+        self.profile_combo = QComboBox()
+        self.profiles: list[dict[str, str]] = []
+        self.selected_selector: str = ""
+        self.profile_combo.currentIndexChanged.connect(self._on_profile_changed)
+
+        self.folder_edit = QLineEdit()
+        self.folder_edit.setPlaceholderText("Dossier de destination")
+
+        browse_btn = QPushButton("Parcourir…")
+        browse_btn.clicked.connect(self._choose_folder)
+
+        folder_layout = QHBoxLayout()
+        folder_layout.addWidget(self.folder_edit)
+        folder_layout.addWidget(browse_btn)
+
+        self.variants_checkbox = QCheckBox("Scraper aussi les variantes")
+
+        self.start_btn = QPushButton("Lancer")
+        self.start_btn.clicked.connect(self._start)
+        self.copy_btn = QPushButton("Copier")
+        self.copy_btn.clicked.connect(self._copy_console)
+        self.export_btn = QPushButton("Exporter")
+        self.export_btn.clicked.connect(self._export_excel)
+
+        buttons_layout = QHBoxLayout()
+        buttons_layout.addWidget(self.start_btn)
+        buttons_layout.addWidget(self.copy_btn)
+        buttons_layout.addWidget(self.export_btn)
+
+        self.console = QTextEdit()
+        self.console.setReadOnly(True)
+
+        self.progress_bar = QProgressBar()
+        self.progress_bar.hide()
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("Fichier :"))
+        layout.addLayout(file_layout)
+        layout.addWidget(QLabel("Profil:"))
+        layout.addWidget(self.profile_combo)
+        layout.addWidget(QLabel("Dossier:"))
+        layout.addLayout(folder_layout)
+        layout.addWidget(self.variants_checkbox)
+        layout.addLayout(buttons_layout)
+        layout.addWidget(self.console)
+        layout.addWidget(self.progress_bar)
+
+        self.refresh_profiles()
+        last = history.load_last_used()
+        self.file_edit.setText(last.get("url", ""))
+        self.folder_edit.setText(last.get("folder", ""))
+
+    # ------------------------------------------------------------------
+    def _on_profile_changed(self, index: int) -> None:
+        if 0 <= index < len(self.profiles):
+            self.selected_selector = self.profiles[index].get("selector", "")
+        else:
+            self.selected_selector = ""
+
+    def set_selected_profile(self, profile: str) -> None:
+        for i, p in enumerate(self.profiles):
+            if p.get("name") == profile:
+                self.profile_combo.setCurrentIndex(i)
+                self.selected_selector = p.get("selector", "")
+                return
+        self.profile_combo.setCurrentIndex(-1)
+        self.selected_selector = ""
+
+    def refresh_profiles(self) -> None:
+        self.profiles = pm.load_profiles()
+        current = self.profile_combo.currentText()
+        self.profile_combo.clear()
+        for p in self.profiles:
+            self.profile_combo.addItem(p.get("name", ""))
+        # restore previous selection if possible
+        if current:
+            self.set_selected_profile(current)
+        else:
+            self._on_profile_changed(self.profile_combo.currentIndex())
+
+    @Slot()
+    def _choose_folder(self) -> None:
+        path = QFileDialog.getExistingDirectory(self, "Choisir un dossier")
+        if path:
+            self.folder_edit.setText(path)
+
+    @Slot()
+    def _choose_file(self) -> None:
+        path, _ = QFileDialog.getOpenFileName(
+            self,
+            "Choisir un fichier",
+            "",
+            "Text Files (*.txt);;All Files (*)",
+        )
+        if path:
+            self.file_edit.setText(path)
+
+    @Slot()
+    def _copy_console(self) -> None:
+        """Copy the console's contents to the clipboard."""
+        text = self.console.toPlainText()
+        QApplication.clipboard().setText(text, mode=QClipboard.Clipboard)
+        # Also populate the selection clipboard on platforms that support it.
+        QApplication.clipboard().setText(text, mode=QClipboard.Selection)
+
+    @Slot()
+    def _export_excel(self) -> None:
+        """Export scraped variant data to an Excel file."""
+        if not self.export_data:
+            QMessageBox.information(self, "Export", "Aucune donnée à exporter.")
+            return
+
+        path, _ = QFileDialog.getSaveFileName(
+            self,
+            "Enregistrer sous",
+            "",
+            "Excel Files (*.xlsx)",
+        )
+        if not path:
+            return
+
+        try:
+            from openpyxl import Workbook
+
+            wb = Workbook()
+            ws = wb.active
+            ws.append(["URL", "Variante", "Image"])
+            for row in self.export_data:
+                ws.append([row["URL"], row["Variant"], row["Image"]])
+            wb.save(path)
+        except Exception as exc:
+            QMessageBox.critical(self, "Export", f"Erreur: {exc}")
+            return
+
+        QMessageBox.information(self, "Export", "Export termin\u00e9.")
+
+    @Slot()
+    def _start(self) -> None:
+        file_path = self.file_edit.text().strip()
+        selector = self.selected_selector.strip()
+        folder = self.folder_edit.text().strip() or "images"
+        if not file_path or not selector:
+            self.console.append("❌ Fichier ou sélecteur manquant")
+            return
+
+        path = Path(file_path)
+        if not path.is_file():
+            self.console.append("❌ Fichier introuvable")
+            return
+
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                urls = [line.strip() for line in f if line.strip()]
+        except Exception as exc:
+            self.console.append(f"❌ Erreur à la lecture du fichier: {exc}")
+            return
+
+        if not urls:
+            self.console.append("❌ Aucun URL dans le fichier")
+            return
+
+        self.start_btn.setEnabled(False)
+        self.console.clear()
+        self.progress_bar.show()
+        self.progress_bar.setRange(0, 0)
+        stream = _ConsoleStream(self.console)
+        old_stdout = sys.stdout
+        sys.stdout = stream
+        self.export_data = []
+        try:
+            for url in urls:
+                try:
+                    if self.variants_checkbox.isChecked():
+                        total, driver = scrape_images(
+                            url, selector, folder, keep_driver=True
+                        )
+                        try:
+                            product_name = driver.find_element(By.TAG_NAME, "h1").text.strip()
+                        except Exception:
+                            product_name = ""
+                        variants = scrape_variants(driver)
+                        if self.storage_widget:
+                            self.storage_widget.add_product(product_name, list(variants.keys()))
+                        driver.quit()
+                    else:
+                        total = scrape_images(url, selector, folder)
+                        variants = {}
+                except Exception as exc:
+                    self.console.append(f"❌ Erreur sur {url}: {exc}")
+                else:
+                    self.console.append(f"✅ {url} - {total} images")
+                    for name, img in variants.items():
+                        self.console.append(f"  • {name}: {img}")
+                        self.export_data.append({"URL": url, "Variant": name, "Image": img})
+                    history.log_scrape(url, self.profile_combo.currentText(), total, folder)
+        finally:
+            sys.stdout = old_stdout
+            self.progress_bar.hide()
+            self.start_btn.setEnabled(True)
+
+
+
+```
+
+# MOTEUR/scraping/widgets/profile_widget.py
+Description: Source code for MOTEUR/scraping/widgets/profile_widget.py
+```python
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QListWidget,
+    QLineEdit,
+    QPushButton,
+    QLabel,
+)
+from PySide6.QtCore import Signal, Slot, QTimer
+
+from .. import profile_manager as pm
+from ..bus.event_bus import bus
+
+
+class ProfileWidget(QWidget):
+    """Widget to manage scraping profiles."""
+
+    profile_chosen = Signal(str)
+    profiles_updated = Signal()
+
+    def __init__(self) -> None:
+        super().__init__()
+
+        self.profile_list = QListWidget()
+        self.profile_list.itemSelectionChanged.connect(self._on_profile_selected)
+
+        self.name_edit = QLineEdit()
+        self.selector_edit = QLineEdit()
+        self.selector_edit.setText(
+            ".woocommerce-product-gallery__image a"
+        )
+
+        self.add_btn = QPushButton("Ajouter")
+        self.add_btn.clicked.connect(self._add_profile)
+        self.update_btn = QPushButton("Modifier")
+        self.update_btn.clicked.connect(self._update_profile)
+        self.delete_btn = QPushButton("Supprimer")
+        self.delete_btn.clicked.connect(self._delete_profile)
+
+        form_layout = QVBoxLayout()
+        form_layout.addWidget(QLabel("Nom:"))
+        form_layout.addWidget(self.name_edit)
+        form_layout.addWidget(QLabel("Sélecteur CSS:"))
+        form_layout.addWidget(self.selector_edit)
+
+        btn_layout = QHBoxLayout()
+        btn_layout.addWidget(self.add_btn)
+        btn_layout.addWidget(self.update_btn)
+        btn_layout.addWidget(self.delete_btn)
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("Profils existants:"))
+        layout.addWidget(self.profile_list)
+        layout.addLayout(form_layout)
+        layout.addLayout(btn_layout)
+
+        self._load_profiles()
+
+        # watch for external profile changes
+        bus.profiles_changed.connect(self._load_profiles)
+
+        self._mtime = pm.PROFILES_FILE.stat().st_mtime if pm.PROFILES_FILE.exists() else 0
+        self._timer = QTimer(self)
+        self._timer.setInterval(2500)
+        self._timer.timeout.connect(self._check_profiles_file)
+        self._timer.start()
+
+    # ------------------------------------------------------------------
+    def _load_profiles(self) -> None:
+        """Load profiles from :mod:`profile_manager` and populate the list."""
+        self.profiles = pm.load_profiles()
+        self._refresh_list()
+
+    def _refresh_list(self) -> None:
+        self.profile_list.clear()
+        for profile in self.profiles:
+            self.profile_list.addItem(profile.get("name", ""))
+
+    @Slot()
+    def _on_profile_selected(self) -> None:
+        current = self.profile_list.currentRow()
+        if current < 0 or current >= len(self.profiles):
+            return
+        profile = self.profiles[current]
+        self.name_edit.setText(profile.get("name", ""))
+        self.selector_edit.setText(profile.get("selector", ""))
+        self.profile_chosen.emit(profile.get("name", ""))
+
+    @Slot()
+    def _add_profile(self) -> None:
+        name = self.name_edit.text().strip()
+        selector = self.selector_edit.text().strip()
+        if not name or not selector:
+            return
+        try:
+            pm.add_profile(name, selector)
+        except ValueError:
+            return
+        self._load_profiles()
+        self.profiles_updated.emit()
+
+    @Slot()
+    def _update_profile(self) -> None:
+        name = self.name_edit.text().strip()
+        selector = self.selector_edit.text().strip()
+        if not name or not selector:
+            return
+        if pm.update_profile(name, selector):
+            self._load_profiles()
+
+    @Slot()
+    def _delete_profile(self) -> None:
+        current = self.profile_list.currentRow()
+        if current < 0 or current >= len(self.profiles):
+            return
+        name = self.profiles[current].get("name", "")
+        if pm.delete_profile(name):
+            self._load_profiles()
+            self.profiles_updated.emit()
+
+    # ------------------------------------------------------------------
+    def _check_profiles_file(self) -> None:
+        p = pm.PROFILES_FILE
+        try:
+            m = p.stat().st_mtime
+            if m != self._mtime:
+                self._mtime = m
+                self._load_profiles()
+        except Exception:
+            pass
+
+
+```
+
+# MOTEUR/scraping/widgets/scrap_widget.py
+Description: Source code for MOTEUR/scraping/widgets/scrap_widget.py
+```python
+from PySide6.QtWidgets import QWidget, QVBoxLayout, QTabWidget
+
+from MOTEUR.ui.theme import load_theme, apply_theme
+from MOTEUR.ui.settings_widget import SettingsWidget
+
+from .image_widget import ImageScraperWidget
+from .history_widget import HistoryWidget
+from .woocommerce_widget import WooCommerceProductWidget
+from .storage_widget import StorageWidget
+from .flask_server_widget import FlaskServerWidget
+
+
+class ScrapWidget(QWidget):
+    def __init__(self) -> None:
+        super().__init__()
+        apply_theme(load_theme())
+        self.modules_order = [
+            "images",
+            "flask",
+            "history",
+            "woocommerce",
+            "stockage",
+        ]
+        self.storage_widget = StorageWidget()
+        self.images_widget = ImageScraperWidget(storage_widget=self.storage_widget)
+        self.flask_widget = FlaskServerWidget()
+        self.history_widget = HistoryWidget()
+        self.woocommerce_widget = WooCommerceProductWidget(
+            storage_widget=self.storage_widget
+        )
+        self.tabs = QTabWidget()
+        self.tabs.addTab(self.images_widget, "Images")
+        self.tabs.addTab(self.flask_widget, "Serveur Flask")
+        self.tabs.addTab(self.history_widget, "Historique")
+        self.tabs.addTab(self.woocommerce_widget, "Fiche Produit WooCommerce")
+        self.tabs.addTab(self.storage_widget, "Stockage")
+        self.settings_widget = SettingsWidget()
+        self.tabs.addTab(self.settings_widget, "Paramètres")
+        layout = QVBoxLayout(self)
+        layout.addWidget(self.tabs)
+
+    def toggle_module(self, name: str, enabled: bool) -> None:
+        pass
+
+    def set_rename(self, enabled: bool) -> None:
+        pass
+
+
+```
+
+# MOTEUR/scraping/widgets/settings_widget.py
+Description: Source code for MOTEUR/scraping/widgets/settings_widget.py
+```python
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QPushButton,
+    QMessageBox,
+    QTextEdit,
+)
+from PySide6.QtCore import Signal, Slot, QCoreApplication, QProcess
+from pathlib import Path
+
+
+class ScrapingSettingsWidget(QWidget):
+    module_toggled = Signal(str, bool)
+    rename_toggled = Signal(bool)
+
+    def __init__(self, modules_order=None, *, show_maintenance: bool = False):
+        super().__init__()
+        from ..utils.restart import relaunch_current_process
+        from ..utils.update import PROJECT_ROOT
+
+        layout = QVBoxLayout(self)
+        # (conserver vos éléments existants ici)
+        _ = (modules_order or [])
+
+        self._project_root = PROJECT_ROOT
+        self._relaunch_current_process = relaunch_current_process
+
+        if show_maintenance:
+            self._build_maintenance_ui(layout)
+
+    # ------------------------------------------------------------------
+    def _build_maintenance_ui(self, layout: QVBoxLayout) -> None:
+        row = QHBoxLayout()
+        self.update_btn = QPushButton("Mettre à jour")
+        self.update_btn.setObjectName("btn_update")
+        self.restart_btn = QPushButton("Redémarrer")
+        self.restart_btn.setObjectName("btn_restart")
+        row.addWidget(self.update_btn)
+        row.addWidget(self.restart_btn)
+        layout.addLayout(row)
+
+        # Simple log output
+        self.log_edit = QTextEdit()
+        self.log_edit.setReadOnly(True)
+        layout.addWidget(self.log_edit)
+
+        # Prepare git QProcess
+        self._git_proc = QProcess(self)
+        self._git_proc.readyReadStandardOutput.connect(
+            lambda: self._append_log(
+                bytes(self._git_proc.readAllStandardOutput()).decode("utf-8", "ignore")
+            )
+        )
+        self._git_proc.readyReadStandardError.connect(
+            lambda: self._append_log(
+                bytes(self._git_proc.readAllStandardError()).decode("utf-8", "ignore")
+            )
+        )
+        self._git_proc.finished.connect(self._on_git_finished)
+
+        self.update_btn.clicked.connect(self._on_update_clicked)
+        self.restart_btn.clicked.connect(self._on_restart_clicked)
+
+    # ------------------------------------------------------------------
+    def _append_log(self, text: str) -> None:
+        if hasattr(self, "log_edit") and self.log_edit is not None:
+            txt = text.strip()
+            if txt:
+                self.log_edit.append(txt)
+
+    # ------------------------------------------------------------------
+    @Slot()
+    def _on_update_clicked(self) -> None:
+        root = Path(self._project_root)
+        if not (root / ".git").exists():
+            QMessageBox.critical(
+                self, "Mettre à jour", f"Aucun dépôt Git détecté dans :\n{root}"
+            )
+            return
+
+        self.update_btn.setEnabled(False)
+        self.update_btn.setText("Mise à jour en cours…")
+        self._append_log(f"> git pull origin main (cwd={root})")
+        self._git_proc.setWorkingDirectory(str(root))
+        self._git_proc.start("git", ["pull", "origin", "main"])
+
+        if not self._git_proc.waitForStarted(2000):
+            self.update_btn.setEnabled(True)
+            self.update_btn.setText("Mettre à jour")
+            QMessageBox.critical(
+                self,
+                "Mettre à jour",
+                "Impossible de démarrer Git. Est-il installé et dans le PATH ?",
+            )
+
+    # ------------------------------------------------------------------
+    def _on_git_finished(self, code: int, status) -> None:
+        self.update_btn.setEnabled(True)
+        self.update_btn.setText("Mettre à jour")
+        if code == 0:
+            QMessageBox.information(self, "Mettre à jour", "Mise à jour réussie.")
+        else:
+            QMessageBox.critical(
+                self,
+                "Mettre à jour",
+                f"Échec du 'git pull' (code {code}). Consulte les logs.",
+            )
+
+    # ------------------------------------------------------------------
+    @Slot()
+    def _on_restart_clicked(self) -> None:
+        ret = QMessageBox.question(
+            self,
+            "Redémarrer",
+            "Voulez-vous vraiment redémarrer l’application ?",
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
+        )
+        if ret != QMessageBox.Yes:
+            return
+        self._relaunch_current_process(delay_sec=0.3)
+        QCoreApplication.quit()
+
+```
+
+# MOTEUR/scraping/widgets/storage_widget.py
+Description: Source code for MOTEUR/scraping/widgets/storage_widget.py
+```python
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+)
+from PySide6.QtCore import Slot
+
+
+class StorageWidget(QWidget):
+    """Simple table to store scraped product names and variants."""
+
+    HEADERS = ["Nom du produit", "Variantes"]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.table = QTableWidget(0, len(self.HEADERS))
+        self.table.setHorizontalHeaderLabels(self.HEADERS)
+
+        self.clear_btn = QPushButton("Vider le stockage")
+        self.clear_btn.clicked.connect(self.clear)
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(self.table)
+        layout.addWidget(self.clear_btn)
+
+    # ------------------------------------------------------------------
+    def add_product(self, name: str, variants: list[str]) -> None:
+        row = self.table.rowCount()
+        self.table.insertRow(row)
+        self.table.setItem(row, 0, QTableWidgetItem(name))
+        self.table.setItem(row, 1, QTableWidgetItem(", ".join(variants)))
+
+    def get_products(self) -> list[dict[str, list[str]]]:
+        products: list[dict[str, list[str]]] = []
+        for row in range(self.table.rowCount()):
+            name_item = self.table.item(row, 0)
+            variants_item = self.table.item(row, 1)
+            name = name_item.text() if name_item else ""
+            variants_text = variants_item.text() if variants_item else ""
+            variants = [v.strip() for v in variants_text.split(",") if v.strip()]
+            products.append({"name": name, "variants": variants})
+        return products
+
+    @Slot()
+    def clear(self) -> None:
+        self.table.setRowCount(0)
+
+```
+
+# MOTEUR/scraping/widgets/woocommerce_widget.py
+Description: Source code for MOTEUR/scraping/widgets/woocommerce_widget.py
+```python
+from __future__ import annotations
+
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QFileDialog,
+    QAbstractItemView,
+    QCheckBox,
+)
+from PySide6.QtCore import Slot
+import csv
+import random
+import string
+import re
+import unicodedata
+from pathlib import Path
+import requests
+
+
+class WooCommerceProductWidget(QWidget):
+    """Widget to edit WooCommerce product data in a table."""
+
+    HEADERS = [
+        "ID",
+        "Type",
+        "SKU",
+        "Name",
+        "Published",
+        "Short description",
+        "Description",
+        "Regular price",
+        "Sale price",
+        "Categories",
+        "Tags",
+        "Images",
+        "In stock?",
+        "Stock",
+        "Tax status",
+        "Shipping class",
+        "Attribute 1 name",
+        "Attribute 1 value(s)",
+        "Attribute 1 visible",
+        "Attribute 1 global",
+    ]
+
+    # Folder containing downloaded product images. Tests monkeypatch this path.
+    IMAGES_ROOT = Path("images")
+
+    # Base URL for uploaded WooCommerce images.
+    BASE_IMAGE_URL = "https://www.planetebob.fr/wp-content/uploads/2025/07/"
+
+    @staticmethod
+    def _slugify(text: str) -> str:
+        text = unicodedata.normalize("NFKD", text)
+        text = text.encode("ascii", "ignore").decode("ascii")
+        text = re.sub(r"[^a-zA-Z0-9\s-]", "", text)
+        text = re.sub(r"[\s_-]+", "-", text).strip("-")
+        return text.lower()
+
+    @staticmethod
+    def _clean_image_urls(urls: list[str]) -> list[str]:
+        """Remove duplicate image URLs using exact and prefix based checks."""
+        unique_urls: list[str] = []
+        for url in urls:
+            if url not in unique_urls:
+                unique_urls.append(url)
+
+        prefix_set: set[str] = set()
+        final_images: list[str] = []
+
+        for url in unique_urls:
+            filename = url.split("/")[-1]
+            base = filename.rsplit(".", 1)[0]
+            prefix = base.split("_")[0].split("-56cm")[0]
+
+            if prefix not in prefix_set:
+                final_images.append(url)
+                prefix_set.add(prefix)
+
+        return final_images
+
+    def __init__(self, *, storage_widget=None) -> None:
+        super().__init__()
+        self.storage_widget = storage_widget
+        self.table = QTableWidget(0, len(self.HEADERS))
+        self.table.setHorizontalHeaderLabels(self.HEADERS)
+        self.table.setSelectionBehavior(QAbstractItemView.SelectRows)
+
+        add_btn = QPushButton("Ajouter une ligne")
+        del_btn = QPushButton("Supprimer la ligne sélectionnée")
+        fill_btn = QPushButton("Remplir")
+        check_btn = QPushButton("Vérifier URLs")
+        import_btn = QPushButton("Importer CSV")
+        export_btn = QPushButton("Exporter CSV")
+
+        add_btn.clicked.connect(self.add_row)
+        del_btn.clicked.connect(self.delete_selected_row)
+        fill_btn.clicked.connect(self.fill_from_storage)
+        check_btn.clicked.connect(self.check_urls)
+        import_btn.clicked.connect(self.import_csv)
+        export_btn.clicked.connect(self.export_csv)
+
+        btn_layout = QHBoxLayout()
+        btn_layout.addWidget(add_btn)
+        btn_layout.addWidget(del_btn)
+        btn_layout.addWidget(fill_btn)
+        btn_layout.addWidget(check_btn)
+        btn_layout.addStretch()
+        btn_layout.addWidget(import_btn)
+        btn_layout.addWidget(export_btn)
+
+        self.clean_images_checkbox = QCheckBox("Nettoyer les images dupliquées")
+        self.clean_images_checkbox.setChecked(True)
+
+        layout = QVBoxLayout(self)
+        layout.addLayout(btn_layout)
+        layout.addWidget(self.clean_images_checkbox)
+        layout.addWidget(self.table)
+
+    # ------------------------------------------------------------------
+    @Slot()
+    def add_row(self) -> None:
+        row = self.table.rowCount()
+        self.table.insertRow(row)
+        for col in range(self.table.columnCount()):
+            self.table.setItem(row, col, QTableWidgetItem(""))
+
+    @Slot()
+    def delete_selected_row(self) -> None:
+        row = self.table.currentRow()
+        if row >= 0:
+            self.table.removeRow(row)
+
+    @Slot()
+    def import_csv(self) -> None:
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Importer CSV", "", "CSV Files (*.csv);;All Files (*)"
+        )
+        if not path:
+            return
+        try:
+            with open(path, newline="", encoding="utf-8") as f:
+                reader = csv.reader(f, delimiter="\t")
+                rows = list(reader)
+        except Exception:
+            return
+        if not rows:
+            return
+        start = 1 if rows[0][: len(self.HEADERS)] == self.HEADERS else 0
+        for data in rows[start:]:
+            row = self.table.rowCount()
+            self.table.insertRow(row)
+            for col in range(len(self.HEADERS)):
+                value = data[col] if col < len(data) else ""
+                self.table.setItem(row, col, QTableWidgetItem(value))
+
+    @Slot()
+    def export_csv(self) -> None:
+        path, _ = QFileDialog.getSaveFileName(
+            self, "Exporter CSV", "", "CSV Files (*.csv);;All Files (*)"
+        )
+        if not path:
+            return
+        with open(path, "w", newline="", encoding="utf-8") as f:
+            writer = csv.writer(f, delimiter=";")
+            writer.writerow(self.HEADERS)
+            for row in range(self.table.rowCount()):
+                data = []
+                for col in range(self.table.columnCount()):
+                    item = self.table.item(row, col)
+                    data.append(item.text() if item else "")
+                writer.writerow(data)
+
+    @Slot()
+    def check_urls(self) -> None:
+        """Check that image URLs in the table are reachable and export a CSV."""
+        path, _ = QFileDialog.getSaveFileName(
+            self, "Exporter résultat", "", "CSV Files (*.csv);;All Files (*)"
+        )
+        if not path:
+            return
+
+        img_col = self.HEADERS.index("Images")
+        urls: list[str] = []
+        for row in range(self.table.rowCount()):
+            item = self.table.item(row, img_col)
+            if not item:
+                continue
+            urls.extend(u.strip() for u in item.text().split(", ") if u.strip())
+
+        results: list[tuple[str, str]] = []
+        for url in urls:
+            try:
+                resp = requests.head(url, timeout=5)
+                ok = resp.status_code == 200
+            except Exception:
+                ok = False
+            results.append((url, "oui" if ok else "non"))
+
+        with open(path, "w", newline="", encoding="utf-8") as f:
+            writer = csv.writer(f, delimiter=";")
+            writer.writerow(["URL", "OK"])
+            writer.writerows(results)
+
+    # ------------------------------------------------------------------
+    @Slot()
+    def fill_from_storage(self) -> None:
+        """Create new rows from the linked storage widget."""
+        if not self.storage_widget:
+            return
+        products = self.storage_widget.get_products()
+        # Clear any previously populated rows before filling again so
+        # repeated calls don't accumulate duplicates.
+        self.table.setRowCount(0)
+        type_col = self.HEADERS.index("Type")
+        sku_col = self.HEADERS.index("SKU")
+        name_col = self.HEADERS.index("Name")
+        img_col = self.HEADERS.index("Images")
+
+        used_skus: set[str] = set()
+
+        def _gen_sku() -> str:
+            """Generate a unique random SKU."""
+            while True:
+                sku = "SKU-" + "".join(
+                    random.choices(string.ascii_uppercase + string.digits, k=8)
+                )
+                if sku not in used_skus:
+                    used_skus.add(sku)
+                    return sku
+
+        for prod in products:
+            product_name = prod["name"]
+            variants = prod["variants"]
+            product_slug = self._slugify(product_name)
+            folder = self.IMAGES_ROOT / product_name
+            local_images: list[str] = []
+            if folder.is_dir():
+                for p in sorted(folder.iterdir()):
+                    if p.suffix.lower() in {".webp", ".jpg", ".jpeg", ".png"}:
+                        local_images.append(p.name)
+
+            variant_files = [
+                f"{product_slug}-{self._slugify(v)}.jpg" for v in variants
+            ]
+            generic_images = [img for img in local_images if img not in variant_files]
+
+            is_variable = len(variants) > 1
+
+            if is_variable:
+                row = self.table.rowCount()
+                self.table.insertRow(row)
+                for col in range(self.table.columnCount()):
+                    self.table.setItem(row, col, QTableWidgetItem(""))
+
+                parent_sku = _gen_sku()
+                self.table.setItem(row, type_col, QTableWidgetItem("variable"))
+                self.table.setItem(row, sku_col, QTableWidgetItem(parent_sku))
+                self.table.setItem(row, name_col, QTableWidgetItem(product_name))
+                parent_images = [
+                    self.BASE_IMAGE_URL + img for img in generic_images + variant_files
+                ]
+                if self.clean_images_checkbox.isChecked():
+                    parent_images = self._clean_image_urls(parent_images)
+                if parent_images:
+                    self.table.setItem(
+                        row,
+                        img_col,
+                        QTableWidgetItem(", ".join(parent_images)),
+                    )
+
+                current_row = row
+                for variant in variants:
+                    current_row += 1
+                    self.table.insertRow(current_row)
+                    for c in range(self.table.columnCount()):
+                        self.table.setItem(current_row, c, QTableWidgetItem(""))
+                    self.table.setItem(current_row, type_col, QTableWidgetItem("variation"))
+                    var_slug = self._slugify(variant)
+                    sku_var = f"{parent_sku}-{var_slug}"
+                    used_skus.add(sku_var)
+                    name_var = f"{product_name} {variant}"
+                    self.table.setItem(current_row, sku_col, QTableWidgetItem(sku_var))
+                    self.table.setItem(current_row, name_col, QTableWidgetItem(name_var))
+                    var_img = self.BASE_IMAGE_URL + f"{product_slug}-{var_slug}.jpg"
+                    self.table.setItem(current_row, img_col, QTableWidgetItem(var_img))
+            else:
+                row = self.table.rowCount()
+                self.table.insertRow(row)
+                for col in range(self.table.columnCount()):
+                    self.table.setItem(row, col, QTableWidgetItem(""))
+
+                sku_val = _gen_sku()
+                self.table.setItem(row, type_col, QTableWidgetItem("simple"))
+                self.table.setItem(row, sku_col, QTableWidgetItem(sku_val))
+                self.table.setItem(row, name_col, QTableWidgetItem(product_name))
+                images = [self.BASE_IMAGE_URL + img for img in generic_images + variant_files]
+                if self.clean_images_checkbox.isChecked():
+                    images = self._clean_image_urls(images)
+                if images:
+                    self.table.setItem(
+                        row,
+                        img_col,
+                        QTableWidgetItem(", ".join(images)),
+                    )
+
+
+
+```
+
+# MOTEUR/ui/settings_widget.py
+Description: Source code for MOTEUR/ui/settings_widget.py
+```python
+from __future__ import annotations
+
+from pathlib import Path
+
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QRadioButton,
+    QPushButton,
+    QTextEdit,
+    QMessageBox,
+)
+from PySide6.QtCore import Slot, QProcess, QCoreApplication
+
+from .theme import load_theme, save_theme, apply_theme
+from MOTEUR.scraping.utils.restart import relaunch_current_process
+from MOTEUR.scraping.utils.update import PROJECT_ROOT
+
+
+class SettingsWidget(QWidget):
+    """General application settings."""
+
+    def __init__(self) -> None:
+        super().__init__()
+
+        self.light_radio = QRadioButton("Clair")
+        self.dark_radio = QRadioButton("Sombre")
+
+        current = load_theme()
+        (self.dark_radio if current == "dark" else self.light_radio).setChecked(True)
+
+        self.light_radio.toggled.connect(lambda _: self._apply())
+        self.dark_radio.toggled.connect(lambda _: self._apply())
+
+        self.apply_btn = QPushButton("Appliquer")
+        self.apply_btn.clicked.connect(self._apply)
+
+        radios = QHBoxLayout()
+        radios.addWidget(self.light_radio)
+        radios.addWidget(self.dark_radio)
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("Thème de l’application"))
+        layout.addLayout(radios)
+        layout.addWidget(self.apply_btn)
+        layout.addWidget(
+            QLabel("Appliqué à toute l’application. Persistant dans settings.json")
+        )
+
+        self._build_maintenance_ui(layout)
+
+    @Slot()
+    def _apply(self) -> None:
+        name = "dark" if self.dark_radio.isChecked() else "light"
+        apply_theme(name)
+        save_theme(name)
+
+    # ------------------------------------------------------------------
+    def _build_maintenance_ui(self, layout: QVBoxLayout) -> None:
+        row = QHBoxLayout()
+        self.update_btn = QPushButton("Mettre à jour")
+        self.update_btn.setObjectName("btn_update")
+        self.restart_btn = QPushButton("Redémarrer")
+        self.restart_btn.setObjectName("btn_restart")
+        row.addWidget(self.update_btn)
+        row.addWidget(self.restart_btn)
+        layout.addLayout(row)
+
+        self.log_edit = QTextEdit()
+        self.log_edit.setReadOnly(True)
+        layout.addWidget(self.log_edit)
+
+        self._git_proc = QProcess(self)
+        self._git_proc.readyReadStandardOutput.connect(
+            lambda: self._append_log(
+                bytes(self._git_proc.readAllStandardOutput()).decode("utf-8", "ignore")
+            )
+        )
+        self._git_proc.readyReadStandardError.connect(
+            lambda: self._append_log(
+                bytes(self._git_proc.readAllStandardError()).decode("utf-8", "ignore")
+            )
+        )
+        self._git_proc.finished.connect(self._on_git_finished)
+
+        self.update_btn.clicked.connect(self._on_update_clicked)
+        self.restart_btn.clicked.connect(self._on_restart_clicked)
+
+    # ------------------------------------------------------------------
+    def _append_log(self, text: str) -> None:
+        txt = text.strip()
+        if txt:
+            self.log_edit.append(txt)
+
+    # ------------------------------------------------------------------
+    @Slot()
+    def _on_update_clicked(self) -> None:
+        root = Path(PROJECT_ROOT)
+        if not (root / ".git").exists():
+            QMessageBox.critical(
+                self, "Mettre à jour", f"Aucun dépôt Git détecté dans :\n{root}"
+            )
+            return
+
+        self.update_btn.setEnabled(False)
+        self.update_btn.setText("Mise à jour en cours…")
+        self._append_log(f"> git pull origin main (cwd={root})")
+        self._git_proc.setWorkingDirectory(str(root))
+        self._git_proc.start("git", ["pull", "origin", "main"])
+
+        if not self._git_proc.waitForStarted(2000):
+            self.update_btn.setEnabled(True)
+            self.update_btn.setText("Mettre à jour")
+            QMessageBox.critical(
+                self,
+                "Mettre à jour",
+                "Impossible de démarrer Git. Est-il installé et dans le PATH ?",
+            )
+
+    # ------------------------------------------------------------------
+    def _on_git_finished(self, code: int, status) -> None:
+        self.update_btn.setEnabled(True)
+        self.update_btn.setText("Mettre à jour")
+        if code == 0:
+            QMessageBox.information(self, "Mettre à jour", "Mise à jour réussie.")
+        else:
+            QMessageBox.critical(
+                self,
+                "Mettre à jour",
+                f"Échec du 'git pull' (code {code}). Consulte les logs.",
+            )
+
+    # ------------------------------------------------------------------
+    @Slot()
+    def _on_restart_clicked(self) -> None:
+        ret = QMessageBox.question(
+            self,
+            "Redémarrer",
+            "Voulez-vous vraiment redémarrer l’application ?",
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
+        )
+        if ret != QMessageBox.Yes:
+            return
+        relaunch_current_process(delay_sec=0.3)
+        QCoreApplication.quit()
+
+```
+
+# MOTEUR/ui/theme.py
+Description: Source code for MOTEUR/ui/theme.py
+```python
+from __future__ import annotations
+
+from pathlib import Path
+import json
+
+from PySide6.QtWidgets import QApplication
+from PySide6.QtGui import QPalette, QColor
+
+
+THEME_FILE = Path(__file__).resolve().parents[2] / "settings.json"
+
+
+def load_theme() -> str:
+    """Return the persisted theme name ("light" or "dark")."""
+    try:
+        if THEME_FILE.exists():
+            data = json.loads(THEME_FILE.read_text(encoding="utf-8") or "{}")
+            theme = (data.get("theme") or "light").lower()
+            return "dark" if theme == "dark" else "light"
+    except Exception:
+        pass
+    return "light"
+
+
+def save_theme(name: str) -> None:
+    """Persist the theme name into :data:`THEME_FILE`."""
+    name = "dark" if name.lower() == "dark" else "light"
+    THEME_FILE.write_text(
+        json.dumps({"theme": name}, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+
+def _dark_palette() -> QPalette:
+    palette = QPalette()
+    palette.setColor(QPalette.Window, QColor("#2b2b2b"))
+    palette.setColor(QPalette.WindowText, QColor("#eeeeee"))
+    palette.setColor(QPalette.Base, QColor("#3c3f41"))
+    palette.setColor(QPalette.AlternateBase, QColor("#2f3234"))
+    palette.setColor(QPalette.ToolTipBase, QColor("#2b2b2b"))
+    palette.setColor(QPalette.ToolTipText, QColor("#ffffff"))
+    palette.setColor(QPalette.Text, QColor("#eeeeee"))
+    palette.setColor(QPalette.Button, QColor("#3c3f41"))
+    palette.setColor(QPalette.ButtonText, QColor("#eeeeee"))
+    palette.setColor(QPalette.BrightText, QColor("#ff6b6b"))
+    palette.setColor(QPalette.Highlight, QColor("#4c78ff"))
+    palette.setColor(QPalette.HighlightedText, QColor("#ffffff"))
+    palette.setColor(QPalette.Link, QColor("#62a8ff"))
+    return palette
+
+
+def _light_palette() -> QPalette:
+    app = QApplication.instance()
+    if app:
+        palette = app.style().standardPalette()
+    else:
+        palette = QPalette()
+    palette.setColor(QPalette.Highlight, QColor("#3d6cff"))
+    palette.setColor(QPalette.HighlightedText, QColor("#ffffff"))
+    palette.setColor(QPalette.Link, QColor("#0b61ff"))
+    return palette
+
+
+def apply_theme(name: str) -> None:
+    """Apply the given theme to the running :class:`QApplication`."""
+    app = QApplication.instance()
+    if not app:
+        return
+    app.setStyle("Fusion")
+    if name.lower() == "dark":
+        palette = _dark_palette()
+        app.setPalette(palette)
+        app.setStyleSheet(
+            "QToolTip { color: #ffffff; background-color: #2b2b2b; border: 0px; }"
+        )
+    else:
+        palette = _light_palette()
+        app.setPalette(palette)
+        app.setStyleSheet("")
+
+```
+
+# README_flask_bridge.md
+Description: Source code for README_flask_bridge.md
+```
+# Flask Bridge
+
+Ce module ajoute un petit serveur Flask permettant de piloter le scraping à
+l'aide d'appels HTTP.  Il peut être lancé depuis l'onglet **Serveur Flask** de
+l'application.
+
+## Démarrage
+1. Lancez l'application graphique `app.py`.
+2. Rendez-vous dans l'onglet *Serveur Flask*.
+3. Choisissez un port et une clé API puis cliquez sur **Démarrer**.
+4. Optionnel : cochez *Expose via ngrok* pour obtenir une URL publique.
+
+L'API key est également lue depuis la variable d'environnement
+``SCRAPER_API_KEY``.  Pour ngrok, la variable ``NGROK_AUTHTOKEN`` est prise en
+compte si aucun jeton n'est saisi.
+
+## Test de l'API
+Une fois le serveur lancé, l'endpoint `/health` répond sans authentification.
+
+```bash
+# Exemples de commandes curl
+# curl http://localhost:5001/health
+# curl -X POST -H "Content-Type: application/json" -H "X-API-KEY: VOTRE_CLE" \
+#      -d '{"url": "https://exemple.com", "selector": "img"}' \
+#      http://localhost:5001/scrape
+# curl -H "X-API-KEY: VOTRE_CLE" http://localhost:5001/jobs/<job_id>
+# curl -X POST http://localhost:5001/actions/image-edit \\
+#      -H "X-API-KEY: VOTRE_CLE" -H "Content-Type: application/json" \\
+#      -d '{"source":{"folder":"/path/images"},"operations":[{"op":"resize","width":1024,"height":1024,"keep_ratio":true}]}'
+```
+
+Les réponses pour les autres endpoints (`/scrape`, `/jobs`, `/profiles`,
+`/history`) nécessitent le header `X-API-KEY`.
+
+```
+
+# app.py
+Description: Source code for app.py
+```python
+
+
+```
+
+# localapp/__init__.py
+Description: Source code for localapp/__init__.py
+```python
+
+```
+
+# localapp/app.py
+Description: Source code for localapp/app.py
+```python
+from pathlib import Path
+import sys
+
+# Allow running this module directly by ensuring the project root is in
+# ``sys.path``.  When executed with ``python localapp/app.py`` the Python
+# interpreter only adds the ``localapp`` directory to ``sys.path`` which
+# prevents imports from the sibling ``MOTEUR`` package.  Adding the parent
+# directory resolves ``ModuleNotFoundError`` for these local imports.
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+try:
+    from PySide6.QtWidgets import (
+        QApplication,
+        QMainWindow,
+        QWidget,
+        QVBoxLayout,
+        QHBoxLayout,
+        QPushButton,
+        QLabel,
+        QStackedWidget,
+        QSizePolicy,
+        QFrame,
+        QScrollArea,
+    )
+    from PySide6.QtCore import Qt, QPropertyAnimation, Slot, QEasingCurve
+    from PySide6.QtGui import QIcon
+except ModuleNotFoundError:
+    print("Install dependencies with pip install -r requirements.txt")
+    sys.exit(1)
+
+from MOTEUR.scraping.widgets.scrap_widget import ScrapWidget
+from MOTEUR.scraping.widgets.settings_widget import ScrapingSettingsWidget
+from MOTEUR.compta.achats.widget import AchatWidget
+from MOTEUR.compta.ventes.widget import VenteWidget
+from MOTEUR.compta.accounting.widget import AccountWidget
+from MOTEUR.scraping.widgets.profile_widget import ProfileWidget
+from MOTEUR.compta.dashboard.widget import DashboardWidget
+from MOTEUR.ui.settings_widget import SettingsWidget
+from MOTEUR.ui.theme import load_theme, apply_theme
+
+BASE_DIR = Path(__file__).resolve().parent
+
+
+class SidebarButton(QPushButton):
+    """Custom button used in the vertical sidebar."""
+
+    def __init__(self, text: str, icon_path: str | None = None) -> None:
+        super().__init__(text)
+        if icon_path:
+            self.setIcon(QIcon(icon_path))
+        self.setStyleSheet(
+            """
+            QPushButton {
+                padding: 10px;
+                border: none;
+                background-color: #f0f0f0;
+                color: #333;
+                text-align: left;
+            }
+            QPushButton:hover {
+                background-color: #d0d0d0;
+            }
+            QPushButton:checked {
+                background-color: #c0c0c0;
+                font-weight: bold;
+            }
+            """
+        )
+        self.setCheckable(True)
+        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+
+
+class CollapsibleSection(QWidget):
+    """Section with a header button that can show or hide its content."""
+
+    def __init__(
+        self,
+        title: str,
+        parent: QWidget | None = None,
+        *,
+        hide_title_when_collapsed: bool = False,
+    ) -> None:
+        super().__init__(parent)
+        self.original_title = title
+        self.hide_title_when_collapsed = hide_title_when_collapsed
+        self.toggle_button = QPushButton(title)
+        self.toggle_button.setCheckable(True)
+        self.toggle_button.setChecked(False)
+        self.toggle_button.setStyleSheet(
+            """
+            QPushButton {
+                background-color: #444;
+                color: white;
+                padding: 10px;
+                text-align: left;
+                font-weight: bold;
+            }
+            QPushButton:checked {
+                background-color: #666;
+            }
+            """
+        )
+
+        self.content_area = QWidget()
+        self.content_area.setMaximumHeight(0)
+        self.content_area.setSizePolicy(
+            QSizePolicy.Expanding,
+            QSizePolicy.Fixed,
+        )
+
+        self.toggle_animation = QPropertyAnimation(
+            self.content_area,
+            b"maximumHeight",
+        )
+        self.toggle_animation.setDuration(300)
+        self.toggle_animation.setEasingCurve(QEasingCurve.InOutCubic)
+        self.toggle_animation.setStartValue(0)
+        self.toggle_animation.setEndValue(0)
+
+        self.toggle_button.clicked.connect(self.toggle)
+        if (
+            self.hide_title_when_collapsed
+            and not self.toggle_button.isChecked()
+        ):
+            self.toggle_button.setText("")
+
+        main_layout = QVBoxLayout(self)
+        main_layout.setContentsMargins(0, 0, 0, 0)
+        main_layout.addWidget(self.toggle_button)
+        main_layout.addWidget(self.content_area)
+
+        self.inner_layout = QVBoxLayout()
+        self.inner_layout.setContentsMargins(0, 0, 0, 0)
+        self.inner_layout.setSpacing(0)
+        self.content_area.setLayout(self.inner_layout)
+
+    def toggle(self) -> None:
+        checked = self.toggle_button.isChecked()
+        total_height = self.content_area.sizeHint().height()
+        self.toggle_animation.setDirection(
+            QPropertyAnimation.Forward
+            if checked
+            else QPropertyAnimation.Backward
+        )
+        self.toggle_animation.setEndValue(total_height if checked else 0)
+        self.toggle_animation.start()
+        if self.hide_title_when_collapsed:
+            self.toggle_button.setText(self.original_title if checked else "")
+
+    def collapse(self) -> None:
+        if self.toggle_button.isChecked():
+            self.toggle_button.setChecked(False)
+            self.toggle()
+
+    def expand(self) -> None:
+        if not self.toggle_button.isChecked():
+            self.toggle_button.setChecked(True)
+            self.toggle()
+
+    def add_widget(self, widget: QWidget) -> None:
+        self.inner_layout.addWidget(widget)
+
+
+class MainWindow(QMainWindow):
+    """Main application window with a sidebar and central stack."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle("COMPTA - Interface de gestion comptable")
+        self.setMinimumSize(1200, 700)
+
+        central_widget = QWidget()
+        self.setCentralWidget(central_widget)
+
+        main_layout = QHBoxLayout(central_widget)
+        main_layout.setContentsMargins(0, 0, 0, 0)
+
+        sidebar_container = QWidget()
+        sidebar_layout = QVBoxLayout(sidebar_container)
+        sidebar_layout.setContentsMargins(0, 0, 0, 0)
+        sidebar_layout.setSpacing(0)
+
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll_content = QWidget()
+        nav_layout = QVBoxLayout(scroll_content)
+        nav_layout.setContentsMargins(0, 0, 0, 0)
+        nav_layout.setSpacing(0)
+        scroll.setWidget(scroll_content)
+
+        sidebar_container.setStyleSheet("background-color: #ffffff;")
+        scroll_content.setStyleSheet("background-color: #ffffff;")
+
+        self.button_group: list[SidebarButton] = []
+        self.compta_buttons: dict[str, SidebarButton] = {}
+
+        self.compta_section = CollapsibleSection(
+            "\ud83d\udcc1 Comptabilit\u00e9", hide_title_when_collapsed=False
+        )
+        compta_icons = {
+            "Tableau de bord": BASE_DIR / "icons" / "dashboard.svg",
+            "Journal": BASE_DIR / "icons" / "journal.svg",
+            "Grand Livre": BASE_DIR / "icons" / "grand_livre.svg",
+            "Bilan": BASE_DIR / "icons" / "bilan.svg",
+            "Résultat": BASE_DIR / "icons" / "resultat.svg",
+            "Comptes": BASE_DIR / "icons" / "journal.svg",
+            "Révision": BASE_DIR / "icons" / "bilan.svg",
+            "Paramètres": BASE_DIR / "icons" / "settings.svg",
+            "Achat": BASE_DIR / "icons" / "achat.svg",
+            "Fournisseurs": BASE_DIR / "icons" / "achat.svg",
+            "Ventes": BASE_DIR / "icons" / "ventes.svg",
+        }
+        for name in compta_icons:
+            btn = SidebarButton(name, icon_path=str(compta_icons[name]))
+            self.compta_buttons[name] = btn
+            if name == "Tableau de bord":
+                self.dashboard_btn = btn
+                btn.clicked.connect(
+                    lambda _, b=btn: self.show_dashboard_page(b)
+                )
+            elif name == "Achat":
+                self.achat_btn = btn
+                btn.clicked.connect(
+                    lambda _, b=btn: self.show_achat_page(b)
+                )
+            elif name == "Fournisseurs":
+                self.suppliers_btn = btn
+                btn.clicked.connect(
+                    lambda _, b=btn: self.show_suppliers_page(b)
+                )
+            elif name == "Comptes":
+                self.accounts_btn = btn
+                btn.clicked.connect(
+                    lambda _, b=btn: self.show_accounts_page(b)
+                )
+            elif name == "Révision":
+                self.revision_btn = btn
+                btn.clicked.connect(
+                    lambda _, b=btn: self.show_revision_page(b)
+                )
+            elif name == "Paramètres":
+                self.param_journals_btn = btn
+                btn.clicked.connect(
+                    lambda _, b=btn: self.show_journals_page(b)
+                )
+            elif name == "Ventes":
+                self.ventes_btn = btn
+                btn.clicked.connect(
+                    lambda _, b=btn: self.show_ventes_page(b)
+                )
+            else:
+                btn.clicked.connect(
+                    lambda _, n=name, b=btn: self.display_content(
+                        f"Comptabilité : {n}", b
+                    )
+                )
+            self.compta_section.add_widget(btn)
+            self.button_group.append(btn)
+        nav_layout.addWidget(self.compta_section)
+
+        self.scrap_section = CollapsibleSection("\ud83d\udee0 Scraping")
+
+        self.profiles_btn = SidebarButton(
+            "Profil Scraping",
+            icon_path=str(BASE_DIR / "icons" / "profile.svg"),
+        )
+        self.profiles_btn.clicked.connect(
+            lambda _, b=self.profiles_btn: self.show_profiles(b)
+        )
+        self.scrap_section.add_widget(self.profiles_btn)
+        self.button_group.append(self.profiles_btn)
+
+        self.scrap_btn = SidebarButton(
+            "Scrap",
+            icon_path=str(BASE_DIR / "icons" / "scraping.svg"),
+        )
+        self.scrap_btn.clicked.connect(
+            lambda _, b=self.scrap_btn: self.show_scrap_page(b)
+        )
+        self.scrap_section.add_widget(self.scrap_btn)
+        self.button_group.append(self.scrap_btn)
+
+        btn = SidebarButton(
+            "Scraping Descriptions",
+            icon_path=str(BASE_DIR / "icons" / "text.svg"),
+        )
+        btn.clicked.connect(
+            lambda _, b=btn: self.display_content("Scraping : Descriptions", b)
+        )
+        self.scrap_section.add_widget(btn)
+        self.button_group.append(btn)
+
+        self.scrap_settings_btn = SidebarButton(
+            "Paramètres Scraping",
+            icon_path=str(BASE_DIR / "icons" / "settings.svg"),
+        )
+        self.scrap_settings_btn.clicked.connect(
+            lambda _, b=self.scrap_settings_btn: self.show_scraping_settings_page(b)
+        )
+        self.scrap_section.add_widget(self.scrap_settings_btn)
+        self.button_group.append(self.scrap_settings_btn)
+        nav_layout.addWidget(self.scrap_section)
+
+        # Collapse the other section when one is expanded
+        self.compta_section.toggle_button.clicked.connect(
+            lambda: self._collapse_other(self.compta_section)
+        )
+        self.scrap_section.toggle_button.clicked.connect(
+            lambda: self._collapse_other(self.scrap_section)
+        )
+
+        nav_layout.addStretch()
+
+        sidebar_layout.addWidget(scroll)
+
+        line = QFrame()
+        line.setFrameShape(QFrame.HLine)
+        line.setStyleSheet("margin:5px 0;")
+        sidebar_layout.addWidget(line)
+
+        self.settings_btn = SidebarButton(
+            "\u2699\ufe0f Paramètres",
+            icon_path=str(BASE_DIR / "icons" / "settings.svg"),
+        )
+        self.settings_btn.clicked.connect(self.show_settings)
+        sidebar_layout.addWidget(self.settings_btn)
+        self.button_group.append(self.settings_btn)
+
+        self.stack = QStackedWidget()
+        self.stack.addWidget(
+            QLabel("Bienvenue sur COMPTA", alignment=Qt.AlignCenter)
+        )
+
+        self.profile_page = ProfileWidget()
+        self.stack.addWidget(self.profile_page)
+
+        self.scrap_page = ScrapWidget()
+        self.stack.addWidget(self.scrap_page)
+
+        self.scraping_settings_page = ScrapingSettingsWidget(
+            self.scrap_page.modules_order,
+            show_maintenance=False,
+        )
+        self.scraping_settings_page.module_toggled.connect(
+            self.scrap_page.toggle_module
+        )
+        self.scraping_settings_page.rename_toggled.connect(
+            self.scrap_page.set_rename
+        )
+        self.stack.addWidget(self.scraping_settings_page)
+
+        self.profile_page.profile_chosen.connect(
+            self.scrap_page.images_widget.set_selected_profile
+        )
+        self.profile_page.profiles_updated.connect(
+            self.scrap_page.images_widget.refresh_profiles
+        )
+
+        self.dashboard_page = DashboardWidget()
+        self.dashboard_page.journal_requested.connect(
+            lambda: self.open_from_dashboard("Journal")
+        )
+        self.dashboard_page.grand_livre_requested.connect(
+            lambda: self.open_from_dashboard("Grand Livre")
+        )
+        self.dashboard_page.scraping_summary_requested.connect(
+            lambda: self.show_scrap_page(self.scrap_btn)
+        )
+        self.stack.addWidget(self.dashboard_page)
+
+        self.achat_page = AchatWidget()
+        self.stack.addWidget(self.achat_page)
+
+        from MOTEUR.compta.suppliers import SupplierTab
+
+        self.suppliers_page = SupplierTab()
+        self.stack.addWidget(self.suppliers_page)
+
+        self.accounts_page = AccountWidget()
+        self.accounts_page.accounts_updated.connect(
+            self.achat_page.refresh_accounts
+        )
+        self.stack.addWidget(self.accounts_page)
+
+        from MOTEUR.compta.parameters import JournalsWidget
+
+        self.journals_page = JournalsWidget()
+        self.stack.addWidget(self.journals_page)
+
+        from MOTEUR.compta.revision import RevisionTab
+
+        self.revision_page = RevisionTab()
+        self.stack.addWidget(self.revision_page)
+
+        self.ventes_page = VenteWidget()
+        self.stack.addWidget(self.ventes_page)
+
+        self.settings_page = SettingsWidget()
+        self.stack.addWidget(self.settings_page)
+
+        main_layout.addWidget(sidebar_container, 1)
+        main_layout.addWidget(self.stack, 4)
+
+    def clear_selection(self) -> None:
+        for btn in self.button_group:
+            btn.setChecked(False)
+
+    def _collapse_other(self, active: CollapsibleSection) -> None:
+        if active.toggle_button.isChecked():
+            other = (
+                self.scrap_section if active is self.compta_section else self.compta_section
+            )
+            other.collapse()
+
+    def display_content(self, text: str, button: SidebarButton) -> None:
+        self.clear_selection()
+        button.setChecked(True)
+        label = QLabel(text, alignment=Qt.AlignCenter)
+        self.stack.addWidget(label)
+        self.stack.setCurrentWidget(label)
+
+    def show_scrap_page(self, button: SidebarButton, tab_index: int = 0) -> None:
+        self.clear_selection()
+        button.setChecked(True)
+        try:
+            self.scrap_page.tabs.setCurrentIndex(tab_index)
+        except Exception:
+            pass
+        self.stack.setCurrentWidget(self.scrap_page)
+
+    def show_scraping_images(self, button: SidebarButton) -> None:
+        self.show_scrap_page(button, tab_index=0)
+
+    def show_profiles(self, button: SidebarButton) -> None:
+        self.clear_selection()
+        button.setChecked(True)
+        self.stack.setCurrentWidget(self.profile_page)
+
+    def show_dashboard_page(self, button: SidebarButton) -> None:
+        self.clear_selection()
+        button.setChecked(True)
+        self.dashboard_page.refresh()
+        self.stack.setCurrentWidget(self.dashboard_page)
+
+    def show_accounts_page(self, button: SidebarButton) -> None:
+        self.clear_selection()
+        button.setChecked(True)
+        self.stack.setCurrentWidget(self.accounts_page)
+
+    def show_revision_page(self, button: SidebarButton) -> None:
+        self.clear_selection()
+        button.setChecked(True)
+        self.stack.setCurrentWidget(self.revision_page)
+
+    def show_journals_page(self, button: SidebarButton) -> None:
+        self.clear_selection()
+        button.setChecked(True)
+        self.stack.setCurrentWidget(self.journals_page)
+
+    def show_achat_page(self, button: SidebarButton) -> None:
+        self.clear_selection()
+        button.setChecked(True)
+        self.stack.setCurrentWidget(self.achat_page)
+
+    def show_suppliers_page(self, button: SidebarButton) -> None:
+        self.clear_selection()
+        button.setChecked(True)
+        self.stack.setCurrentWidget(self.suppliers_page)
+
+    def show_scraping_settings_page(self, button: SidebarButton) -> None:
+        self.clear_selection()
+        button.setChecked(True)
+        self.stack.setCurrentWidget(self.scraping_settings_page)
+
+    def show_ventes_page(self, button: SidebarButton) -> None:
+        self.clear_selection()
+        button.setChecked(True)
+        self.stack.setCurrentWidget(self.ventes_page)
+
+    def open_from_dashboard(self, name: str) -> None:
+        btn = self.compta_buttons.get(name)
+        if btn:
+            self.display_content(f"Comptabilité : {name}", btn)
+
+    def show_settings(self) -> None:
+        self.clear_selection()
+        self.settings_btn.setChecked(True)
+        self.stack.setCurrentWidget(self.settings_page)
+
+
+
+if __name__ == "__main__":
+    app = QApplication(sys.argv)
+    apply_theme(load_theme())
+    interface = MainWindow()
+    interface.show()
+    sys.exit(app.exec())
+
+```
+
+# localapp/icons/achat.svg
+Description: Source code for localapp/icons/achat.svg
+```
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
+</svg>
+
+```
+
+# localapp/icons/bilan.svg
+Description: Source code for localapp/icons/bilan.svg
+```
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
+</svg>
+
+```
+
+# localapp/icons/dashboard.svg
+Description: Source code for localapp/icons/dashboard.svg
+```
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
+</svg>
+
+```
+
+# localapp/icons/grand_livre.svg
+Description: Source code for localapp/icons/grand_livre.svg
+```
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
+</svg>
+
+```
+
+# localapp/icons/journal.svg
+Description: Source code for localapp/icons/journal.svg
+```
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
+</svg>
+
+```
+
+# localapp/icons/profile.svg
+Description: Source code for localapp/icons/profile.svg
+```
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
+</svg>
+
+```
+
+# localapp/icons/resultat.svg
+Description: Source code for localapp/icons/resultat.svg
+```
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
+</svg>
+
+```
+
+# localapp/icons/scraping.svg
+Description: Source code for localapp/icons/scraping.svg
+```
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
+</svg>
+
+```
+
+# localapp/icons/settings.svg
+Description: Source code for localapp/icons/settings.svg
+```
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
+</svg>
+
+```
+
+# localapp/icons/text.svg
+Description: Source code for localapp/icons/text.svg
+```
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
+</svg>
+
+```
+
+# localapp/icons/ventes.svg
+Description: Source code for localapp/icons/ventes.svg
+```
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
+</svg>
+
+```
+
+# requirements.txt
+Description: Source code for requirements.txt
+```
+PySide6
+pytest
+selenium
+requests
+openpyxl
+Flask
+pyngrok
+Pillow>=10
+
+```
+
+# tests/manual_profiles_test.md
+Description: Source code for tests/manual_profiles_test.md
+```
+# Manual Profiles Test
+
+1. Lancer l'application Qt et démarrer le serveur Flask depuis l'onglet dédié.
+2. Depuis un terminal ou Postman, envoyer :
+   ```bash
+   curl -X POST https://<ngrok>.ngrok-free.app/profiles \
+        -H "X-API-KEY: <CLE>" -H "Content-Type: application/json" \
+        -d '{"name":"Test","selector":".img-class"}'
+   ```
+3. Vérifier que la réponse HTTP est `201` et que le profil "Test" apparaît immédiatement dans l'onglet Profil Scraping.
+4. Répéter la requête POST identique : la réponse doit être `409` et aucun doublon ne doit apparaître dans l'UI.
+5. Tester la route de liste :
+   ```bash
+   curl -X GET https://<ngrok>.ngrok-free.app/profiles -H "X-API-KEY: <CLE>"
+   ```
+   Le profil "Test" doit être présent dans le JSON retourné.
+
+```
+
+# tests/test_download_naming.py
+Description: Source code for tests/test_download_naming.py
+```python
+from pathlib import Path
+import sys
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from MOTEUR.scraping.image_scraper import _download
+import types
+
+class DummyResponse:
+    def __init__(self):
+        self.content = b'x' * 200
+        self.headers = {'Content-Type': 'image/png'}
+    def raise_for_status(self):
+        pass
+
+def test_download_name_cleanup(tmp_path, monkeypatch):
+    def fake_get(url, timeout=10):
+        return DummyResponse()
+    monkeypatch.setattr('MOTEUR.scraping.image_scraper.requests.get', fake_get)
+
+    url1 = 'http://example.com/bob-avec-lacet-409.jpg'
+    url2 = 'http://example.com/bob-avec-lacet-1023.jpg'
+    _download(url1, tmp_path)
+    _download(url2, tmp_path)
+
+    names = sorted(p.name for p in tmp_path.iterdir())
+    assert names == ['bob-avec-lacet.jpg', 'bob-avec-lacet_1.jpg']
+
+
+```
+
+# tests/test_image_action_endpoint.py
+Description: Source code for tests/test_image_action_endpoint.py
+```python
+import time
+from pathlib import Path
+
+from PIL import Image
+
+from MOTEUR.scraping.server.flask_server import FlaskBridgeServer
+
+
+def _make_image(path: Path, color: str) -> None:
+    img = Image.new("RGB", (10, 10), color)
+    img.save(path)
+
+
+def test_image_action_endpoint(tmp_path):
+    _make_image(tmp_path / "a.png", "red")
+    _make_image(tmp_path / "b.jpg", "blue")
+
+    srv = FlaskBridgeServer()
+    srv.api_key = "k"
+    client = srv.app.test_client()
+
+    payload = {
+        "source": {"folder": str(tmp_path)},
+        "operations": [{"op": "resize", "width": 5, "height": 5, "keep_ratio": True}],
+        "target_subdir": "out",
+    }
+    resp = client.post(
+        "/actions/image-edit", json=payload, headers={"X-API-KEY": "k"}
+    )
+    assert resp.status_code == 202
+    job_id = resp.get_json()["job_id"]
+
+    for _ in range(30):
+        data = client.get(
+            f"/jobs/{job_id}", headers={"X-API-KEY": "k"}
+        ).get_json()
+        if data["status"] in {"done", "error"}:
+            break
+        time.sleep(0.1)
+    assert data["status"] == "done"
+    assert data["progress"]["downloaded"] == 2
+    out_dir = Path(data["output_dir"])
+    assert (out_dir / "a.png").exists()
+    assert (out_dir / "b.jpg").exists()
+
+```
+
+# tests/test_image_scraper_widget.py
+Description: Source code for tests/test_image_scraper_widget.py
+```python
+from pathlib import Path
+import sys
+import os
+import pytest
+
+QtWidgets = pytest.importorskip("PySide6.QtWidgets")
+QApplication = QtWidgets.QApplication
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from MOTEUR.scraping import profile_manager as pm
+from MOTEUR.scraping import history
+from MOTEUR.scraping.widgets.image_widget import ImageScraperWidget
+
+
+def test_scrape_logs_history(tmp_path, monkeypatch):
+    pm.PROFILES_FILE = tmp_path / "profiles.json"
+    history.HISTORY_FILE = tmp_path / "history.json"
+    history.LAST_USED_FILE = tmp_path / "last.json"
+    pm.save_profiles([{"name": "p1", "selector": ".a"}])
+
+    app = QApplication.instance() or QApplication([])
+    widget = ImageScraperWidget()
+    widget.refresh_profiles()
+    widget.set_selected_profile("p1")
+    urls_file = tmp_path / "urls.txt"
+    urls_file.write_text("http://example.com\nhttp://ex2.com\n")
+    widget.file_edit.setText(str(urls_file))
+    widget.folder_edit.setText(str(tmp_path))
+
+    monkeypatch.setattr(
+        "MOTEUR.scraping.widgets.image_widget.scrape_images",
+        lambda url, sel, folder: 5,
+    )
+
+    widget._start()
+
+    entries = history.load_history()
+    assert len(entries) == 2
+    assert entries[0]["url"] == "http://example.com"
+    assert entries[1]["url"] == "http://ex2.com"
+    assert all(e["profile"] == "p1" and e["images"] == 5 for e in entries)
+    widget.close()
+
+
+def test_export_excel(tmp_path, monkeypatch):
+    pm.PROFILES_FILE = tmp_path / "profiles.json"
+    pm.save_profiles([{"name": "p1", "selector": ".a"}])
+
+    app = QApplication.instance() or QApplication([])
+    widget = ImageScraperWidget()
+    widget.export_data = [
+        {"URL": "u1", "Variant": "v1", "Image": "img1"},
+        {"URL": "u2", "Variant": "v2", "Image": "img2"},
+    ]
+
+    out_file = tmp_path / "out.xlsx"
+
+    monkeypatch.setattr(
+        "MOTEUR.scraping.widgets.image_widget.QFileDialog.getSaveFileName",
+        lambda *a, **k: (str(out_file), "")
+    )
+    infos = []
+    monkeypatch.setattr(
+        "MOTEUR.scraping.widgets.image_widget.QMessageBox.information",
+        lambda *a, **k: infos.append(1)
+    )
+
+    widget._export_excel()
+
+    assert out_file.exists()
+    from openpyxl import load_workbook
+
+    wb = load_workbook(out_file)
+    ws = wb.active
+    data = list(ws.iter_rows(values_only=True))
+    assert data[1] == ("u1", "v1", "img1")
+    assert data[2] == ("u2", "v2", "img2")
+    widget.close()
+
+```
+
+# tests/test_mainwindow.py
+Description: Source code for tests/test_mainwindow.py
+```python
+import sys
+from pathlib import Path
+import pytest
+
+QtWidgets = pytest.importorskip("PySide6.QtWidgets")
+QApplication = QtWidgets.QApplication
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+import os
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from localapp.app import MainWindow
+
+
+def test_mainwindow_creation():
+    app = QApplication.instance() or QApplication([])
+    window = MainWindow()
+    assert window.windowTitle() == "COMPTA - Interface de gestion comptable"
+    window.close()
+
+```
+
+# tests/test_profile_manager.py
+Description: Source code for tests/test_profile_manager.py
+```python
+from pathlib import Path
+import sys
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+import pytest
+
+from MOTEUR.scraping import profile_manager as pm
+
+
+def test_load_profiles_empty(tmp_path: Path):
+    pm.PROFILES_FILE = tmp_path / "profiles.json"
+    assert pm.load_profiles() == []
+
+
+def test_add_update_delete_profile(tmp_path: Path):
+    pm.PROFILES_FILE = tmp_path / "profiles.json"
+
+    # Add a profile
+    pm.add_profile("test", ".selector")
+    profiles = pm.load_profiles()
+    assert profiles == [{"name": "test", "selector": ".selector"}]
+
+    # Update the profile
+    updated = pm.update_profile("test", "div.img")
+    assert updated is True
+    profiles = pm.load_profiles()
+    assert profiles[0]["selector"] == "div.img"
+
+    # Delete the profile
+    removed = pm.delete_profile("test")
+    assert removed is True
+    assert pm.load_profiles() == []
+
+    # Update/delete non-existing returns False
+    assert pm.update_profile("missing", "x") is False
+    assert pm.delete_profile("missing") is False
+
+
+def test_profile_persistence(tmp_path: Path):
+    """Profiles created via :mod:`profile_manager` should persist on disk."""
+    pm.PROFILES_FILE = tmp_path / "profiles.json"
+
+    pm.add_profile("persist", ".x")
+    # Reload from disk to verify persistence
+    new_list = pm.load_profiles()
+    assert new_list == [{"name": "persist", "selector": ".x"}]
+
+```
+
+# tests/test_profile_widget.py
+Description: Source code for tests/test_profile_widget.py
+```python
+from pathlib import Path
+import sys
+import os
+import pytest
+
+QtWidgets = pytest.importorskip("PySide6.QtWidgets")
+QApplication = QtWidgets.QApplication
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from MOTEUR.scraping import profile_manager as pm
+from MOTEUR.scraping.widgets.profile_widget import ProfileWidget
+
+
+def setup_widget(tmp_path):
+    pm.PROFILES_FILE = tmp_path / "profiles.json"
+    pm.save_profiles([
+        {"name": "p1", "selector": ".a"},
+        {"name": "p2", "selector": ".b"},
+    ])
+    app = QApplication.instance() or QApplication([])
+    widget = ProfileWidget()
+    return widget
+
+
+def test_load_and_select(tmp_path):
+    widget = setup_widget(tmp_path)
+    assert widget.profile_list.count() == 2
+
+    chosen = []
+    widget.profile_chosen.connect(lambda name: chosen.append(name))
+    widget.profile_list.setCurrentRow(1)
+    assert chosen == ["p2"]
+    widget.close()
+
+
+def test_add_and_delete(tmp_path):
+    widget = setup_widget(tmp_path)
+    updates = []
+    widget.profiles_updated.connect(lambda: updates.append(1))
+
+    widget.name_edit.setText("new")
+    widget.selector_edit.setText(".c")
+    widget.add_btn.click()
+    assert widget.profile_list.count() == 3
+    assert len(updates) == 1
+
+    widget.profile_list.setCurrentRow(0)
+    widget.delete_btn.click()
+    assert widget.profile_list.count() == 2
+    assert len(updates) == 2
+    widget.close()
+
+
+def test_profile_selection_updates_image_widget(tmp_path):
+    """Selecting a profile should update the ImageScraperWidget."""
+    from MOTEUR.scraping.widgets.image_widget import ImageScraperWidget
+
+    pm.PROFILES_FILE = tmp_path / "profiles.json"
+    pm.save_profiles([
+        {"name": "p1", "selector": ".a"},
+        {"name": "p2", "selector": ".b"},
+    ])
+
+    app = QApplication.instance() or QApplication([])
+    profile_widget = ProfileWidget()
+    image_widget = ImageScraperWidget()
+    image_widget.refresh_profiles()
+    profile_widget.profile_chosen.connect(image_widget.set_selected_profile)
+
+    profile_widget.profile_list.setCurrentRow(1)
+    assert image_widget.profile_combo.currentText() == "p2"
+    profile_widget.close()
+    image_widget.close()
+
+```
+
+# tests/test_restart_utils.py
+Description: Source code for tests/test_restart_utils.py
+```python
+import os
+import sys
+import subprocess
+import time
+
+from MOTEUR.scraping.utils.restart import relaunch_current_process
+
+
+def test_relaunch_uses_absolute_script_path(monkeypatch, tmp_path):
+    # simulate a script launched with a relative path
+    script = tmp_path / "script.py"
+    script.write_text("print('hi')\n")
+    monkeypatch.setattr(sys, 'argv', [script.name, 'arg1'])
+
+    called = {}
+    def fake_popen(argv, **kwargs):
+        called['argv'] = argv
+        class Dummy: pass
+        return Dummy()
+
+    monkeypatch.setattr(subprocess, 'Popen', fake_popen)
+    monkeypatch.setattr(time, 'sleep', lambda s: None)
+
+    relaunch_current_process()
+
+    assert os.path.isabs(called['argv'][1])
+    assert called['argv'][1].endswith('script.py')
+
+```
+
+# tests/test_scrape_variants.py
+Description: Source code for tests/test_scrape_variants.py
+```python
+from pathlib import Path
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from MOTEUR.scraping.image_scraper import scrape_variants
+from selenium.webdriver.common.by import By
+
+class DummyElement:
+    def __init__(self, attrs=None):
+        self.attrs = attrs or {}
+    def get_attribute(self, name):
+        return self.attrs.get(name)
+    def is_displayed(self):
+        return True
+    def find_element(self, by, value):
+        # only used to get following sibling label
+        return DummyElement()
+
+class DummyDriver:
+    def __init__(self, url):
+        self.current_url = url
+        self.inputs = [
+            DummyElement({'value': 'Camel', 'id': 'v1'}),
+            DummyElement({'value': 'Noir', 'id': 'v2'})
+        ]
+        self.label_map = { 'v1': DummyElement(), 'v2': DummyElement() }
+        self.img = DummyElement({'src': 'http://x'})
+    def find_elements(self, by, value):
+        if value == ".variant-picker__option-values input[type='radio']":
+            return self.inputs
+        return []
+    def find_element(self, by, value):
+        if value.startswith("label[for='"):
+            key = value.split("'")[1]
+            return self.label_map[key]
+        return self.img
+    def execute_script(self, script, el):
+        pass
+
+class DummyWait:
+    def __init__(self, driver, timeout):
+        pass
+    def until(self, method):
+        method(None)
+
+
+def test_scrape_variants_generate_urls(monkeypatch):
+    monkeypatch.setattr('MOTEUR.scraping.image_scraper.WebDriverWait', DummyWait)
+    driver = DummyDriver('https://competitor.com/products/bob-avec-lacet')
+    mapping = scrape_variants(driver)
+    assert mapping == {
+        'Camel': 'https://www.planetebob.fr/wp-content/uploads/2025/07/bob-avec-lacet-camel.jpg',
+        'Noir': 'https://www.planetebob.fr/wp-content/uploads/2025/07/bob-avec-lacet-noir.jpg',
+    }
+
+```
+
+# tests/test_settings_widget.py
+Description: Source code for tests/test_settings_widget.py
+```python
+from pathlib import Path
+import sys
+import os
+import pytest
+
+QtWidgets = pytest.importorskip("PySide6.QtWidgets")
+QApplication = QtWidgets.QApplication
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from MOTEUR.scraping.widgets.settings_widget import ScrapingSettingsWidget
+from MOTEUR.scraping.utils import update
+
+
+def test_update_button_triggers_git_pull(monkeypatch):
+    started = {}
+
+    app = QApplication.instance() or QApplication([])
+    widget = ScrapingSettingsWidget(show_maintenance=True)
+
+    def fake_start(program, arguments):
+        started["program"] = program
+        started["arguments"] = list(arguments)
+
+    def fake_waitForStarted(timeout):
+        return True
+
+    monkeypatch.setattr(widget._git_proc, "start", fake_start)
+    monkeypatch.setattr(widget._git_proc, "waitForStarted", fake_waitForStarted)
+
+    btn = widget.findChild(QtWidgets.QPushButton, "btn_update")
+    btn.click()
+    widget.close()
+
+    assert started["program"] == "git"
+    assert started["arguments"] == ["pull", "origin", "main"]
+    assert widget._git_proc.workingDirectory() == str(update.PROJECT_ROOT)
+
+```
+
+# tests/test_storage_integration.py
+Description: Source code for tests/test_storage_integration.py
+```python
+import sys
+import os
+from pathlib import Path
+import pytest
+
+QtWidgets = pytest.importorskip("PySide6.QtWidgets")
+QApplication = QtWidgets.QApplication
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from MOTEUR.scraping import profile_manager as pm, history
+from MOTEUR.scraping.widgets.image_widget import ImageScraperWidget
+from MOTEUR.scraping.widgets.storage_widget import StorageWidget
+
+
+class DummyDriver:
+    def find_element(self, by, value):
+        class El:
+            text = "Bob"
+        return El()
+
+    def quit(self):
+        pass
+
+
+def test_image_scraper_adds_to_storage(tmp_path, monkeypatch):
+    pm.PROFILES_FILE = tmp_path / "profiles.json"
+    history.HISTORY_FILE = tmp_path / "history.json"
+    history.LAST_USED_FILE = tmp_path / "last.json"
+    pm.save_profiles([{"name": "p1", "selector": ".a"}])
+
+    app = QApplication.instance() or QApplication([])
+    storage = StorageWidget()
+    widget = ImageScraperWidget(storage_widget=storage)
+    widget.refresh_profiles()
+    widget.set_selected_profile("p1")
+    urls_file = tmp_path / "urls.txt"
+    urls_file.write_text("http://example.com\n")
+    widget.file_edit.setText(str(urls_file))
+    widget.folder_edit.setText(str(tmp_path))
+    widget.variants_checkbox.setChecked(True)
+
+    monkeypatch.setattr(
+        "MOTEUR.scraping.widgets.image_widget.scrape_images",
+        lambda url, sel, folder, keep_driver=False: (0, DummyDriver()),
+    )
+    monkeypatch.setattr(
+        "MOTEUR.scraping.widgets.image_widget.scrape_variants",
+        lambda driver: {"Noir": "img1", "Beige": "img2"},
+    )
+
+    widget._start()
+
+    assert storage.table.rowCount() == 1
+    assert storage.table.item(0, 0).text() == "Bob"
+    assert "Noir" in storage.table.item(0, 1).text()
+    widget.close()
+    storage.close()
+
+```
+
+# tests/test_storage_widget.py
+Description: Source code for tests/test_storage_widget.py
+```python
+import sys
+import os
+from pathlib import Path
+import pytest
+
+QtWidgets = pytest.importorskip("PySide6.QtWidgets")
+QApplication = QtWidgets.QApplication
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from MOTEUR.scraping.widgets.storage_widget import StorageWidget
+from MOTEUR.scraping.widgets.woocommerce_widget import WooCommerceProductWidget
+
+
+def test_storage_basic_operations():
+    app = QApplication.instance() or QApplication([])
+    storage = StorageWidget()
+    storage.add_product("bob", ["Noir", "Beige"])
+    assert storage.table.rowCount() == 1
+    products = storage.get_products()
+    assert products[0]["name"] == "bob"
+    assert products[0]["variants"] == ["Noir", "Beige"]
+    storage.clear()
+    assert storage.table.rowCount() == 0
+    storage.close()
+
+```
+
+# tests/test_woocommerce_widget.py
+Description: Source code for tests/test_woocommerce_widget.py
+```python
+import sys
+import os
+from pathlib import Path
+import csv
+import pytest
+
+QtWidgets = pytest.importorskip("PySide6.QtWidgets")
+QApplication = QtWidgets.QApplication
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from MOTEUR.scraping.widgets.woocommerce_widget import WooCommerceProductWidget
+from MOTEUR.scraping.widgets.scrap_widget import ScrapWidget
+from MOTEUR.scraping.widgets.storage_widget import StorageWidget
+
+
+def test_widget_headers():
+    app = QApplication.instance() or QApplication([])
+    widget = WooCommerceProductWidget(storage_widget=StorageWidget())
+    assert widget.table.columnCount() == len(widget.HEADERS)
+    widget.close()
+
+
+def test_tab_added_to_scrapwidget():
+    app = QApplication.instance() or QApplication([])
+    sw = ScrapWidget()
+    labels = [sw.tabs.tabText(i) for i in range(sw.tabs.count())]
+    assert "Fiche Produit WooCommerce" in labels
+    assert "Stockage" in labels
+    sw.close()
+
+def test_fill_from_storage(tmp_path, monkeypatch):
+    app = QApplication.instance() or QApplication([])
+    storage = StorageWidget()
+    storage.add_product("bob", ["Noir", "Beige"])
+    storage.add_product("chapeau", ["Unique"])
+
+    images_root = tmp_path / "images"
+    (images_root / "bob").mkdir(parents=True)
+    (images_root / "bob" / "bob.jpg").write_text("x")
+    (images_root / "bob" / "bob-noir.jpg").write_text("x")
+    (images_root / "bob" / "bob-beige.jpg").write_text("x")
+    (images_root / "chapeau").mkdir()
+    (images_root / "chapeau" / "chapeau.jpg").write_text("x")
+    (images_root / "chapeau" / "chapeau-unique.jpg").write_text("x")
+
+    monkeypatch.setattr(WooCommerceProductWidget, "IMAGES_ROOT", images_root)
+
+    widget = WooCommerceProductWidget(storage_widget=storage)
+    widget.fill_from_storage()
+    assert widget.table.rowCount() == 4
+    type_col = widget.HEADERS.index("Type")
+    name_col = widget.HEADERS.index("Name")
+    sku_col = widget.HEADERS.index("SKU")
+    img_col = widget.HEADERS.index("Images")
+
+    parent_sku = widget.table.item(0, sku_col).text()
+    assert widget.table.item(0, name_col).text() == "bob"
+    assert widget.table.item(0, type_col).text() == "variable"
+    images0 = set(widget.table.item(0, img_col).text().split(', '))
+    assert images0 == {
+        "https://www.planetebob.fr/wp-content/uploads/2025/07/bob.jpg",
+        "https://www.planetebob.fr/wp-content/uploads/2025/07/bob-noir.jpg",
+        "https://www.planetebob.fr/wp-content/uploads/2025/07/bob-beige.jpg",
+    }
+
+    assert widget.table.item(1, type_col).text() == "variation"
+    assert widget.table.item(1, sku_col).text() == f"{parent_sku}-noir"
+    assert widget.table.item(1, name_col).text() == "bob Noir"
+    assert widget.table.item(1, img_col).text() == (
+        "https://www.planetebob.fr/wp-content/uploads/2025/07/bob-noir.jpg"
+    )
+
+    assert widget.table.item(2, type_col).text() == "variation"
+    assert widget.table.item(2, sku_col).text() == f"{parent_sku}-beige"
+    assert widget.table.item(2, img_col).text() == (
+        "https://www.planetebob.fr/wp-content/uploads/2025/07/bob-beige.jpg"
+    )
+
+    assert widget.table.item(3, type_col).text() == "simple"
+    images3 = set(widget.table.item(3, img_col).text().split(', '))
+    assert images3 == {
+        "https://www.planetebob.fr/wp-content/uploads/2025/07/chapeau.jpg",
+        "https://www.planetebob.fr/wp-content/uploads/2025/07/chapeau-unique.jpg",
+    }
+    widget.close()
+    storage.close()
+
+
+def test_export_csv_delimiter(tmp_path, monkeypatch):
+    app = QApplication.instance() or QApplication([])
+    widget = WooCommerceProductWidget(storage_widget=StorageWidget())
+    widget.add_row()
+    name_col = widget.HEADERS.index("Name")
+    widget.table.setItem(0, name_col, QtWidgets.QTableWidgetItem("bob"))
+
+    out_file = tmp_path / "out.csv"
+    monkeypatch.setattr(
+        "MOTEUR.scraping.widgets.woocommerce_widget.QFileDialog.getSaveFileName",
+        lambda *a, **k: (str(out_file), ""),
+    )
+
+    widget.export_csv()
+
+    with open(out_file, newline="", encoding="utf-8") as f:
+        rows = list(csv.reader(f, delimiter=";"))
+
+    assert rows[0] == widget.HEADERS
+    assert rows[1][name_col] == "bob"
+    widget.close()
+
+
+def test_clean_image_urls_option(tmp_path, monkeypatch):
+    app = QApplication.instance() or QApplication([])
+    storage = StorageWidget()
+    storage.add_product("bob", ["Unique"])
+
+    images_root = tmp_path / "images"
+    (images_root / "bob").mkdir(parents=True)
+    (images_root / "bob" / "bob.jpg").write_text("x")
+    (images_root / "bob" / "bob_1.jpg").write_text("x")
+    (images_root / "bob" / "bob-unique.jpg").write_text("x")
+
+    monkeypatch.setattr(WooCommerceProductWidget, "IMAGES_ROOT", images_root)
+
+    # Cleaning enabled (default)
+    widget = WooCommerceProductWidget(storage_widget=storage)
+    widget.fill_from_storage()
+    img_col = widget.HEADERS.index("Images")
+    images = widget.table.item(0, img_col).text().split(", ")
+    assert images == [
+        "https://www.planetebob.fr/wp-content/uploads/2025/07/bob.jpg",
+        "https://www.planetebob.fr/wp-content/uploads/2025/07/bob-unique.jpg",
+    ]
+    widget.close()
+
+    # Cleaning disabled
+    widget2 = WooCommerceProductWidget(storage_widget=storage)
+    widget2.clean_images_checkbox.setChecked(False)
+    widget2.fill_from_storage()
+    images2 = widget2.table.item(0, img_col).text().split(", ")
+    assert images2 == [
+        "https://www.planetebob.fr/wp-content/uploads/2025/07/bob.jpg",
+        "https://www.planetebob.fr/wp-content/uploads/2025/07/bob_1.jpg",
+        "https://www.planetebob.fr/wp-content/uploads/2025/07/bob-unique.jpg",
+    ]
+    widget2.close()
+
+
+def test_fill_multiple_times_no_duplicates(tmp_path, monkeypatch):
+    app = QApplication.instance() or QApplication([])
+    storage = StorageWidget()
+    storage.add_product("bob", ["Unique"])
+
+    widget = WooCommerceProductWidget(storage_widget=storage)
+    widget.fill_from_storage()
+    first_count = widget.table.rowCount()
+
+    # Fill again - row count should remain the same
+    widget.fill_from_storage()
+    assert widget.table.rowCount() == first_count
+
+    out_file = tmp_path / "out.csv"
+    monkeypatch.setattr(
+        "MOTEUR.scraping.widgets.woocommerce_widget.QFileDialog.getSaveFileName",
+        lambda *a, **k: (str(out_file), ""),
+    )
+
+    widget.export_csv()
+
+    with open(out_file, newline="", encoding="utf-8") as f:
+        rows = list(csv.reader(f, delimiter=";"))
+
+    # one header row + one product row
+    assert len(rows) - 1 == first_count
+    widget.close()
+    storage.close()
+
+```
+
+# gpt/openapi.yaml
+Description: Source code for gpt/openapi.yaml
+```yaml
+openapi: 3.0.3
+info:
+  title: Flask Bridge API
+  version: '1.0'
+paths:
+  /files/list:
+    get:
+      summary: List images in a folder (alias or absolute path)
+      operationId: listFiles
+      security:
+        - apiKey: []
+      parameters:
+        - name: folder
+          in: query
+          required: true
+          schema:
+            type: string
+            example: sample_folder
+      responses:
+        '200':
+          description: List of files and public URLs
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  folder:
+                    type: string
+                  count:
+                    type: integer
+                  files:
+                    type: array
+                    items:
+                      type: string
+                  urls:
+                    type: array
+                    items:
+                      type: string
+        '400':
+          description: Invalid request
+        '401':
+          description: Unauthorized
+  /files/raw:
+    get:
+      summary: Serve a single image file
+      operationId: getFile
+      security:
+        - apiKey: []
+      parameters:
+        - name: folder
+          in: query
+          required: true
+          schema:
+            type: string
+            example: sample_folder
+        - name: name
+          in: query
+          required: true
+          schema:
+            type: string
+            example: bob-avec-lacet-noir.webp
+      responses:
+        '200':
+          description: The image bytes
+          content:
+            image/*:
+              schema:
+                type: string
+                format: binary
+        '400':
+          description: Invalid request
+        '401':
+          description: Unauthorized
+        '404':
+          description: File not found
+components:
+  securitySchemes:
+    apiKey:
+      type: apiKey
+      in: header
+      name: X-API-KEY
+```
+
+### >>> gpt/openapi.yaml (130 lignes)
+openapi: 3.1.0
+info:
+  title: Lamine Bridge (Files + Products)
+  version: "1.0"
+servers:
+  - url: https://YOUR_PUBLIC_DOMAIN
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-KEY
+security:
+  - ApiKeyAuth: []
+paths:
+  /files/list:
+    get:
+      operationId: listFiles
+      summary: Liste les fichiers d'un dossier (alias ou chemin absolu)
+      parameters:
+        - in: query
+          name: folder
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: OK (fichiers + urls + folder absolu)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  folder: { type: string }
+                  count:  { type: integer }
+                  files:  { type: array, items: { type: string } }
+                  urls:   { type: array, items: { type: string } }
+  /files/raw:
+    get:
+      operationId: getRawFile
+      summary: Sert un fichier binaire (image) depuis un dossier
+      parameters:
+        - in: query
+          name: folder
+          required: true
+          schema: { type: string }
+        - in: query
+          name: name
+          required: true
+          schema: { type: string }
+      responses:
+        "200": { description: Image bytes }
+  /products:
+    get:
+      operationId: listProducts
+      summary: Liste les produits (1 dossier = 1 produit)
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        slug: { type: string }
+                        name: { type: string }
+                        images_count: { type: integer }
+  /products/{slug}/images:
+    get:
+      operationId: getProductImages
+      summary: URLs publiques des images d’un produit (via /files/raw)
+      parameters:
+        - in: path
+          name: slug
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  product: { type: string }
+                  slug:    { type: string }
+                  images:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name: { type: string }
+                        url: { type: string }
+                        preview_url: { type: string }
+        "404": { description: Not found }
+  /products/{slug}/descriptions:
+    post:
+      operationId: saveProductDescription
+      summary: Enregistre la fiche produit (CSV Woo + trace JSON)
+      parameters:
+        - in: path
+          name: slug
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name: { type: string }
+                short_description: { type: string }
+                description: { type: string }
+                categories: { type: array, items: { type: string } }
+                tags: { type: array, items: { type: string } }
+                regular_price: { type: string }
+                sale_price: { type: string }
+                slug: { type: string }
+                focus_keyword: { type: string }
+                meta_title: { type: string }
+                meta_description: { type: string }
+                internal_link: { type: string }
+      responses:
+        "200": { description: OK }
+        "401": { description: Unauthorized }
+
+### >>> gpt/product_bridge_behavior.txt (10 lignes)
+Tu es un générateur de fiches produits FR (fr-FR), SEO “pur” (Rank Math).
+Règles par produit :
+- Analyse 3 à 5 images renvoyées par l’API pour déduire matière, couleur, style, lacet/ficelle, etc.
+- Génère : Name, Short description (60–80 mots), Description (230–240 mots, lisible), Categories (2–4), Tags (2–4), Slug, Focus keyword, Meta title (55–60 car), Meta description (140–160), Internal link.
+- Densité mot-clé 1–1,5%, pas d’emoji, pas de promesses médicales.
+Procédure :
+1) GET /products → récupérer la liste (par lots de 20 max).
+2) Pour chaque slug → GET /products/{slug}/images → choisir 3–5 images.
+3) Générer la fiche et POST /products/{slug}/descriptions (JSON exact).
+4) Ignorer les produits ayant déjà un generated.json si l’API le signale à l’avenir.
+
+### >>> localapp/__init__.py (0 lignes)
+
+
+### >>> localapp/app.py (553 lignes)
+# --- Boot Qt silencieux (avant imports PySide6) ---
+import os
+os.environ.setdefault("QT_LOGGING_RULES", "qt.qpa.fonts=false;qt.qpa.*=false")
+# Si nécessaire pour diagnostiquer (désactive DirectWrite) :
+# os.environ.setdefault("QT_NO_DIRECTWRITE", "1")
+
+# --- Bootstrap UTF-8, compatible run module ET run direct ---
+try:
+    from .utf8_bootstrap import force_utf8_stdio
+except ImportError:
+    # ex: si lancé par chemin direct (pas en module)
+    from utf8_bootstrap import force_utf8_stdio
+force_utf8_stdio()
+
+# Logs robustes (print_safe)
+try:
+    from .log_safe import print_safe, open_utf8
+except ImportError:
+    from log_safe import print_safe, open_utf8
+
+from pathlib import Path
+import sys
+
+# Allow running this module directly by ensuring the project root is in
+# ``sys.path``.  When executed with ``python localapp/app.py`` the Python
+# interpreter only adds the ``localapp`` directory to ``sys.path`` which
+# prevents imports from the sibling ``MOTEUR`` package.  Adding the parent
+# directory resolves ``ModuleNotFoundError`` for these local imports.
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+SETTINGS_FILE = PROJECT_ROOT / "settings.json"
+try:
+    from PySide6.QtWidgets import (
+        QApplication,
+        QMainWindow,
+        QWidget,
+        QVBoxLayout,
+        QHBoxLayout,
+        QPushButton,
+        QLabel,
+        QSizePolicy,
+        QScrollArea,
+        QFrame,
+    )
+    from PySide6.QtCore import Qt, QPropertyAnimation, Slot, QEasingCurve
+    from PySide6.QtGui import QIcon, QKeySequence, QShortcut
+except ModuleNotFoundError:
+    print_safe("Install dependencies with pip install -r requirements.txt")
+    sys.exit(1)
+
+from MOTEUR.scraping.widgets.scrap_widget import ScrapWidget
+from MOTEUR.compta.achats.widget import AchatWidget
+from MOTEUR.compta.ventes.widget import VenteWidget
+from MOTEUR.compta.accounting.widget import AccountWidget
+from MOTEUR.scraping.widgets.profile_widget import ProfileWidget
+from MOTEUR.compta.dashboard.widget import DashboardWidget
+from gallery_widget import GalleryWidget
+
+from localapp.ui_theme import ThemeManager
+from localapp.ui_icons import get_icon
+from localapp.ui_animations import AnimatedStack
+from localapp.pages.settings_page import SettingsPage
+import json
+
+
+class SidebarButton(QPushButton):
+    """Custom button used in the vertical sidebar."""
+
+    def __init__(self, text: str, icon: QIcon | None = None) -> None:
+        super().__init__(text)
+        if icon:
+            self.setIcon(icon)
+        self.setStyleSheet(
+            """
+            QPushButton {
+                padding: 10px;
+                border: none;
+                background-color: #f0f0f0;
+                color: #333;
+                text-align: left;
+            }
+            QPushButton:hover {
+                background-color: #d0d0d0;
+            }
+            QPushButton:checked {
+                background-color: #c0c0c0;
+                font-weight: bold;
+            }
+            """
+        )
+        self.setCheckable(True)
+        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+
+
+class CollapsibleSection(QWidget):
+    """Section with a header button that can show or hide its content."""
+
+    def __init__(
+        self,
+        title: str,
+        parent: QWidget | None = None,
+        *,
+        hide_title_when_collapsed: bool = False,
+    ) -> None:
+        super().__init__(parent)
+        self.original_title = title
+        self.hide_title_when_collapsed = hide_title_when_collapsed
+        self.toggle_button = QPushButton(title)
+        self.toggle_button.setCheckable(True)
+        self.toggle_button.setChecked(False)
+        self.toggle_button.setStyleSheet(
+            """
+            QPushButton {
+                background-color: #444;
+                color: white;
+                padding: 10px;
+                text-align: left;
+                font-weight: bold;
+            }
+            QPushButton:checked {
+                background-color: #666;
+            }
+            """
+        )
+
+        self.content_area = QWidget()
+        self.content_area.setMaximumHeight(0)
+        self.content_area.setSizePolicy(
+            QSizePolicy.Policy.Expanding,
+            QSizePolicy.Policy.Minimum,
+        )
+        self.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum
+        )
+
+        self.toggle_animation = QPropertyAnimation(
+            self.content_area,
+            b"maximumHeight",
+        )
+        self.toggle_animation.setDuration(300)
+        self.toggle_animation.setEasingCurve(QEasingCurve.InOutCubic)
+        self.toggle_animation.setStartValue(0)
+        self.toggle_animation.setEndValue(0)
+
+        self.toggle_button.clicked.connect(self.toggle)
+        if (
+            self.hide_title_when_collapsed
+            and not self.toggle_button.isChecked()
+        ):
+            self.toggle_button.setText("")
+
+        main_layout = QVBoxLayout(self)
+        main_layout.setContentsMargins(0, 0, 0, 0)
+        main_layout.addWidget(self.toggle_button)
+        main_layout.addWidget(self.content_area)
+
+        self.inner_layout = QVBoxLayout()
+        self.inner_layout.setContentsMargins(0, 0, 0, 0)
+        self.inner_layout.setSpacing(0)
+        self.content_area.setLayout(self.inner_layout)
+
+    def toggle(self) -> None:
+        checked = self.toggle_button.isChecked()
+        total_height = self.content_area.sizeHint().height()
+        self.toggle_animation.setDirection(
+            QPropertyAnimation.Forward
+            if checked
+            else QPropertyAnimation.Backward
+        )
+        self.toggle_animation.setEndValue(total_height if checked else 0)
+        self.toggle_animation.start()
+        if self.hide_title_when_collapsed:
+            self.toggle_button.setText(self.original_title if checked else "")
+
+    def collapse(self) -> None:
+        if self.toggle_button.isChecked():
+            self.toggle_button.setChecked(False)
+            self.toggle()
+
+    def expand(self) -> None:
+        if not self.toggle_button.isChecked():
+            self.toggle_button.setChecked(True)
+            self.toggle()
+
+    def add_widget(self, widget: QWidget) -> None:
+        self.inner_layout.addWidget(widget)
+
+
+class MainWindow(QMainWindow):
+    """Main application window with a sidebar and central stack."""
+
+    def __init__(self, theme: ThemeManager | None = None) -> None:
+        super().__init__()
+        self.theme = theme
+        self.settings = self._load_settings()
+        if self.theme:
+            self.theme.apply(self.settings.get("theme", "dark"))
+        self.setWindowTitle("COMPTA - Interface de gestion comptable")
+        self.setMinimumSize(1200, 700)
+
+        central_widget = QWidget()
+        self.setCentralWidget(central_widget)
+
+        main_layout = QHBoxLayout(central_widget)
+        main_layout.setContentsMargins(0, 0, 0, 0)
+
+        sidebar_container = QWidget()
+        sidebar_layout = QVBoxLayout(sidebar_container)
+        sidebar_layout.setContentsMargins(0, 0, 0, 0)
+        sidebar_layout.setSpacing(0)
+
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QFrame.NoFrame)
+        scroll.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+        scroll_content = QWidget()
+        scroll_content.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum
+        )
+        nav_layout = QVBoxLayout(scroll_content)
+        nav_layout.setContentsMargins(0, 0, 0, 0)
+        nav_layout.setSpacing(0)
+        scroll.setWidget(scroll_content)
+
+        sidebar_container.setStyleSheet("background-color: #ffffff;")
+        scroll_content.setStyleSheet("background-color: #ffffff;")
+
+        self.button_group: list[SidebarButton] = []
+        self.compta_buttons: dict[str, SidebarButton] = {}
+
+
+        self.compta_section = CollapsibleSection(
+            "📁 Comptabilité", hide_title_when_collapsed=False
+        )
+        compta_items = [
+            ("Tableau de bord", "dashboard", self.show_dashboard_page),
+            ("Journal", "journal", lambda b: self.display_content("Comptabilité : Journal", b)),
+            (
+                "Grand Livre",
+                "grand_livre",
+                lambda b: self.display_content("Comptabilité : Grand Livre", b),
+            ),
+            ("Bilan", "bilan", lambda b: self.display_content("Comptabilité : Bilan", b)),
+            (
+                "Résultat",
+                "resultat",
+                lambda b: self.display_content("Comptabilité : Résultat", b),
+            ),
+            ("Comptes", "comptes", self.show_accounts_page),
+            ("Révision", "revision", self.show_revision_page),
+            ("Paramètres", "parametres", self.show_journals_page),
+        ]
+        for name, icon_name, handler in compta_items:
+            btn = SidebarButton(name, get_icon(icon_name))
+            self.compta_buttons[name] = btn
+            btn.clicked.connect(lambda _, b=btn, h=handler: h(b))
+            self.compta_section.add_widget(btn)
+            self.button_group.append(btn)
+        nav_layout.addWidget(self.compta_section)
+
+        self.scrap_section = CollapsibleSection("🛠️ Scraping")
+
+        self.scrap_btn = SidebarButton("Scrap", get_icon("scrap"))
+        self.scrap_btn.clicked.connect(
+            lambda _, b=self.scrap_btn: self.show_scrap_page(b)
+        )
+        self.scrap_section.add_widget(self.scrap_btn)
+        self.button_group.append(self.scrap_btn)
+
+        self.profiles_btn = SidebarButton(
+            "Profil Scraping", get_icon("profil_scraping")
+        )
+        self.profiles_btn.clicked.connect(
+            lambda _, b=self.profiles_btn: self.show_profiles(b)
+        )
+        self.scrap_section.add_widget(self.profiles_btn)
+        self.button_group.append(self.profiles_btn)
+
+        self.gallery_btn = SidebarButton("Galerie", get_icon("galerie"))
+        self.gallery_btn.clicked.connect(lambda _, b=self.gallery_btn: self.show_gallery_tab())
+        self.scrap_section.add_widget(self.gallery_btn)
+        self.button_group.append(self.gallery_btn)
+
+        nav_layout.addWidget(self.scrap_section)
+        # Collapse the other section when one is expanded
+        self.compta_section.toggle_button.clicked.connect(
+            lambda: self._collapse_other(self.compta_section)
+        )
+        self.scrap_section.toggle_button.clicked.connect(
+            lambda: self._collapse_other(self.scrap_section)
+        )
+        nav_layout.addStretch()
+
+        sidebar_layout.addWidget(scroll, 1)
+
+        line = QFrame()
+        line.setFrameShape(QFrame.Shape.HLine)
+        line.setStyleSheet("margin:6px 0;")
+        sidebar_layout.addWidget(line)
+
+        self.settings_btn = SidebarButton("Paramètres", get_icon("parametres"))
+        self.settings_btn.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed
+        )
+        self.settings_btn.setMinimumHeight(34)
+        self.settings_btn.setEnabled(True)
+        self.settings_btn.setObjectName("sidebar-item")
+        self.settings_btn.clicked.connect(
+            lambda _, b=self.settings_btn: self.show_settings(b)
+        )
+        self.button_group.append(self.settings_btn)
+        sidebar_layout.addWidget(self.settings_btn)
+        self.stack = AnimatedStack()
+        self.stack.addWidget(
+            QLabel("Bienvenue sur COMPTA", alignment=Qt.AlignCenter)
+        )
+
+        self.profile_page = ProfileWidget()
+        self.stack.addWidget(self.profile_page)
+
+        self.scrap_page = ScrapWidget()
+        self.stack.addWidget(self.scrap_page)
+
+
+        base_url = getattr(self, "flask_base_url", "")
+        api_key = getattr(self, "api_key", None)
+        self.gallery_page = GalleryWidget(self, base_url=base_url, api_key=api_key)
+        self.stack.addWidget(self.gallery_page)
+
+        self.profile_page.profile_chosen.connect(
+            self.scrap_page.images_widget.set_selected_profile
+        )
+        self.profile_page.profiles_updated.connect(
+            self.scrap_page.images_widget.refresh_profiles
+        )
+
+        self.dashboard_page = DashboardWidget()
+        self.dashboard_page.journal_requested.connect(
+            lambda: self.open_from_dashboard("Journal")
+        )
+        self.dashboard_page.grand_livre_requested.connect(
+            lambda: self.open_from_dashboard("Grand Livre")
+        )
+        self.dashboard_page.scraping_summary_requested.connect(
+            lambda: self.show_scrap_page(self.scrap_btn)
+        )
+        self.stack.addWidget(self.dashboard_page)
+
+        self.achat_page = AchatWidget()
+        self.stack.addWidget(self.achat_page)
+
+        from MOTEUR.compta.suppliers import SupplierTab
+
+        self.suppliers_page = SupplierTab()
+        self.stack.addWidget(self.suppliers_page)
+
+        self.accounts_page = AccountWidget()
+        self.accounts_page.accounts_updated.connect(
+            self.achat_page.refresh_accounts
+        )
+        self.stack.addWidget(self.accounts_page)
+
+        from MOTEUR.compta.parameters import JournalsWidget
+
+        self.journals_page = JournalsWidget()
+        self.stack.addWidget(self.journals_page)
+
+        from MOTEUR.compta.revision import RevisionTab
+
+        self.revision_page = RevisionTab()
+        self.stack.addWidget(self.revision_page)
+
+        self.ventes_page = VenteWidget()
+        self.stack.addWidget(self.ventes_page)
+
+        self.app_ctx = AppContext(self)
+        self.settings_page = SettingsPage(self.app_ctx, self)
+        self.stack.addWidget(self.settings_page)
+
+        main_layout.addWidget(sidebar_container, 1)
+        main_layout.addWidget(self.stack, 4)
+
+        # Install global shortcuts
+        self._install_shortcuts()
+
+    def clear_selection(self) -> None:
+        for btn in self.button_group:
+            btn.setChecked(False)
+
+    def _collapse_other(self, active: CollapsibleSection) -> None:
+        if active.toggle_button.isChecked():
+            other = (
+                self.scrap_section if active is self.compta_section else self.compta_section
+            )
+            other.collapse()
+
+    def _install_shortcuts(self) -> None:
+        def add(key: str, fn):
+            sc = QShortcut(QKeySequence(key), self)
+            sc.activated.connect(fn)
+
+        if hasattr(self, "show_scrap_page"):
+            add("Ctrl+1", lambda: self.show_scrap_page(self.scrap_btn))
+        if hasattr(self, "show_profiles"):
+            add("Ctrl+2", lambda: self.show_profiles(self.profiles_btn))
+        if hasattr(self, "show_gallery_tab"):
+            add("Ctrl+3", self.show_gallery_tab)
+        if hasattr(self, "show_flask_tab"):
+            add("Ctrl+4", self.show_flask_tab)
+        if hasattr(self, "show_settings"):
+            add("Ctrl+5", lambda: self.show_settings(self.settings_btn))
+
+        target = getattr(self, "scrap_page", None)
+        if target and hasattr(target, "start_scan"):
+            add("Ctrl+L", target.start_scan)
+        if target and hasattr(target, "copy_links_to_clipboard"):
+            add("Ctrl+C", target.copy_links_to_clipboard)
+        if target and hasattr(target, "dedupe_links"):
+            add("Ctrl+D", target.dedupe_links)
+        if target and hasattr(target, "export_links_csv"):
+            add("Ctrl+E", target.export_links_csv)
+
+    def display_content(self, text: str, button: SidebarButton) -> None:
+        self.clear_selection()
+        button.setChecked(True)
+        label = QLabel(text, alignment=Qt.AlignCenter)
+        self.stack.addWidget(label)
+        self.stack.setCurrentWidget(label)
+
+    def show_scrap_page(self, button: SidebarButton, tab_index: int = 0) -> None:
+        self.clear_selection()
+        button.setChecked(True)
+        try:
+            self.scrap_page.tabs.setCurrentIndex(tab_index)
+        except Exception:
+            pass
+        self.stack.setCurrentWidget(self.scrap_page)
+
+    def show_scraping_images(self, button: SidebarButton) -> None:
+        self.show_scrap_page(button, tab_index=0)
+
+    def show_profiles(self, button: SidebarButton) -> None:
+        self.clear_selection()
+        button.setChecked(True)
+        self.stack.setCurrentWidget(self.profile_page)
+
+    def show_gallery_tab(self) -> None:
+        self.clear_selection()
+        if hasattr(self, "gallery_btn"):
+            self.gallery_btn.setChecked(True)
+        self.stack.setCurrentWidget(self.gallery_page)
+
+    def show_dashboard_page(self, button: SidebarButton) -> None:
+        self.clear_selection()
+        button.setChecked(True)
+        self.dashboard_page.refresh()
+        self.stack.setCurrentWidget(self.dashboard_page)
+
+    def show_accounts_page(self, button: SidebarButton) -> None:
+        self.clear_selection()
+        button.setChecked(True)
+        self.stack.setCurrentWidget(self.accounts_page)
+
+    def show_revision_page(self, button: SidebarButton) -> None:
+        self.clear_selection()
+        button.setChecked(True)
+        self.stack.setCurrentWidget(self.revision_page)
+
+    def show_journals_page(self, button: SidebarButton) -> None:
+        self.clear_selection()
+        button.setChecked(True)
+        self.stack.setCurrentWidget(self.journals_page)
+
+    def show_achat_page(self, button: SidebarButton) -> None:
+        self.clear_selection()
+        button.setChecked(True)
+        self.stack.setCurrentWidget(self.achat_page)
+
+    def show_suppliers_page(self, button: SidebarButton) -> None:
+        self.clear_selection()
+        button.setChecked(True)
+        self.stack.setCurrentWidget(self.suppliers_page)
+
+    def show_ventes_page(self, button: SidebarButton) -> None:
+        self.clear_selection()
+        button.setChecked(True)
+        self.stack.setCurrentWidget(self.ventes_page)
+
+    def open_from_dashboard(self, name: str) -> None:
+        btn = self.compta_buttons.get(name)
+        if btn:
+            self.display_content(f"Comptabilité : {name}", btn)
+
+    def show_settings(self, button: SidebarButton) -> None:
+        self.clear_selection()
+        button.setChecked(True)
+        self.stack.setCurrentWidget(self.settings_page)
+
+    def _load_settings(self) -> dict:
+        try:
+            return json.loads(SETTINGS_FILE.read_text(encoding="utf-8"))
+        except Exception:
+            return {}
+
+    def save_settings(self) -> None:
+        try:
+            SETTINGS_FILE.write_text(
+                json.dumps(self.settings, indent=2, ensure_ascii=False),
+                encoding="utf-8",
+            )
+        except Exception as e:
+            print_safe(f"Could not save settings: {e}")
+
+
+class AppContext:
+    def __init__(self, mw: MainWindow):
+        self.mw = mw
+        self.root_dir = PROJECT_ROOT
+
+    def apply_theme(self, theme: str):
+        if self.mw.theme:
+            self.mw.theme.apply(theme)
+        self.mw.settings["theme"] = theme
+        self.mw.save_settings()
+
+    def current_theme(self) -> str:
+        return self.mw.settings.get("theme", "dark")
+
+    def log(self, msg: str):
+        print_safe(msg)
+
+
+
+if __name__ == "__main__":
+    import faulthandler, pathlib
+
+    path = pathlib.Path("crash.log")
+    try:
+        faulthandler.enable(all_threads=True)
+        faulthandler.dump_traceback_later(30, repeat=True, file=open_utf8(path, "a"))
+    except Exception:
+        pass
+
+    app = QApplication(sys.argv)
+    try:
+        import localapp.resources_rc  # noqa: F401
+    except Exception:
+        pass
+    theme = ThemeManager(app)
+    interface = MainWindow(theme)
+    interface.show()
+    sys.exit(app.exec())
+
+### >>> localapp/icons/achat.svg (3 lignes)
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
+</svg>
+
+### >>> localapp/icons/bilan.svg (3 lignes)
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
+</svg>
+
+### >>> localapp/icons/dashboard.svg (3 lignes)
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
+</svg>
+
+### >>> localapp/icons/grand_livre.svg (3 lignes)
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
+</svg>
+
+### >>> localapp/icons/journal.svg (3 lignes)
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
+</svg>
+
+### >>> localapp/icons/profile.svg (3 lignes)
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
+</svg>
+
+### >>> localapp/icons/resultat.svg (3 lignes)
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
+</svg>
+
+### >>> localapp/icons/scraping.svg (3 lignes)
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
+</svg>
+
+### >>> localapp/icons/settings.svg (3 lignes)
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
+</svg>
+
+### >>> localapp/icons/text.svg (3 lignes)
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
+</svg>
+
+### >>> localapp/icons/ventes.svg (3 lignes)
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
+</svg>
+
+### >>> localapp/log_safe.py (31 lignes)
+# -*- coding: utf-8 -*-
+# localapp/log_safe.py
+import sys
+from typing import Any
+
+
+def _safe_write(stream, text: str):
+    try:
+        stream.write(text + "\n")
+    except Exception:
+        enc = getattr(stream, "encoding", None) or "utf-8"
+        stream.write(text.encode(enc, "backslashreplace").decode(enc) + "\n")
+
+
+def print_safe(*args: Any, sep: str=" ", end: str="\n"):
+    out = getattr(sys, "stdout", None)
+    if not out:
+        return
+    s = sep.join("" if a is None else str(a) for a in args)
+    if end and not s.endswith(end):
+        s = s + end
+    try:
+        out.write(s)
+    except Exception:
+        _safe_write(out, s.rstrip("\n"))
+
+
+def open_utf8(path: str, mode: str="r"):
+    if "b" in mode:
+        return open(path, mode)
+    return open(path, mode, encoding="utf-8", errors="replace")
+
+### >>> localapp/pages/__init__.py (0 lignes)
+
+
+### >>> localapp/pages/settings_page.py (152 lignes)
+# localapp/pages/settings_page.py
+from pathlib import Path
+import os, sys
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QPushButton,
+    QPlainTextEdit,
+    QLabel,
+    QCheckBox,
+    QGroupBox,
+)
+from PySide6.QtCore import QProcess, Qt
+from localapp.utils_collect import detect_project_root, build_copy_txt
+try:
+    from localapp.ui_animations import toast
+except Exception:
+    toast = lambda *a, **k: None
+
+class SettingsPage(QWidget):
+    def __init__(self, app_ctx, parent=None):
+        """
+        app_ctx: objet contenant au moins:
+          - root_dir (Path): racine du projet (cwd du git pull)
+          - apply_theme(theme: str): applique 'dark' ou 'light' à l'app et persiste dans settings.json
+          - current_theme() -> str: retourne 'dark' ou 'light'
+          - log(msg: str): (optionnel) fonction de log globale
+        """
+        super().__init__(parent)
+        self.app_ctx = app_ctx
+        self.proc = None
+
+        root = QVBoxLayout(self)
+
+        # --- Ligne boutons d'action ---
+        actions = QGroupBox("Actions")
+        a_layout = QHBoxLayout(actions)
+
+        self.btn_update_app = QPushButton("Mettre à jour l’app")
+        self.btn_restart    = QPushButton("Redémarrer")
+        self.btn_update_txt = QPushButton("Mettre à jour le txt")
+
+        a_layout.addWidget(self.btn_update_app)
+        a_layout.addWidget(self.btn_restart)
+        a_layout.addWidget(self.btn_update_txt)
+
+        # --- Switch thème dans Paramètres ---
+        theme_box = QGroupBox("Apparence")
+        t_layout = QHBoxLayout(theme_box)
+        self.chk_dark = QCheckBox("Mode sombre")
+        self.lbl_theme = QLabel("")  # affichera "Mode sombre" / "Mode clair"
+        self.chk_dark.setChecked(self.app_ctx.current_theme() == "dark")
+        self._update_theme_label()
+        t_layout.addWidget(self.chk_dark)
+        t_layout.addWidget(self.lbl_theme)
+        t_layout.addStretch(1)
+
+        # --- Console ---
+        console_box = QGroupBox("Console")
+        c_layout = QVBoxLayout(console_box)
+        self.console = QPlainTextEdit()
+        self.console.setReadOnly(True)
+        c_layout.addWidget(self.console)
+
+        # Assemblage
+        root.addWidget(actions)
+        root.addWidget(theme_box)
+        root.addWidget(console_box)
+        root.addStretch(1)
+
+        # Signals
+        self.btn_update_app.clicked.connect(self._on_update_app)
+        self.btn_restart.clicked.connect(self._on_restart)
+
+        # Connexion idempotente au slot _on_update_copy_txt
+        try:
+            self.btn_update_txt.clicked.disconnect(self._on_update_copy_txt)
+        except TypeError:
+            # Aucune connexion existante : on ignore
+            pass
+
+        self.btn_update_txt.clicked.connect(
+            self._on_update_copy_txt,
+            Qt.ConnectionType.UniqueConnection
+        )
+        self.chk_dark.stateChanged.connect(self._on_theme_toggled)
+
+    # ==== Actions ====
+    def _append(self, text: str):
+        self.console.appendPlainText(text)
+
+    def _run_process(self, program: str, args: list[str], cwd: Path):
+        # Lance un QProcess et pipe stdout/stderr vers la console
+        if self.proc:
+            self.proc.kill()
+            self.proc = None
+        self.proc = QProcess(self)
+        self.proc.setProgram(program)
+        self.proc.setArguments(args)
+        self.proc.setWorkingDirectory(str(cwd))
+        self.proc.setProcessChannelMode(QProcess.MergedChannels)
+        self.proc.readyReadStandardOutput.connect(
+            lambda: self._append(bytes(self.proc.readAllStandardOutput()).decode(errors="replace"))
+        )
+        self.proc.readyReadStandardError.connect(
+            lambda: self._append(bytes(self.proc.readAllStandardError()).decode(errors="replace"))
+        )
+        self.proc.started.connect(lambda: self._append(f"> {program} {' '.join(args)} (cwd={cwd})"))
+        self.proc.finished.connect(lambda code, _status: self._append(f"[exit {code}]"))
+        self.proc.start()
+
+    def _on_update_app(self):
+        # git pull origin main dans la racine du projet
+        root = self.app_ctx.root_dir
+        git = "git.exe" if os.name == "nt" else "git"
+        self._run_process(git, ["pull", "origin", "main"], root)
+
+    def _on_restart(self):
+        self._append("Redémarrage en cours…")
+        # Flush puis relance le process
+        self._restart_app()
+
+    def _on_update_copy_txt(self):
+        # racine du projet
+        root = detect_project_root(Path(__file__).resolve())
+        out_path = root / "copy.txt"
+        stats = build_copy_txt(root, out_path)
+        # log UI
+        try:
+            self.console.appendPlainText(
+                f"copy.txt mis à jour: {stats['files']} fichiers, {stats['bytes']} octets → {stats['out']}"
+            )
+        except Exception:
+            pass
+        toast(self, "copy.txt mis à jour", "success")
+
+    # ==== Thème ====
+    def _update_theme_label(self):
+        self.lbl_theme.setText("Mode sombre" if self.chk_dark.isChecked() else "Mode clair")
+
+    def _on_theme_toggled(self, state):
+        theme = "dark" if self.chk_dark.isChecked() else "light"
+        self.app_ctx.apply_theme(theme)
+        self._update_theme_label()
+        self._append(f"Thème appliqué: {theme}")
+
+    # ==== Restart ====
+    def _restart_app(self):
+        # relance le processus Python courant avec les mêmes arguments
+        python = sys.executable
+        os.execl(python, python, *sys.argv)
+
+### >>> localapp/resources_rc.py (18762 lignes)
+# Resource object code (Python 3)
+# Created by: object code
+# Created by: The Resource Compiler for Qt version 6.9.1
+# WARNING! All changes made in this file will be lost!
+
+from PySide6 import QtCore
+
+qt_resource_data = b"\
+\x00\x00\x05R\
+/\
+* Typo & base */\
+\x0a* { font-family\
+: \x22Inter\x22, \x22Sego\
+e UI\x22, Arial; }\x0a\
+QWidget { backgr\
+ound: #0f1115; c\
+olor: #e7eaf0; }\
+\x0a\x0a/* Boutons */\x0a\
+QPushButton {\x0a  \
+background: #1b1\
+f2a; color: #e7e\
+af0; border: 1px\
+ solid #232838;\x0a\
+  padding: 7px 1\
+2px; border-radi\
+us: 10px;\x0a}\x0aQPus\
+hButton:hover { \
+background: #232\
+838; }\x0aQPushButt\
+on:disabled { co\
+lor:#7c8190; bor\
+der-color:#1b203\
+0; }\x0a\x0a/* LineEdi\
+t/Combo */\x0aQLine\
+Edit, QPlainText\
+Edit, QComboBox,\
+ QSpinBox, QText\
+Edit {\x0a  backgro\
+und: #0c0f14; co\
+lor: #e7eaf0; bo\
+rder:1px solid #\
+232838;\x0a  border\
+-radius: 8px; pa\
+dding: 6px 8px;\x0a\
+}\x0a\x0a/* Tabs */\x0aQT\
+abBar::tab {\x0a  b\
+ackground: trans\
+parent; padding:\
+ 8px 14px; margi\
+n: 0 4px; border\
+-radius: 10px;\x0a}\
+\x0aQTabBar::tab:se\
+lected { backgro\
+und: #1b1f2a; }\x0a\
+QTabWidget::pane\
+ { border-top: 1\
+px solid #232838\
+; }\x0a\x0a/* Table */\
+\x0aQHeaderView::se\
+ction {\x0a  backgr\
+ound:#121621; co\
+lor:#cfd6e6; bor\
+der:1px solid #2\
+32838; padding:6\
+px 8px;\x0a}\x0aQTable\
+View { gridline-\
+color:#232838; s\
+election-backgro\
+und-color:#22314\
+a; }\x0a\x0a/* Progres\
+s */\x0aQProgressBa\
+r { background:#\
+0c0f14; border:1\
+px solid #232838\
+; border-radius:\
+8px; text-align:\
+center; }\x0aQProgr\
+essBar::chunk { \
+background:#3f8c\
+ff; border-radiu\
+s:8px; }\x0a\x0a/* Scr\
+ollbar */\x0aQScrol\
+lBar:vertical { \
+background: #0f1\
+115; width: 12px\
+; margin:0; }\x0aQS\
+crollBar::handle\
+:vertical { back\
+ground:#22314a; \
+border-radius:6p\
+x; min-height: 2\
+4px; }\x0aQScrollBa\
+r::handle:vertic\
+al:hover { backg\
+round:#2a3a59; }\
+\x0a\
+\x00\x00\x04\x9b\
+*\
+ { font-family: \
+\x22Inter\x22, \x22Segoe \
+UI\x22, Arial; }\x0aQW\
+idget { backgrou\
+nd:#f7f8fb; colo\
+r:#0e1726; }\x0aQPu\
+shButton { backg\
+round:#ffffff; c\
+olor:#0e1726; bo\
+rder:1px solid #\
+e2e6ef; padding:\
+7px 12px; border\
+-radius:10px; }\x0a\
+QPushButton:hove\
+r { background:#\
+f1f3f9; }\x0aQLineE\
+dit, QPlainTextE\
+dit, QComboBox, \
+QSpinBox, QTextE\
+dit {\x0a  backgrou\
+nd:#ffffff; colo\
+r:#0e1726; borde\
+r:1px solid #e2e\
+6ef; border-radi\
+us:8px; padding:\
+6px 8px;\x0a}\x0aQTabB\
+ar::tab { backgr\
+ound:transparent\
+; padding:8px 14\
+px; margin:0 4px\
+; border-radius:\
+10px; }\x0aQTabBar:\
+:tab:selected { \
+background:#ffff\
+ff; border:1px s\
+olid #e2e6ef; }\x0a\
+QTabWidget::pane\
+ { border-top:1p\
+x solid #e2e6ef;\
+ }\x0aQHeaderView::\
+section { backgr\
+ound:#ffffff; co\
+lor:#223; border\
+:1px solid #e2e6\
+ef; padding:6px \
+8px; }\x0aQTableVie\
+w { gridline-col\
+or:#e2e6ef; sele\
+ction-background\
+-color:#e5efff; \
+}\x0aQProgressBar {\
+ background:#fff\
+fff; border:1px \
+solid #e2e6ef; b\
+order-radius:8px\
+; text-align:cen\
+ter; }\x0aQProgress\
+Bar::chunk { bac\
+kground:#2463eb;\
+ border-radius:8\
+px; }\x0aQScrollBar\
+:vertical { back\
+ground:#f7f8fb; \
+width:12px; marg\
+in:0; }\x0aQScrollB\
+ar::handle:verti\
+cal { background\
+:#dbe3f3; border\
+-radius:6px; min\
+-height:24px; }\x0a\
+QScrollBar::hand\
+le:vertical:hove\
+r { background:#\
+cbd7f0; }\x0a\
+\x00\x04n\xdd\
+\x0a\
+\x0a\x0a\x0a\x0a\x0a\x0a\x0a<!DOCTYPE\
+ html>\x0a<html\x0a  l\
+ang=\x22en\x22\x0a  \x0a  da\
+ta-color-mode=\x22a\
+uto\x22 data-light-\
+theme=\x22light\x22 da\
+ta-dark-theme=\x22d\
+ark\x22\x0a  data-a11y\
+-animated-images\
+=\x22system\x22 data-a\
+11y-link-underli\
+nes=\x22true\x22\x0a  \x0a  \
+>\x0a\x0a\x0a\x0a\x0a  <head>\x0a \
+   <meta charset\
+=\x22utf-8\x22>\x0a  <lin\
+k rel=\x22dns-prefe\
+tch\x22 href=\x22https\
+://github.github\
+assets.com\x22>\x0a  <\
+link rel=\x22dns-pr\
+efetch\x22 href=\x22ht\
+tps://avatars.gi\
+thubusercontent.\
+com\x22>\x0a  <link re\
+l=\x22dns-prefetch\x22\
+ href=\x22https://g\
+ithub-cloud.s3.a\
+mazonaws.com\x22>\x0a \
+ <link rel=\x22dns-\
+prefetch\x22 href=\x22\
+https://user-ima\
+ges.githubuserco\
+ntent.com/\x22>\x0a  <\
+link rel=\x22precon\
+nect\x22 href=\x22http\
+s://github.githu\
+bassets.com\x22 cro\
+ssorigin>\x0a  <lin\
+k rel=\x22preconnec\
+t\x22 href=\x22https:/\
+/avatars.githubu\
+sercontent.com\x22>\
+\x0a\x0a      <link cr\
+ossorigin=\x22anony\
+mous\x22 rel=\x22prelo\
+ad\x22 as=\x22script\x22 \
+href=\x22https://gi\
+thub.githubasset\
+s.com/assets/glo\
+bal-banner-disab\
+le-59fed23c5fc1.\
+js\x22 />\x0a\x0a  <link \
+rel=\x22preload\x22 hr\
+ef=\x22https://gith\
+ub.githubassets.\
+com/assets/mona-\
+sans-d1bf285e9b9\
+b.woff2\x22 as=\x22fon\
+t\x22 type=\x22font/wo\
+ff2\x22 crossorigin\
+>\x0a\x0a\x0a  <link cros\
+sorigin=\x22anonymo\
+us\x22 media=\x22all\x22 \
+rel=\x22stylesheet\x22\
+ href=\x22https://g\
+ithub.githubasse\
+ts.com/assets/li\
+ght-6448649c7147\
+.css\x22 /><link cr\
+ossorigin=\x22anony\
+mous\x22 media=\x22all\
+\x22 rel=\x22styleshee\
+t\x22 href=\x22https:/\
+/github.githubas\
+sets.com/assets/\
+light_high_contr\
+ast-42fc7e3b06b7\
+.css\x22 /><link cr\
+ossorigin=\x22anony\
+mous\x22 media=\x22all\
+\x22 rel=\x22styleshee\
+t\x22 href=\x22https:/\
+/github.githubas\
+sets.com/assets/\
+dark-d17b946fc2c\
+5.css\x22 /><link c\
+rossorigin=\x22anon\
+ymous\x22 media=\x22al\
+l\x22 rel=\x22styleshe\
+et\x22 href=\x22https:\
+//github.githuba\
+ssets.com/assets\
+/dark_high_contr\
+ast-1b924088c83a\
+.css\x22 /><link da\
+ta-color-theme=\x22\
+light\x22 crossorig\
+in=\x22anonymous\x22 m\
+edia=\x22all\x22 rel=\x22\
+stylesheet\x22 data\
+-href=\x22https://g\
+ithub.githubasse\
+ts.com/assets/li\
+ght-6448649c7147\
+.css\x22 /><link da\
+ta-color-theme=\x22\
+light_high_contr\
+ast\x22 crossorigin\
+=\x22anonymous\x22 med\
+ia=\x22all\x22 rel=\x22st\
+ylesheet\x22 data-h\
+ref=\x22https://git\
+hub.githubassets\
+.com/assets/ligh\
+t_high_contrast-\
+42fc7e3b06b7.css\
+\x22 /><link data-c\
+olor-theme=\x22ligh\
+t_colorblind\x22 cr\
+ossorigin=\x22anony\
+mous\x22 media=\x22all\
+\x22 rel=\x22styleshee\
+t\x22 data-href=\x22ht\
+tps://github.git\
+hubassets.com/as\
+sets/light_color\
+blind-44cfaf0c8f\
+7b.css\x22 /><link \
+data-color-theme\
+=\x22light_colorbli\
+nd_high_contrast\
+\x22 crossorigin=\x22a\
+nonymous\x22 media=\
+\x22all\x22 rel=\x22style\
+sheet\x22 data-href\
+=\x22https://github\
+.githubassets.co\
+m/assets/light_c\
+olorblind_high_c\
+ontrast-979217ef\
+d93e.css\x22 /><lin\
+k data-color-the\
+me=\x22light_tritan\
+opia\x22 crossorigi\
+n=\x22anonymous\x22 me\
+dia=\x22all\x22 rel=\x22s\
+tylesheet\x22 data-\
+href=\x22https://gi\
+thub.githubasset\
+s.com/assets/lig\
+ht_tritanopia-4d\
+5383026bfa.css\x22 \
+/><link data-col\
+or-theme=\x22light_\
+tritanopia_high_\
+contrast\x22 crosso\
+rigin=\x22anonymous\
+\x22 media=\x22all\x22 re\
+l=\x22stylesheet\x22 d\
+ata-href=\x22https:\
+//github.githuba\
+ssets.com/assets\
+/light_tritanopi\
+a_high_contrast-\
+ff6ff8532348.css\
+\x22 /><link data-c\
+olor-theme=\x22dark\
+\x22 crossorigin=\x22a\
+nonymous\x22 media=\
+\x22all\x22 rel=\x22style\
+sheet\x22 data-href\
+=\x22https://github\
+.githubassets.co\
+m/assets/dark-d1\
+7b946fc2c5.css\x22 \
+/><link data-col\
+or-theme=\x22dark_h\
+igh_contrast\x22 cr\
+ossorigin=\x22anony\
+mous\x22 media=\x22all\
+\x22 rel=\x22styleshee\
+t\x22 data-href=\x22ht\
+tps://github.git\
+hubassets.com/as\
+sets/dark_high_c\
+ontrast-1b924088\
+c83a.css\x22 /><lin\
+k data-color-the\
+me=\x22dark_colorbl\
+ind\x22 crossorigin\
+=\x22anonymous\x22 med\
+ia=\x22all\x22 rel=\x22st\
+ylesheet\x22 data-h\
+ref=\x22https://git\
+hub.githubassets\
+.com/assets/dark\
+_colorblind-6547\
+86382462.css\x22 />\
+<link data-color\
+-theme=\x22dark_col\
+orblind_high_con\
+trast\x22 crossorig\
+in=\x22anonymous\x22 m\
+edia=\x22all\x22 rel=\x22\
+stylesheet\x22 data\
+-href=\x22https://g\
+ithub.githubasse\
+ts.com/assets/da\
+rk_colorblind_hi\
+gh_contrast-ecca\
+008c6f6e.css\x22 />\
+<link data-color\
+-theme=\x22dark_tri\
+tanopia\x22 crossor\
+igin=\x22anonymous\x22\
+ media=\x22all\x22 rel\
+=\x22stylesheet\x22 da\
+ta-href=\x22https:/\
+/github.githubas\
+sets.com/assets/\
+dark_tritanopia-\
+fff376053989.css\
+\x22 /><link data-c\
+olor-theme=\x22dark\
+_tritanopia_high\
+_contrast\x22 cross\
+origin=\x22anonymou\
+s\x22 media=\x22all\x22 r\
+el=\x22stylesheet\x22 \
+data-href=\x22https\
+://github.github\
+assets.com/asset\
+s/dark_tritanopi\
+a_high_contrast-\
+49adf52571e5.css\
+\x22 /><link data-c\
+olor-theme=\x22dark\
+_dimmed\x22 crossor\
+igin=\x22anonymous\x22\
+ media=\x22all\x22 rel\
+=\x22stylesheet\x22 da\
+ta-href=\x22https:/\
+/github.githubas\
+sets.com/assets/\
+dark_dimmed-66d9\
+7c13c98a.css\x22 />\
+<link data-color\
+-theme=\x22dark_dim\
+med_high_contras\
+t\x22 crossorigin=\x22\
+anonymous\x22 media\
+=\x22all\x22 rel=\x22styl\
+esheet\x22 data-hre\
+f=\x22https://githu\
+b.githubassets.c\
+om/assets/dark_d\
+immed_high_contr\
+ast-c58f1d0432b9\
+.css\x22 />\x0a\x0a  <sty\
+le type=\x22text/cs\
+s\x22>\x0a    :root {\x0a\
+      --tab-size\
+-preference: 4;\x0a\
+    }\x0a\x0a    pre, \
+code {\x0a      tab\
+-size: var(--tab\
+-size-preference\
+);\x0a    }\x0a  </sty\
+le>\x0a\x0a    <link c\
+rossorigin=\x22anon\
+ymous\x22 media=\x22al\
+l\x22 rel=\x22styleshe\
+et\x22 href=\x22https:\
+//github.githuba\
+ssets.com/assets\
+/primer-primitiv\
+es-dc7ca6859caf.\
+css\x22 />\x0a    <lin\
+k crossorigin=\x22a\
+nonymous\x22 media=\
+\x22all\x22 rel=\x22style\
+sheet\x22 href=\x22htt\
+ps://github.gith\
+ubassets.com/ass\
+ets/primer-e11b5\
+0dc0d94.css\x22 />\x0a\
+    <link crosso\
+rigin=\x22anonymous\
+\x22 media=\x22all\x22 re\
+l=\x22stylesheet\x22 h\
+ref=\x22https://git\
+hub.githubassets\
+.com/assets/glob\
+al-b2440ba1b569.\
+css\x22 />\x0a    <lin\
+k crossorigin=\x22a\
+nonymous\x22 media=\
+\x22all\x22 rel=\x22style\
+sheet\x22 href=\x22htt\
+ps://github.gith\
+ubassets.com/ass\
+ets/github-ce246\
+942b490.css\x22 />\x0a\
+  <link crossori\
+gin=\x22anonymous\x22 \
+media=\x22all\x22 rel=\
+\x22stylesheet\x22 hre\
+f=\x22https://githu\
+b.githubassets.c\
+om/assets/reposi\
+tory-06e1b367189\
+c.css\x22 />\x0a\x0a  \x0a\x0a\x0a\
+  <script type=\x22\
+application/json\
+\x22 id=\x22client-env\
+\x22>{\x22locale\x22:\x22en\x22\
+,\x22featureFlags\x22:\
+[\x22alternate_user\
+_config_repo\x22,\x22a\
+pi_insights_show\
+_missing_data_ba\
+nner\x22,\x22attestati\
+ons_filtering\x22,\x22\
+attestations_sor\
+ting\x22,\x22client_ve\
+rsion_header\x22,\x22c\
+ode_scanning_sec\
+urity_configurat\
+ion_ternary_stat\
+e\x22,\x22codespaces_p\
+rebuild_region_t\
+arget_update\x22,\x22c\
+ontact_requests_\
+implicit_opt_in\x22\
+,\x22contentful_lp_\
+copilot_extensio\
+ns\x22,\x22contentful_\
+lp_flex_features\
+\x22,\x22contentful_lp\
+_footnotes\x22,\x22cop\
+ilot_chat_attach\
+_multiple_images\
+\x22,\x22copilot_chat_\
+file_redirect\x22,\x22\
+copilot_chat_gro\
+up_notifications\
+\x22,\x22copilot_chat_\
+reduce_quota_che\
+cks\x22,\x22copilot_ch\
+at_search_bar_re\
+direct\x22,\x22copilot\
+_chat_vision_in_\
+claude\x22,\x22copilot\
+_chat_vision_ski\
+p_thread_create\x22\
+,\x22copilot_custom\
+_copilots_featur\
+e_preview\x22,\x22copi\
+lot_custom_copil\
+ots_images\x22,\x22cop\
+ilot_duplicate_t\
+hread\x22,\x22copilot_\
+free_to_paid_tel\
+em\x22,\x22copilot_ftp\
+_hyperspace_upgr\
+ade_prompt\x22,\x22cop\
+ilot_ftp_setting\
+s_upgrade\x22,\x22copi\
+lot_ftp_upgrade_\
+to_pro_from_mode\
+ls\x22,\x22copilot_ftp\
+_your_copilot_se\
+ttings\x22,\x22copilot\
+_gpt5_promotion_\
+banner\x22,\x22copilot\
+_immersive_agent\
+_branch_selectio\
+n\x22,\x22copilot_imme\
+rsive_structured\
+_model_picker\x22,\x22\
+copilot_no_float\
+ing_button\x22,\x22cop\
+ilot_read_shared\
+_conversation\x22,\x22\
+copilot_spaces_i\
+nput_menu_select\
+\x22,\x22copilot_space\
+s_permissions_ta\
+b\x22,\x22copilot_spac\
+es_repo_context\x22\
+,\x22copilot_spaces\
+_upsert_reload_i\
+n_background\x22,\x22c\
+opilot_spaces_v3\
+_ui\x22,\x22copilot_sp\
+ark_allow_empty_\
+commit\x22,\x22copilot\
+_spark_single_us\
+er_iteration\x22,\x22c\
+opilot_spark_use\
+_billing_headers\
+\x22,\x22copilot_spark\
+_write_iteration\
+_history_to_git\x22\
+,\x22copilot_task_o\
+riented_assistiv\
+e_prompts\x22,\x22copi\
+lot_workbench_ag\
+ent_seed_tool\x22,\x22\
+copilot_workbenc\
+h_cache\x22,\x22copilo\
+t_workbench_conn\
+ection_reload_ba\
+nner\x22,\x22copilot_w\
+orkbench_preview\
+_analytics\x22,\x22cop\
+ilot_workbench_r\
+atelimit_fallbac\
+k\x22,\x22copilot_work\
+bench_refresh_on\
+_wsod\x22,\x22copilot_\
+workbench_synthe\
+tic_generation\x22,\
+\x22custom_copilots\
+_128k_window\x22,\x22c\
+ustom_copilots_c\
+api_mode\x22,\x22custo\
+m_copilots_file_\
+uploads\x22,\x22direct\
+_to_salesforce\x22,\
+\x22dotcom_chat_cli\
+ent_side_skills\x22\
+,\x22failbot_report\
+_error_react_app\
+s_on_page\x22,\x22ghos\
+t_pilot_confiden\
+ce_truncation_25\
+\x22,\x22ghost_pilot_c\
+onfidence_trunca\
+tion_40\x22,\x22hpc_im\
+prove_dom_insert\
+ion_observer\x22,\x22i\
+nsert_before_pat\
+ch\x22,\x22issue_depen\
+dencies_issue_in\
+dex_pill_click\x22,\
+\x22issue_fields_re\
+port_usage\x22,\x22iss\
+ues_preserve_tok\
+ens_in_urls\x22,\x22is\
+sues_react_blur_\
+item_picker_on_c\
+lose\x22,\x22issues_re\
+act_bots_timelin\
+e_pagination\x22,\x22i\
+ssues_react_proh\
+ibit_title_fallb\
+ack\x22,\x22issues_rea\
+ct_remove_placeh\
+olders\x22,\x22lifecyc\
+le_label_name_up\
+dates\x22,\x22link_con\
+tact_sales_swp_m\
+arketo\x22,\x22marketi\
+ng_fullstory_sam\
+pling\x22,\x22marketin\
+g_pages_search_e\
+xplore_provider\x22\
+,\x22memex_mwl_filt\
+er_field_delimit\
+er\x22,\x22migrate_toa\
+sts_to_banners_w\
+eb_notifications\
+\x22,\x22notifications\
+_accessibility_d\
+ialog_reviewers_\
+migration\x22,\x22prim\
+er_react_segment\
+ed_control_toolt\
+ip\x22,\x22record_sso_\
+banner_metrics\x22,\
+\x22remove_child_pa\
+tch\x22,\x22sample_net\
+work_conn_type\x22,\
+\x22scheduled_remin\
+ders_updated_lim\
+its\x22,\x22site_copil\
+ot_plans_emphasi\
+ze_pro\x22,\x22site_ho\
+mepage_contentfu\
+l\x22,\x22site_msbuild\
+_hide_integratio\
+ns\x22,\x22site_msbuil\
+d_launch\x22,\x22site_\
+msbuild_webgl_he\
+ro\x22,\x22spark_commi\
+t_on_default_bra\
+nch\x22,\x22spark_sync\
+_repository_afte\
+r_iteration\x22,\x22sw\
+p_enterprise_con\
+tact_form\x22,\x22view\
+screen_sandbox\x22,\
+\x22workbench_defau\
+lt_sonnet4\x22,\x22wor\
+kbench_store_rea\
+donly\x22],\x22copilot\
+ApiOverrideUrl\x22:\
+null}</script>\x0a<\
+script crossorig\
+in=\x22anonymous\x22 t\
+ype=\x22application\
+/javascript\x22 src\
+=\x22https://github\
+.githubassets.co\
+m/assets/high-co\
+ntrast-cookie-43\
+044cc98e23.js\x22><\
+/script>\x0a<script\
+ crossorigin=\x22an\
+onymous\x22 type=\x22a\
+pplication/javas\
+cript\x22 src=\x22http\
+s://github.githu\
+bassets.com/asse\
+ts/wp-runtime-92\
+bc4a718d13.js\x22 d\
+efer=\x22defer\x22></s\
+cript>\x0a<script c\
+rossorigin=\x22anon\
+ymous\x22 type=\x22app\
+lication/javascr\
+ipt\x22 src=\x22https:\
+//github.githuba\
+ssets.com/assets\
+/vendors-node_mo\
+dules_oddbird_po\
+pover-polyfill_d\
+ist_popover-fn_j\
+s-a8c266e5f126.j\
+s\x22 defer=\x22defer\x22\
+></script>\x0a<scri\
+pt crossorigin=\x22\
+anonymous\x22 type=\
+\x22application/jav\
+ascript\x22 src=\x22ht\
+tps://github.git\
+hubassets.com/as\
+sets/vendors-nod\
+e_modules_github\
+_mini-throttle_d\
+ist_index_js-nod\
+e_modules_stackt\
+race-parser_dist\
+_s-1d3d52-639793\
+92733d.js\x22 defer\
+=\x22defer\x22></scrip\
+t>\x0a<script cross\
+origin=\x22anonymou\
+s\x22 type=\x22applica\
+tion/javascript\x22\
+ src=\x22https://gi\
+thub.githubasset\
+s.com/assets/ui_\
+packages_failbot\
+_failbot_ts-0825\
+a7514813.js\x22 def\
+er=\x22defer\x22></scr\
+ipt>\x0a<script cro\
+ssorigin=\x22anonym\
+ous\x22 type=\x22appli\
+cation/javascrip\
+t\x22 src=\x22https://\
+github.githubass\
+ets.com/assets/e\
+nvironment-f35dd\
+522ae2e.js\x22 defe\
+r=\x22defer\x22></scri\
+pt>\x0a<script cros\
+sorigin=\x22anonymo\
+us\x22 type=\x22applic\
+ation/javascript\
+\x22 src=\x22https://g\
+ithub.githubasse\
+ts.com/assets/ve\
+ndors-node_modul\
+es_primer_behavi\
+ors_dist_esm_ind\
+ex_mjs-c44edfed7\
+f0d.js\x22 defer=\x22d\
+efer\x22></script>\x0a\
+<script crossori\
+gin=\x22anonymous\x22 \
+type=\x22applicatio\
+n/javascript\x22 sr\
+c=\x22https://githu\
+b.githubassets.c\
+om/assets/vendor\
+s-node_modules_g\
+ithub_selector-o\
+bserver_dist_ind\
+ex_esm_js-3bc735\
+efc2fb.js\x22 defer\
+=\x22defer\x22></scrip\
+t>\x0a<script cross\
+origin=\x22anonymou\
+s\x22 type=\x22applica\
+tion/javascript\x22\
+ src=\x22https://gi\
+thub.githubasset\
+s.com/assets/ven\
+dors-node_module\
+s_github_relativ\
+e-time-element_d\
+ist_index_js-e43\
+198c9c229.js\x22 de\
+fer=\x22defer\x22></sc\
+ript>\x0a<script cr\
+ossorigin=\x22anony\
+mous\x22 type=\x22appl\
+ication/javascri\
+pt\x22 src=\x22https:/\
+/github.githubas\
+sets.com/assets/\
+vendors-node_mod\
+ules_github_auto\
+-complete-elemen\
+t_dist_index_js-\
+node_modules_git\
+hub_catalyst_-0d\
+7d60-e7c651f2037\
+f.js\x22 defer=\x22def\
+er\x22></script>\x0a<s\
+cript crossorigi\
+n=\x22anonymous\x22 ty\
+pe=\x22application/\
+javascript\x22 src=\
+\x22https://github.\
+githubassets.com\
+/assets/vendors-\
+node_modules_git\
+hub_text-expande\
+r-element_dist_i\
+ndex_js-e50fb7a5\
+fe8c.js\x22 defer=\x22\
+defer\x22></script>\
+\x0a<script crossor\
+igin=\x22anonymous\x22\
+ type=\x22applicati\
+on/javascript\x22 s\
+rc=\x22https://gith\
+ub.githubassets.\
+com/assets/vendo\
+rs-node_modules_\
+github_filter-in\
+put-element_dist\
+_index_js-node_m\
+odules_github_re\
+mote-inp-665e70-\
+03ac9ce9c364.js\x22\
+ defer=\x22defer\x22><\
+/script>\x0a<script\
+ crossorigin=\x22an\
+onymous\x22 type=\x22a\
+pplication/javas\
+cript\x22 src=\x22http\
+s://github.githu\
+bassets.com/asse\
+ts/vendors-node_\
+modules_github_m\
+arkdown-toolbar-\
+element_dist_ind\
+ex_js-6a8c7d9a08\
+fe.js\x22 defer=\x22de\
+fer\x22></script>\x0a<\
+script crossorig\
+in=\x22anonymous\x22 t\
+ype=\x22application\
+/javascript\x22 src\
+=\x22https://github\
+.githubassets.co\
+m/assets/vendors\
+-node_modules_gi\
+thub_file-attach\
+ment-element_dis\
+t_index_js-node_\
+modules_primer_v\
+iew-co-777ce2-1d\
+d746215ae3.js\x22 d\
+efer=\x22defer\x22></s\
+cript>\x0a<script c\
+rossorigin=\x22anon\
+ymous\x22 type=\x22app\
+lication/javascr\
+ipt\x22 src=\x22https:\
+//github.githuba\
+ssets.com/assets\
+/github-elements\
+-5cffbf1169b0.js\
+\x22 defer=\x22defer\x22>\
+</script>\x0a<scrip\
+t crossorigin=\x22a\
+nonymous\x22 type=\x22\
+application/java\
+script\x22 src=\x22htt\
+ps://github.gith\
+ubassets.com/ass\
+ets/element-regi\
+stry-7aeb4222619\
+f.js\x22 defer=\x22def\
+er\x22></script>\x0a<s\
+cript crossorigi\
+n=\x22anonymous\x22 ty\
+pe=\x22application/\
+javascript\x22 src=\
+\x22https://github.\
+githubassets.com\
+/assets/vendors-\
+node_modules_bra\
+intree_browser-d\
+etection_dist_br\
+owser-detection_\
+js-node_modules_\
+githu-bb80ec-422\
+a87d68b40.js\x22 de\
+fer=\x22defer\x22></sc\
+ript>\x0a<script cr\
+ossorigin=\x22anony\
+mous\x22 type=\x22appl\
+ication/javascri\
+pt\x22 src=\x22https:/\
+/github.githubas\
+sets.com/assets/\
+vendors-node_mod\
+ules_lit-html_li\
+t-html_js-b93a87\
+060d31.js\x22 defer\
+=\x22defer\x22></scrip\
+t>\x0a<script cross\
+origin=\x22anonymou\
+s\x22 type=\x22applica\
+tion/javascript\x22\
+ src=\x22https://gi\
+thub.githubasset\
+s.com/assets/ven\
+dors-node_module\
+s_morphdom_dist_\
+morphdom-esm_js-\
+node_modules_swc\
+_helpers_esm__de\
+fine_property_js\
+-457369b2bc79.js\
+\x22 defer=\x22defer\x22>\
+</script>\x0a<scrip\
+t crossorigin=\x22a\
+nonymous\x22 type=\x22\
+application/java\
+script\x22 src=\x22htt\
+ps://github.gith\
+ubassets.com/ass\
+ets/vendors-node\
+_modules_github_\
+turbo_dist_turbo\
+_es2017-esm_js-5\
+95819d3686f.js\x22 \
+defer=\x22defer\x22></\
+script>\x0a<script \
+crossorigin=\x22ano\
+nymous\x22 type=\x22ap\
+plication/javasc\
+ript\x22 src=\x22https\
+://github.github\
+assets.com/asset\
+s/vendors-node_m\
+odules_github_re\
+mote-form_dist_i\
+ndex_js-node_mod\
+ules_delegated-e\
+vents_dist_inde-\
+893f9f-8351bc3b1\
+582.js\x22 defer=\x22d\
+efer\x22></script>\x0a\
+<script crossori\
+gin=\x22anonymous\x22 \
+type=\x22applicatio\
+n/javascript\x22 sr\
+c=\x22https://githu\
+b.githubassets.c\
+om/assets/vendor\
+s-node_modules_g\
+ithub_quote-sele\
+ction_dist_index\
+_js-node_modules\
+_github_session-\
+resume_-d3ee0b-5\
+4a0d20a9ae1.js\x22 \
+defer=\x22defer\x22></\
+script>\x0a<script \
+crossorigin=\x22ano\
+nymous\x22 type=\x22ap\
+plication/javasc\
+ript\x22 src=\x22https\
+://github.github\
+assets.com/asset\
+s/ui_packages_up\
+datable-content_\
+updatable-conten\
+t_ts-1cf7991389b\
+4.js\x22 defer=\x22def\
+er\x22></script>\x0a<s\
+cript crossorigi\
+n=\x22anonymous\x22 ty\
+pe=\x22application/\
+javascript\x22 src=\
+\x22https://github.\
+githubassets.com\
+/assets/app_asse\
+ts_modules_githu\
+b_behaviors_task\
+-list_ts-app_ass\
+ets_modules_gith\
+ub_sso_ts-ui_pac\
+kages-900dde-eef\
+525613171.js\x22 de\
+fer=\x22defer\x22></sc\
+ript>\x0a<script cr\
+ossorigin=\x22anony\
+mous\x22 type=\x22appl\
+ication/javascri\
+pt\x22 src=\x22https:/\
+/github.githubas\
+sets.com/assets/\
+app_assets_modul\
+es_github_sticky\
+-scroll-into-vie\
+w_ts-c9618dd6662\
+a.js\x22 defer=\x22def\
+er\x22></script>\x0a<s\
+cript crossorigi\
+n=\x22anonymous\x22 ty\
+pe=\x22application/\
+javascript\x22 src=\
+\x22https://github.\
+githubassets.com\
+/assets/app_asse\
+ts_modules_githu\
+b_behaviors_ajax\
+-error_ts-app_as\
+sets_modules_git\
+hub_behaviors_in\
+clude-d0d0a6-f1c\
+40b7e9d92.js\x22 de\
+fer=\x22defer\x22></sc\
+ript>\x0a<script cr\
+ossorigin=\x22anony\
+mous\x22 type=\x22appl\
+ication/javascri\
+pt\x22 src=\x22https:/\
+/github.githubas\
+sets.com/assets/\
+app_assets_modul\
+es_github_behavi\
+ors_commenting_e\
+dit_ts-app_asset\
+s_modules_github\
+_behaviors_ht-83\
+c235-54f5b4a9031\
+5.js\x22 defer=\x22def\
+er\x22></script>\x0a<s\
+cript crossorigi\
+n=\x22anonymous\x22 ty\
+pe=\x22application/\
+javascript\x22 src=\
+\x22https://github.\
+githubassets.com\
+/assets/behavior\
+s-d526db371626.j\
+s\x22 defer=\x22defer\x22\
+></script>\x0a<scri\
+pt crossorigin=\x22\
+anonymous\x22 type=\
+\x22application/jav\
+ascript\x22 src=\x22ht\
+tps://github.git\
+hubassets.com/as\
+sets/vendors-nod\
+e_modules_delega\
+ted-events_dist_\
+index_js-node_mo\
+dules_github_cat\
+alyst_lib_index_\
+js-ef6d0f-3a56c0\
+6b9620.js\x22 defer\
+=\x22defer\x22></scrip\
+t>\x0a<script cross\
+origin=\x22anonymou\
+s\x22 type=\x22applica\
+tion/javascript\x22\
+ src=\x22https://gi\
+thub.githubasset\
+s.com/assets/not\
+ifications-globa\
+l-33a139fab0d9.j\
+s\x22 defer=\x22defer\x22\
+></script>\x0a  \x0a\x0a \
+ <title>Page not\
+ found \xc2\xb7 GitHub\
+ \xc2\xb7 GitHub</titl\
+e>\x0a\x0a\x0a\x0a  <meta na\
+me=\x22route-patter\
+n\x22 content=\x22/:us\
+er_id/:repositor\
+y/raw/*name(/*pa\
+th)\x22 data-turbo-\
+transient>\x0a  <me\
+ta name=\x22route-c\
+ontroller\x22 conte\
+nt=\x22blob\x22 data-t\
+urbo-transient>\x0a\
+  <meta name=\x22ro\
+ute-action\x22 cont\
+ent=\x22raw\x22 data-t\
+urbo-transient>\x0a\
+  <meta name=\x22fe\
+tch-nonce\x22 conte\
+nt=\x22v2:afb3744b-\
+1a4d-0bb1-77df-8\
+61c464a42ea\x22>\x0a\x0a \
+   \x0a  <meta name\
+=\x22current-catalo\
+g-service-hash\x22 \
+content=\x22f3abb0c\
+c802f3d7b95fc876\
+2b94bdcb13bf3963\
+4c40c357301c4aa1\
+d67a256fb\x22>\x0a\x0a\x0a  \
+<meta name=\x22requ\
+est-id\x22 content=\
+\x228D49:1679BF:276\
+CC:32CC5:689D382\
+9\x22 data-turbo-tr\
+ansient=\x22true\x22 /\
+><meta name=\x22htm\
+l-safe-nonce\x22 co\
+ntent=\x22e29633ef1\
+42261e5b30d523e4\
+b987bf4be52bad7d\
+fc06022dfb766e56\
+2814762\x22 data-tu\
+rbo-transient=\x22t\
+rue\x22 /><meta nam\
+e=\x22visitor-paylo\
+ad\x22 content=\x22eyJ\
+yZWZlcnJlciI6bnV\
+sbCwicmVxdWVzdF9\
+pZCI6IjhENDk6MTY\
+3OUJGOjI3NkNDOjM\
+yQ0M1OjY4OUQzODI\
+5IiwidmlzaXRvcl9\
+pZCI6IjMzMzg2NjY\
+1NjU1NzU3MTg5NTM\
+iLCJyZWdpb25fZWR\
+nZSI6ImlhZCIsInJ\
+lZ2lvbl9yZW5kZXI\
+iOiJpYWQifQ==\x22 d\
+ata-turbo-transi\
+ent=\x22true\x22 /><me\
+ta name=\x22visitor\
+-hmac\x22 content=\x22\
+b508379bcadc506a\
+e6c3aefbb2ae66a8\
+c839826a00b5205a\
+05610db43854ad23\
+\x22 data-turbo-tra\
+nsient=\x22true\x22 />\
+\x0a\x0a\x0a    <meta nam\
+e=\x22hovercard-sub\
+ject-tag\x22 conten\
+t=\x22repository:10\
+1033179\x22 data-tu\
+rbo-transient>\x0a\x0a\
+\x0a  <meta name=\x22g\
+ithub-keyboard-s\
+hortcuts\x22 conten\
+t=\x22copilot\x22 data\
+-turbo-transient\
+=\x22true\x22 />\x0a  \x0a\x0a \
+ <meta name=\x22sel\
+ected-link\x22 valu\
+e=\x22/rsms/inter/r\
+aw/master/docs/f\
+ont-files/Inter-\
+Regular.ttf\x22 dat\
+a-turbo-transien\
+t>\x0a  <link rel=\x22\
+assets\x22 href=\x22ht\
+tps://github.git\
+hubassets.com/\x22>\
+\x0a\x0a    <meta name\
+=\x22google-site-ve\
+rification\x22 cont\
+ent=\x22Apib7-x98H0\
+j5cPqHWwSMm6dNU4\
+GmODRoqxLiDzdx9I\
+\x22>\x0a\x0a<meta name=\x22\
+octolytics-url\x22 \
+content=\x22https:/\
+/collector.githu\
+b.com/github/col\
+lect\x22 />\x0a\x0a  \x0a\x0a  \
+\x0a\x0a\x0a\x0a\x0a    <meta n\
+ame=\x22user-login\x22\
+ content=\x22\x22>\x0a\x0a  \
+\x0a\x0a    <meta name\
+=\x22viewport\x22 cont\
+ent=\x22width=devic\
+e-width\x22>\x0a\x0a    \x0a\
+\x0a      <meta nam\
+e=\x22description\x22 \
+content=\x22GitHub \
+is where people \
+build software. \
+More than 150 mi\
+llion people use\
+ GitHub to disco\
+ver, fork, and c\
+ontribute to ove\
+r 420 million pr\
+ojects.\x22>\x0a\x0a     \
+ <link rel=\x22sear\
+ch\x22 type=\x22applic\
+ation/opensearch\
+description+xml\x22\
+ href=\x22/opensear\
+ch.xml\x22 title=\x22G\
+itHub\x22>\x0a\x0a    <li\
+nk rel=\x22fluid-ic\
+on\x22 href=\x22https:\
+//github.com/flu\
+idicon.png\x22 titl\
+e=\x22GitHub\x22>\x0a    \
+<meta property=\x22\
+fb:app_id\x22 conte\
+nt=\x22140148869343\
+6528\x22>\x0a    <meta\
+ name=\x22apple-itu\
+nes-app\x22 content\
+=\x22app-id=1477376\
+905, app-argumen\
+t=https://github\
+.com/rsms/inter/\
+raw/master/docs/\
+font-files/Inter\
+-Regular.ttf\x22 />\
+\x0a\x0a      <meta pr\
+operty=\x22og:url\x22 \
+content=\x22https:/\
+/github.com\x22>\x0a  \
+<meta property=\x22\
+og:site_name\x22 co\
+ntent=\x22GitHub\x22>\x0a\
+  <meta property\
+=\x22og:title\x22 cont\
+ent=\x22Build softw\
+are better, toge\
+ther\x22>\x0a  <meta p\
+roperty=\x22og:desc\
+ription\x22 content\
+=\x22GitHub is wher\
+e people build s\
+oftware. More th\
+an 150 million p\
+eople use GitHub\
+ to discover, fo\
+rk, and contribu\
+te to over 420 m\
+illion projects.\
+\x22>\x0a  <meta prope\
+rty=\x22og:image\x22 c\
+ontent=\x22https://\
+github.githubass\
+ets.com/assets/g\
+ithub-logo-55c5b\
+9a1fe52.png\x22>\x0a  \
+<meta property=\x22\
+og:image:type\x22 c\
+ontent=\x22image/pn\
+g\x22>\x0a  <meta prop\
+erty=\x22og:image:w\
+idth\x22 content=\x221\
+200\x22>\x0a  <meta pr\
+operty=\x22og:image\
+:height\x22 content\
+=\x221200\x22>\x0a  <meta\
+ property=\x22og:im\
+age\x22 content=\x22ht\
+tps://github.git\
+hubassets.com/as\
+sets/github-mark\
+-57519b92ca4e.pn\
+g\x22>\x0a  <meta prop\
+erty=\x22og:image:t\
+ype\x22 content=\x22im\
+age/png\x22>\x0a  <met\
+a property=\x22og:i\
+mage:width\x22 cont\
+ent=\x221200\x22>\x0a  <m\
+eta property=\x22og\
+:image:height\x22 c\
+ontent=\x22620\x22>\x0a  \
+<meta property=\x22\
+og:image\x22 conten\
+t=\x22https://githu\
+b.githubassets.c\
+om/assets/github\
+-octocat-13c86b8\
+b336d.png\x22>\x0a  <m\
+eta property=\x22og\
+:image:type\x22 con\
+tent=\x22image/png\x22\
+>\x0a  <meta proper\
+ty=\x22og:image:wid\
+th\x22 content=\x22120\
+0\x22>\x0a  <meta prop\
+erty=\x22og:image:h\
+eight\x22 content=\x22\
+620\x22>\x0a\x0a  <meta p\
+roperty=\x22twitter\
+:site\x22 content=\x22\
+github\x22>\x0a  <meta\
+ property=\x22twitt\
+er:site:id\x22 cont\
+ent=\x2213334762\x22>\x0a\
+  <meta property\
+=\x22twitter:creato\
+r\x22 content=\x22gith\
+ub\x22>\x0a  <meta pro\
+perty=\x22twitter:c\
+reator:id\x22 conte\
+nt=\x2213334762\x22>\x0a \
+ <meta property=\
+\x22twitter:card\x22 c\
+ontent=\x22summary_\
+large_image\x22>\x0a  \
+<meta property=\x22\
+twitter:title\x22 c\
+ontent=\x22GitHub\x22>\
+\x0a  <meta propert\
+y=\x22twitter:descr\
+iption\x22 content=\
+\x22GitHub is where\
+ people build so\
+ftware. More tha\
+n 150 million pe\
+ople use GitHub \
+to discover, for\
+k, and contribut\
+e to over 420 mi\
+llion projects.\x22\
+>\x0a  <meta proper\
+ty=\x22twitter:imag\
+e\x22 content=\x22http\
+s://github.githu\
+bassets.com/asse\
+ts/github-logo-5\
+5c5b9a1fe52.png\x22\
+>\x0a  <meta proper\
+ty=\x22twitter:imag\
+e:width\x22 content\
+=\x221200\x22>\x0a  <meta\
+ property=\x22twitt\
+er:image:height\x22\
+ content=\x221200\x22>\
+\x0a\x0a\x0a\x0a\x0a      <meta\
+ name=\x22hostname\x22\
+ content=\x22github\
+.com\x22>\x0a\x0a\x0a\x0a      \
+  <meta name=\x22ex\
+pected-hostname\x22\
+ content=\x22github\
+.com\x22>\x0a\x0a\x0a  <meta\
+ http-equiv=\x22x-p\
+jax-version\x22 con\
+tent=\x22f4d20813e2\
+67cd59332c48e894\
+95e5b3a1c8e3ad93\
+45883de78db36718\
+20f9e2\x22 data-tur\
+bo-track=\x22reload\
+\x22>\x0a  <meta http-\
+equiv=\x22x-pjax-cs\
+p-version\x22 conte\
+nt=\x228fba9c9418de\
+26103e6176951dd0\
+c38780be21b972f2\
+019085dee08622fd\
+b843\x22 data-turbo\
+-track=\x22reload\x22>\
+\x0a  <meta http-eq\
+uiv=\x22x-pjax-css-\
+version\x22 content\
+=\x22e21db56dd5182f\
+1e70bf1dd27fc086\
+2b43573892dc1c25\
+397040e0584b5bff\
+53\x22 data-turbo-t\
+rack=\x22reload\x22>\x0a \
+ <meta http-equi\
+v=\x22x-pjax-js-ver\
+sion\x22 content=\x22d\
+25a9236433345a80\
+025651aa576bd7b4\
+c2fd95be14e4b936\
+071a81f4762c91e\x22\
+ data-turbo-trac\
+k=\x22reload\x22>\x0a\x0a  <\
+meta name=\x22turbo\
+-cache-control\x22 \
+content=\x22no-prev\
+iew\x22 data-turbo-\
+transient=\x22\x22>\x0a\x0a \
+     <link cross\
+origin=\x22anonymou\
+s\x22 media=\x22all\x22 r\
+el=\x22stylesheet\x22 \
+href=\x22https://gi\
+thub.githubasset\
+s.com/assets/sit\
+e-0e541b2f9f14.c\
+ss\x22 />\x0a  <link c\
+rossorigin=\x22anon\
+ymous\x22 media=\x22al\
+l\x22 rel=\x22styleshe\
+et\x22 href=\x22https:\
+//github.githuba\
+ssets.com/assets\
+/error-3bfb6168c\
+7d5.css\x22 />\x0a  <m\
+eta name=\x22is_log\
+ged_out_page\x22 co\
+ntent=\x22true\x22>\x0a  \
+<meta name=\x22octo\
+lytics-page-type\
+\x22 content=\x22marke\
+ting\x22>\x0a  \x0a\x0a  \x0a\x0a\x0a\
+\x0a      <link rel\
+=\x22canonical\x22 hre\
+f=\x22https://githu\
+b.com/rsms/inter\
+/raw/master/docs\
+/font-files/Inte\
+r-Regular.ttf\x22 d\
+ata-turbo-transi\
+ent>\x0a\x0a\x0a    <meta\
+ name=\x22turbo-bod\
+y-classes\x22 conte\
+nt=\x22logged-out e\
+nv-production pa\
+ge-responsive mi\
+n-height-full d-\
+flex flex-column\
+\x22>\x0a\x0a\x0a  <meta nam\
+e=\x22browser-stats\
+-url\x22 content=\x22h\
+ttps://api.githu\
+b.com/_private/b\
+rowser/stats\x22>\x0a\x0a\
+  <meta name=\x22br\
+owser-errors-url\
+\x22 content=\x22https\
+://api.github.co\
+m/_private/brows\
+er/errors\x22>\x0a\x0a  <\
+meta name=\x22relea\
+se\x22 content=\x222a2\
+76d15e175595c4db\
+ac2d455399997445\
+281fd\x22>\x0a  <meta \
+name=\x22ui-target\x22\
+ content=\x22full\x22>\
+\x0a\x0a  <link rel=\x22m\
+ask-icon\x22 href=\x22\
+https://github.g\
+ithubassets.com/\
+assets/pinned-oc\
+tocat-093da3e6fa\
+40.svg\x22 color=\x22#\
+000000\x22>\x0a  <link\
+ rel=\x22alternate \
+icon\x22 class=\x22js-\
+site-favicon\x22 ty\
+pe=\x22image/png\x22 h\
+ref=\x22https://git\
+hub.githubassets\
+.com/favicons/fa\
+vicon.png\x22>\x0a  <l\
+ink rel=\x22icon\x22 c\
+lass=\x22js-site-fa\
+vicon\x22 type=\x22ima\
+ge/svg+xml\x22 href\
+=\x22https://github\
+.githubassets.co\
+m/favicons/favic\
+on.svg\x22 data-bas\
+e-href=\x22https://\
+github.githubass\
+ets.com/favicons\
+/favicon\x22>\x0a\x0a<met\
+a name=\x22theme-co\
+lor\x22 content=\x22#1\
+e2327\x22>\x0a<meta na\
+me=\x22color-scheme\
+\x22 content=\x22light\
+ dark\x22 />\x0a\x0a\x0a  <l\
+ink rel=\x22manifes\
+t\x22 href=\x22/manife\
+st.json\x22 crossOr\
+igin=\x22use-creden\
+tials\x22>\x0a\x0a  </hea\
+d>\x0a\x0a  <body clas\
+s=\x22logged-out en\
+v-production pag\
+e-responsive min\
+-height-full d-f\
+lex flex-column\x22\
+ style=\x22word-wra\
+p: break-word;\x22>\
+\x0a    <div data-t\
+urbo-body class=\
+\x22logged-out env-\
+production page-\
+responsive min-h\
+eight-full d-fle\
+x flex-column\x22 s\
+tyle=\x22word-wrap:\
+ break-word;\x22>\x0a \
+     \x0a\x0a\x0a\x0a    <di\
+v class=\x22positio\
+n-relative heade\
+r-wrapper js-hea\
+der-wrapper \x22>\x0a \
+     <a href=\x22#s\
+tart-of-content\x22\
+ data-skip-targe\
+t-assigned=\x22fals\
+e\x22 class=\x22px-2 p\
+y-4 color-bg-acc\
+ent-emphasis col\
+or-fg-on-emphasi\
+s show-on-focus \
+js-skip-to-conte\
+nt\x22>Skip to cont\
+ent</a>\x0a\x0a      <\
+span data-view-c\
+omponent=\x22true\x22 \
+class=\x22progress-\
+pjax-loader Prog\
+ress position-fi\
+xed width-full\x22>\
+\x0a    <span style\
+=\x22width: 0%;\x22 da\
+ta-view-componen\
+t=\x22true\x22 class=\x22\
+Progress-item pr\
+ogress-pjax-load\
+er-bar left-0 to\
+p-0 color-bg-acc\
+ent-emphasis\x22></\
+span>\x0a</span>   \
+   \x0a      \x0a     \
+ <link crossorig\
+in=\x22anonymous\x22 m\
+edia=\x22all\x22 rel=\x22\
+stylesheet\x22 href\
+=\x22https://github\
+.githubassets.co\
+m/assets/primer-\
+react.837d55d8a7\
+f64d93bd28.modul\
+e.css\x22 />\x0a<link \
+crossorigin=\x22ano\
+nymous\x22 media=\x22a\
+ll\x22 rel=\x22stylesh\
+eet\x22 href=\x22https\
+://github.github\
+assets.com/asset\
+s/keyboard-short\
+cuts-dialog.f8fb\
+a3bd67fe74f9227b\
+.module.css\x22 />\x0a\
+\x0a<react-partial\x0a\
+  partial-name=\x22\
+keyboard-shortcu\
+ts-dialog\x22\x0a  dat\
+a-ssr=\x22false\x22\x0a  \
+data-attempted-s\
+sr=\x22false\x22\x0a  dat\
+a-react-profilin\
+g=\x22false\x22\x0a>\x0a  \x0a \
+ <script type=\x22a\
+pplication/json\x22\
+ data-target=\x22re\
+act-partial.embe\
+ddedData\x22>{\x22prop\
+s\x22:{\x22docsUrl\x22:\x22h\
+ttps://docs.gith\
+ub.com/get-start\
+ed/accessibility\
+/keyboard-shortc\
+uts\x22}}</script>\x0a\
+  <div data-targ\
+et=\x22react-partia\
+l.reactRoot\x22></d\
+iv>\x0a</react-part\
+ial>\x0a\x0a\x0a\x0a\x0a\x0a      \
+\x0a\x0a          \x0a\x0a  \
+            \x0a<sc\
+ript crossorigin\
+=\x22anonymous\x22 typ\
+e=\x22application/j\
+avascript\x22 src=\x22\
+https://github.g\
+ithubassets.com/\
+assets/vendors-n\
+ode_modules_gsap\
+_index_js-028cb2\
+a18f5a.js\x22 defer\
+=\x22defer\x22></scrip\
+t>\x0a<script cross\
+origin=\x22anonymou\
+s\x22 type=\x22applica\
+tion/javascript\x22\
+ src=\x22https://gi\
+thub.githubasset\
+s.com/assets/ven\
+dors-node_module\
+s_github_remote-\
+form_dist_index_\
+js-node_modules_\
+delegated-events\
+_dist_inde-94fd6\
+7-5a370a947905.j\
+s\x22 defer=\x22defer\x22\
+></script>\x0a<scri\
+pt crossorigin=\x22\
+anonymous\x22 type=\
+\x22application/jav\
+ascript\x22 src=\x22ht\
+tps://github.git\
+hubassets.com/as\
+sets/sessions-06\
+e5a2cf5cc8.js\x22 d\
+efer=\x22defer\x22></s\
+cript>\x0a<header c\
+lass=\x22HeaderMktg\
+ header-logged-o\
+ut js-details-co\
+ntainer js-heade\
+r Details f4 py-\
+3\x22 role=\x22banner\x22\
+ data-is-top=\x22tr\
+ue\x22 data-color-m\
+ode=light data-l\
+ight-theme=light\
+ data-dark-theme\
+=dark>\x0a  <h2 cla\
+ss=\x22sr-only\x22>Nav\
+igation Menu</h2\
+>\x0a\x0a  <button typ\
+e=\x22button\x22 class\
+=\x22HeaderMktg-bac\
+kdrop d-lg-none \
+border-0 positio\
+n-fixed top-0 le\
+ft-0 width-full \
+height-full js-d\
+etails-target\x22 a\
+ria-label=\x22Toggl\
+e navigation\x22>\x0a \
+   <span class=\x22\
+d-none\x22>Toggle n\
+avigation</span>\
+\x0a  </button>\x0a\x0a  \
+<div class=\x22d-fl\
+ex flex-column f\
+lex-lg-row flex-\
+items-center px-\
+3 px-md-4 px-lg-\
+5 height-full po\
+sition-relative \
+z-1\x22>\x0a    <div c\
+lass=\x22d-flex fle\
+x-justify-betwee\
+n flex-items-cen\
+ter width-full w\
+idth-lg-auto\x22>\x0a \
+     <div class=\
+\x22flex-1\x22>\x0a      \
+  <button aria-l\
+abel=\x22Toggle nav\
+igation\x22 aria-ex\
+panded=\x22false\x22 t\
+ype=\x22button\x22 dat\
+a-view-component\
+=\x22true\x22 class=\x22j\
+s-details-target\
+ js-nav-padding-\
+recalculate js-h\
+eader-menu-toggl\
+e Button--link B\
+utton--medium Bu\
+tton d-lg-none c\
+olor-fg-inherit \
+p-1\x22>  <span cla\
+ss=\x22Button-conte\
+nt\x22>\x0a    <span c\
+lass=\x22Button-lab\
+el\x22><div class=\x22\
+HeaderMenu-toggl\
+e-bar rounded my\
+-1\x22></div>\x0a     \
+       <div clas\
+s=\x22HeaderMenu-to\
+ggle-bar rounded\
+ my-1\x22></div>\x0a  \
+          <div c\
+lass=\x22HeaderMenu\
+-toggle-bar roun\
+ded my-1\x22></div>\
+</span>\x0a  </span\
+>\x0a</button>\x0a    \
+  </div>\x0a\x0a      \
+<a class=\x22mr-lg-\
+3 color-fg-inher\
+it flex-order-2 \
+js-prevent-focus\
+-on-mobile-nav\x22\x0a\
+        href=\x22/\x22\
+\x0a        aria-la\
+bel=\x22Homepage\x22\x0a \
+       data-anal\
+ytics-event=\x22{&q\
+uot;category&quo\
+t;:&quot;Marketi\
+ng nav&quot;,&qu\
+ot;action&quot;:\
+&quot;click to g\
+o to homepage&qu\
+ot;,&quot;label&\
+quot;:&quot;ref_\
+page:Marketing;r\
+ef_cta:Logomark;\
+ref_loc:Header&q\
+uot;}\x22>\x0a        \
+<svg height=\x2232\x22\
+ aria-hidden=\x22tr\
+ue\x22 viewBox=\x220 0\
+ 24 24\x22 version=\
+\x221.1\x22 width=\x2232\x22\
+ data-view-compo\
+nent=\x22true\x22 clas\
+s=\x22octicon octic\
+on-mark-github\x22>\
+\x0a    <path d=\x22M1\
+2 1C5.923 1 1 5.\
+923 1 12c0 4.867\
+ 3.149 8.979 7.5\
+21 10.436.55.096\
+.756-.233.756-.5\
+22 0-.262-.013-1\
+.128-.013-2.049-\
+2.764.509-3.479-\
+.674-3.699-1.292\
+-.124-.317-.66-1\
+.293-1.127-1.554\
+-.385-.207-.936-\
+.715-.014-.729.8\
+66-.014 1.485.79\
+7 1.691 1.128.99\
+ 1.663 2.571 1.1\
+96 3.204.907.096\
+-.715.385-1.196.\
+701-1.471-2.448-\
+.275-5.005-1.224\
+-5.005-5.432 0-1\
+.196.426-2.186 1\
+.128-2.956-.111-\
+.275-.496-1.402.\
+11-2.915 0 0 .92\
+1-.288 3.024 1.1\
+28a10.193 10.193\
+ 0 0 1 2.75-.371\
+c.936 0 1.871.12\
+3 2.75.371 2.104\
+-1.43 3.025-1.12\
+8 3.025-1.128.60\
+5 1.513.221 2.64\
+.111 2.915.701.7\
+7 1.127 1.747 1.\
+127 2.956 0 4.22\
+2-2.571 5.157-5.\
+019 5.432.399.34\
+4.743 1.004.743 \
+2.035 0 1.471-.0\
+14 2.654-.014 3.\
+025 0 .289.206.6\
+32.756.522C19.85\
+1 20.979 23 16.8\
+54 23 12c0-6.077\
+-4.922-11-11-11Z\
+\x22></path>\x0a</svg>\
+\x0a      </a>\x0a\x0a   \
+   <div class=\x22d\
+-flex flex-1 fle\
+x-order-2 text-r\
+ight d-lg-none g\
+ap-2 flex-justif\
+y-end\x22>\x0a        \
+  <a\x0a           \
+ href=\x22/login?re\
+turn_to=https%3A\
+%2F%2Fgithub.com\
+%2Frsms%2Finter%\
+2Fraw%2Fmaster%2\
+Fdocs%2Ffont-fil\
+es%2FInter-Regul\
+ar.ttf\x22\x0a        \
+    class=\x22Heade\
+rMenu-link Heade\
+rMenu-button d-i\
+nline-flex f5 no\
+-underline borde\
+r color-border-d\
+efault rounded-2\
+ px-2 py-1 color\
+-fg-inherit js-p\
+revent-focus-on-\
+mobile-nav\x22\x0a    \
+        data-hyd\
+ro-click=\x22{&quot\
+;event_type&quot\
+;:&quot;authenti\
+cation.click&quo\
+t;,&quot;payload\
+&quot;:{&quot;lo\
+cation_in_page&q\
+uot;:&quot;site \
+header menu&quot\
+;,&quot;reposito\
+ry_id&quot;:null\
+,&quot;auth_type\
+&quot;:&quot;SIG\
+N_UP&quot;,&quot\
+;originating_url\
+&quot;:&quot;htt\
+ps://github.com/\
+rsms/inter/raw/m\
+aster/docs/font-\
+files/Inter-Regu\
+lar.ttf&quot;,&q\
+uot;user_id&quot\
+;:null}}\x22 data-h\
+ydro-click-hmac=\
+\x22f00e075e0d159f3\
+9944bc90cd67cc91\
+eba3bfcbad1281a4\
+c3239310f2059b02\
+0\x22\x0a            d\
+ata-analytics-ev\
+ent=\x22{&quot;cate\
+gory&quot;:&quot\
+;Marketing nav&q\
+uot;,&quot;actio\
+n&quot;:&quot;cl\
+ick to Sign in&q\
+uot;,&quot;label\
+&quot;:&quot;ref\
+_page:Marketing;\
+ref_cta:Sign in;\
+ref_loc:Header&q\
+uot;}\x22\x0a         \
+ >\x0a            S\
+ign in\x0a         \
+ </a>\x0a          \
+    <div class=\x22\
+AppHeader-appear\
+anceSettings\x22>\x0a \
+   <react-partia\
+l-anchor>\x0a      \
+<button data-tar\
+get=\x22react-parti\
+al-anchor.anchor\
+\x22 id=\x22icon-butto\
+n-eefeb87e-6a1b-\
+4e81-8af7-6c463b\
+157078\x22 aria-lab\
+elledby=\x22tooltip\
+-380c8a01-2839-4\
+0b0-ae40-9f62281\
+e33d1\x22 type=\x22but\
+ton\x22 disabled=\x22d\
+isabled\x22 data-vi\
+ew-component=\x22tr\
+ue\x22 class=\x22Butto\
+n Button--iconOn\
+ly Button--invis\
+ible Button--med\
+ium AppHeader-bu\
+tton HeaderMenu-\
+link border curs\
+or-wait\x22>  <svg \
+aria-hidden=\x22tru\
+e\x22 height=\x2216\x22 v\
+iewBox=\x220 0 16 1\
+6\x22 version=\x221.1\x22\
+ width=\x2216\x22 data\
+-view-component=\
+\x22true\x22 class=\x22oc\
+ticon octicon-sl\
+iders Button-vis\
+ual\x22>\x0a    <path \
+d=\x22M15 2.75a.75.\
+75 0 0 1-.75.75h\
+-4a.75.75 0 0 1 \
+0-1.5h4a.75.75 0\
+ 0 1 .75.75Zm-8.\
+5.75v1.25a.75.75\
+ 0 0 0 1.5 0v-4a\
+.75.75 0 0 0-1.5\
+ 0V2H1.75a.75.75\
+ 0 0 0 0 1.5H6.5\
+Zm1.25 5.25a.75.\
+75 0 0 0 0-1.5h-\
+6a.75.75 0 0 0 0\
+ 1.5h6ZM15 8a.75\
+.75 0 0 1-.75.75\
+H11.5V10a.75.75 \
+0 1 1-1.5 0V6a.7\
+5.75 0 0 1 1.5 0\
+v1.25h2.75A.75.7\
+5 0 0 1 15 8Zm-9\
+ 5.25v-2a.75.75 \
+0 0 0-1.5 0v1.25\
+H1.75a.75.75 0 0\
+ 0 0 1.5H4.5v1.2\
+5a.75.75 0 0 0 1\
+.5 0v-2Zm9 0a.75\
+.75 0 0 1-.75.75\
+h-6a.75.75 0 0 1\
+ 0-1.5h6a.75.75 \
+0 0 1 .75.75Z\x22><\
+/path>\x0a</svg>\x0a</\
+button><tool-tip\
+ id=\x22tooltip-380\
+c8a01-2839-40b0-\
+ae40-9f62281e33d\
+1\x22 for=\x22icon-but\
+ton-eefeb87e-6a1\
+b-4e81-8af7-6c46\
+3b157078\x22 popove\
+r=\x22manual\x22 data-\
+direction=\x22s\x22 da\
+ta-type=\x22label\x22 \
+data-view-compon\
+ent=\x22true\x22 class\
+=\x22sr-only positi\
+on-absolute\x22>App\
+earance settings\
+</tool-tip>\x0a\x0a   \
+   <template dat\
+a-target=\x22react-\
+partial-anchor.t\
+emplate\x22>\x0a      \
+  <link crossori\
+gin=\x22anonymous\x22 \
+media=\x22all\x22 rel=\
+\x22stylesheet\x22 hre\
+f=\x22https://githu\
+b.githubassets.c\
+om/assets/primer\
+-react.837d55d8a\
+7f64d93bd28.modu\
+le.css\x22 />\x0a<link\
+ crossorigin=\x22an\
+onymous\x22 media=\x22\
+all\x22 rel=\x22styles\
+heet\x22 href=\x22http\
+s://github.githu\
+bassets.com/asse\
+ts/appearance-se\
+ttings.76259b61e\
+cc822265749.modu\
+le.css\x22 />\x0a\x0a<rea\
+ct-partial\x0a  par\
+tial-name=\x22appea\
+rance-settings\x22\x0a\
+  data-ssr=\x22fals\
+e\x22\x0a  data-attemp\
+ted-ssr=\x22false\x22\x0a\
+  data-react-pro\
+filing=\x22false\x22\x0a>\
+\x0a  \x0a  <script ty\
+pe=\x22application/\
+json\x22 data-targe\
+t=\x22react-partial\
+.embeddedData\x22>{\
+\x22props\x22:{}}</scr\
+ipt>\x0a  <div data\
+-target=\x22react-p\
+artial.reactRoot\
+\x22></div>\x0a</react\
+-partial>\x0a\x0a\x0a    \
+  </template>\x0a  \
+  </react-partia\
+l-anchor>\x0a  </di\
+v>\x0a\x0a      </div>\
+\x0a    </div>\x0a\x0a\x0a  \
+  <div class=\x22He\
+aderMenu js-head\
+er-menu height-f\
+it position-lg-r\
+elative d-lg-fle\
+x flex-column fl\
+ex-auto top-0\x22>\x0a\
+      <div class\
+=\x22HeaderMenu-wra\
+pper d-flex flex\
+-column flex-sel\
+f-start flex-lg-\
+row flex-auto ro\
+unded rounded-lg\
+-0\x22>\x0a          <\
+nav class=\x22Heade\
+rMenu-nav\x22 aria-\
+label=\x22Global\x22>\x0a\
+            <ul \
+class=\x22d-lg-flex\
+ list-style-none\
+\x22>\x0a\x0a\x0a           \
+     <li class=\x22\
+HeaderMenu-item \
+position-relativ\
+e flex-wrap flex\
+-justify-between\
+ flex-items-cent\
+er d-block d-lg-\
+flex flex-lg-now\
+rap flex-lg-item\
+s-center js-deta\
+ils-container js\
+-header-menu-ite\
+m\x22>\x0a      <butto\
+n type=\x22button\x22 \
+class=\x22HeaderMen\
+u-link border-0 \
+width-full width\
+-lg-auto px-0 px\
+-lg-2 py-lg-2 no\
+-wrap d-flex fle\
+x-items-center f\
+lex-justify-betw\
+een js-details-t\
+arget\x22 aria-expa\
+nded=\x22false\x22>\x0a  \
+      Product\x0a  \
+      <svg opaci\
+ty=\x220.5\x22 aria-hi\
+dden=\x22true\x22 heig\
+ht=\x2216\x22 viewBox=\
+\x220 0 16 16\x22 vers\
+ion=\x221.1\x22 width=\
+\x2216\x22 data-view-c\
+omponent=\x22true\x22 \
+class=\x22octicon o\
+cticon-chevron-d\
+own HeaderMenu-i\
+con ml-1\x22>\x0a    <\
+path d=\x22M12.78 5\
+.22a.749.749 0 0\
+ 1 0 1.06l-4.25 \
+4.25a.749.749 0 \
+0 1-1.06 0L3.22 \
+6.28a.749.749 0 \
+1 1 1.06-1.06L8 \
+8.939l3.72-3.719\
+a.749.749 0 0 1 \
+1.06 0Z\x22></path>\
+\x0a</svg>\x0a      </\
+button>\x0a\x0a      <\
+div class=\x22Heade\
+rMenu-dropdown d\
+ropdown-menu rou\
+nded m-0 p-0 pt-\
+2 pt-lg-4 positi\
+on-relative posi\
+tion-lg-absolute\
+ left-0 left-lg-\
+n3 pb-2 pb-lg-4 \
+d-lg-flex flex-w\
+rap dropdown-men\
+u-wide\x22>\x0a       \
+   <div class=\x22H\
+eaderMenu-column\
+ pl-lg-4 px-lg-4\
+\x22>\x0a             \
+ <div class=\x22\x22>\x0a\
+\x0a               \
+ <ul class=\x22list\
+-style-none f5\x22 \
+>\x0a              \
+      <li>\x0a  <a \
+class=\x22HeaderMen\
+u-dropdown-link \
+d-block no-under\
+line position-re\
+lative py-2 Link\
+--secondary d-fl\
+ex flex-items-ce\
+nter Link--has-d\
+escription pb-lg\
+-3\x22 data-analyti\
+cs-event=\x22{&quot\
+;location&quot;:\
+&quot;navbar&quo\
+t;,&quot;action&\
+quot;:&quot;gith\
+ub_copilot&quot;\
+,&quot;context&q\
+uot;:&quot;produ\
+ct&quot;,&quot;t\
+ag&quot;:&quot;l\
+ink&quot;,&quot;\
+label&quot;:&quo\
+t;github_copilot\
+_link_product_na\
+vbar&quot;}\x22 hre\
+f=\x22https://githu\
+b.com/features/c\
+opilot\x22>\x0a      <\
+svg aria-hidden=\
+\x22true\x22 height=\x222\
+4\x22 viewBox=\x220 0 \
+24 24\x22 version=\x22\
+1.1\x22 width=\x2224\x22 \
+data-view-compon\
+ent=\x22true\x22 class\
+=\x22octicon octico\
+n-copilot color-\
+fg-subtle mr-3\x22>\
+\x0a    <path d=\x22M2\
+3.922 16.992c-.8\
+61 1.495-5.859 5\
+.023-11.922 5.02\
+3-6.063 0-11.061\
+-3.528-11.922-5.\
+023A.641.641 0 0\
+ 1 0 16.736v-2.8\
+69a.841.841 0 0 \
+1 .053-.22c.372-\
+.935 1.347-2.292\
+ 2.605-2.656.167\
+-.429.414-1.055.\
+644-1.517a10.195\
+ 10.195 0 0 1-.0\
+52-1.086c0-1.331\
+.282-2.499 1.132\
+-3.368.397-.406.\
+89-.717 1.474-.9\
+52 1.399-1.136 3\
+.392-2.093 6.122\
+-2.093 2.731 0 4\
+.767.957 6.166 2\
+.093.584.235 1.0\
+77.546 1.474.952\
+.85.869 1.132 2.\
+037 1.132 3.368 \
+0 .368-.014.733-\
+.052 1.086.23.46\
+2.477 1.088.644 \
+1.517 1.258.364 \
+2.233 1.721 2.60\
+5 2.656a.832.832\
+ 0 0 1 .053.22v2\
+.869a.641.641 0 \
+0 1-.078.256ZM12\
+.172 11h-.344a4.\
+323 4.323 0 0 1-\
+.355.508C10.703 \
+12.455 9.555 13 \
+7.965 13c-1.725 \
+0-2.989-.359-3.7\
+82-1.259a2.005 2\
+.005 0 0 1-.085-\
+.104L4 11.741v6.\
+585c1.435.779 4.\
+514 2.179 8 2.17\
+9 3.486 0 6.565-\
+1.4 8-2.179v-6.5\
+85l-.098-.104s-.\
+033.045-.085.104\
+c-.793.9-2.057 1\
+.259-3.782 1.259\
+-1.59 0-2.738-.5\
+45-3.508-1.492a4\
+.323 4.323 0 0 1\
+-.355-.508h-.016\
+.016Zm.641-2.935\
+c.136 1.057.403 \
+1.913.878 2.497.\
+442.544 1.134.93\
+8 2.344.938 1.57\
+3 0 2.292-.337 2\
+.657-.751.384-.4\
+35.558-1.15.558-\
+2.361 0-1.14-.24\
+3-1.847-.705-2.3\
+19-.477-.488-1.3\
+19-.862-2.824-1.\
+025-1.487-.161-2\
+.192.138-2.533.5\
+29-.269.307-.437\
+.808-.438 1.578v\
+.021c0 .265.021.\
+562.063.893Zm-1.\
+626 0c.042-.331.\
+063-.628.063-.89\
+4v-.02c-.001-.77\
+-.169-1.271-.438\
+-1.578-.341-.391\
+-1.046-.69-2.533\
+-.529-1.505.163-\
+2.347.537-2.824 \
+1.025-.462.472-.\
+705 1.179-.705 2\
+.319 0 1.211.175\
+ 1.926.558 2.361\
+.365.414 1.084.7\
+51 2.657.751 1.2\
+1 0 1.902-.394 2\
+.344-.938.475-.5\
+84.742-1.44.878-\
+2.497Z\x22></path><\
+path d=\x22M14.5 14\
+.25a1 1 0 0 1 1 \
+1v2a1 1 0 0 1-2 \
+0v-2a1 1 0 0 1 1\
+-1Zm-5 0a1 1 0 0\
+ 1 1 1v2a1 1 0 0\
+ 1-2 0v-2a1 1 0 \
+0 1 1-1Z\x22></path\
+>\x0a</svg>\x0a      <\
+div>\x0a          <\
+div class=\x22color\
+-fg-default h4\x22>\
+\x0a            Git\
+Hub Copilot\x0a    \
+      </div>\x0a   \
+     Write bette\
+r code with AI\x0a \
+     </div>\x0a\x0a   \
+ \x0a</a></li>\x0a\x0a   \
+                \
+ <li>\x0a  <a class\
+=\x22HeaderMenu-dro\
+pdown-link d-blo\
+ck no-underline \
+position-relativ\
+e py-2 Link--sec\
+ondary d-flex fl\
+ex-items-center \
+Link--has-descri\
+ption pb-lg-3\x22 d\
+ata-analytics-ev\
+ent=\x22{&quot;loca\
+tion&quot;:&quot\
+;navbar&quot;,&q\
+uot;action&quot;\
+:&quot;github_sp\
+ark&quot;,&quot;\
+context&quot;:&q\
+uot;product&quot\
+;,&quot;tag&quot\
+;:&quot;link&quo\
+t;,&quot;label&q\
+uot;:&quot;githu\
+b_spark_link_pro\
+duct_navbar&quot\
+;}\x22 href=\x22https:\
+//github.com/fea\
+tures/spark\x22>\x0a  \
+    <svg aria-hi\
+dden=\x22true\x22 heig\
+ht=\x2224\x22 viewBox=\
+\x220 0 24 24\x22 vers\
+ion=\x221.1\x22 width=\
+\x2224\x22 data-view-c\
+omponent=\x22true\x22 \
+class=\x22octicon o\
+cticon-sparkle-f\
+ill color-fg-sub\
+tle mr-3\x22>\x0a    <\
+path d=\x22M11.296 \
+1.924c.24-.656 1\
+.168-.656 1.408 \
+0l.717 1.958a11.\
+25 11.25 0 0 0 6\
+.697 6.697l1.958\
+.717c.657.24.657\
+ 1.168 0 1.408l-\
+1.958.717a11.25 \
+11.25 0 0 0-6.69\
+7 6.697l-.717 1.\
+958c-.24.657-1.1\
+68.657-1.408 0l-\
+.717-1.958a11.25\
+ 11.25 0 0 0-6.6\
+97-6.697l-1.958-\
+.717c-.656-.24-.\
+656-1.168 0-1.40\
+8l1.958-.717a11.\
+25 11.25 0 0 0 6\
+.697-6.697l.717-\
+1.958Z\x22></path>\x0a\
+</svg>\x0a      <di\
+v>\x0a          <di\
+v class=\x22color-f\
+g-default h4\x22>\x0a \
+           GitHu\
+b Spark\x0a        \
+      <span clas\
+s=\x22HeaderMenu-la\
+bel\x22>\x0a          \
+      New\x0a      \
+        </span>\x0a\
+          </div>\
+\x0a        Build a\
+nd deploy intell\
+igent apps\x0a     \
+ </div>\x0a\x0a    \x0a</\
+a></li>\x0a\x0a       \
+             <li\
+>\x0a  <a class=\x22He\
+aderMenu-dropdow\
+n-link d-block n\
+o-underline posi\
+tion-relative py\
+-2 Link--seconda\
+ry d-flex flex-i\
+tems-center Link\
+--has-descriptio\
+n pb-lg-3\x22 data-\
+analytics-event=\
+\x22{&quot;location\
+&quot;:&quot;nav\
+bar&quot;,&quot;\
+action&quot;:&qu\
+ot;github_models\
+&quot;,&quot;con\
+text&quot;:&quot\
+;product&quot;,&\
+quot;tag&quot;:&\
+quot;link&quot;,\
+&quot;label&quot\
+;:&quot;github_m\
+odels_link_produ\
+ct_navbar&quot;}\
+\x22 href=\x22https://\
+github.com/featu\
+res/models\x22>\x0a   \
+   <svg aria-hid\
+den=\x22true\x22 heigh\
+t=\x2224\x22 viewBox=\x22\
+0 0 24 24\x22 versi\
+on=\x221.1\x22 width=\x22\
+24\x22 data-view-co\
+mponent=\x22true\x22 c\
+lass=\x22octicon oc\
+ticon-ai-model c\
+olor-fg-subtle m\
+r-3\x22>\x0a    <path \
+d=\x22M19.375 8.5a3\
+.25 3.25 0 1 1-3\
+.163 4h-3a3.252 \
+3.252 0 0 1-4.44\
+3 2.509L7.214 17\
+.76a3.25 3.25 0 \
+1 1-1.342-.674l1\
+.672-2.957A3.238\
+ 3.238 0 0 1 6.7\
+5 12c0-.907.371-\
+1.727.97-2.316L6\
+.117 6.846A3.253\
+ 3.253 0 0 1 1.8\
+75 3.75a3.25 3.2\
+5 0 1 1 5.526 2.\
+32l1.603 2.836A3\
+.25 3.25 0 0 1 1\
+3.093 11h3.119a3\
+.252 3.252 0 0 1\
+ 3.163-2.5ZM10 1\
+0.25a1.75 1.75 0\
+ 1 0-.001 3.499A\
+1.75 1.75 0 0 0 \
+10 10.25ZM5.125 \
+2a1.75 1.75 0 1 \
+0 0 3.5 1.75 1.7\
+5 0 0 0 0-3.5Zm1\
+2.5 9.75a1.75 1.\
+75 0 1 0 3.5 0 1\
+.75 1.75 0 0 0-3\
+.5 0Zm-14.25 8.5\
+a1.75 1.75 0 1 0\
+ 3.501-.001 1.75\
+ 1.75 0 0 0-3.50\
+1.001Z\x22></path>\x0a\
+</svg>\x0a      <di\
+v>\x0a          <di\
+v class=\x22color-f\
+g-default h4\x22>\x0a \
+           GitHu\
+b Models\x0a       \
+       <span cla\
+ss=\x22HeaderMenu-l\
+abel\x22>\x0a         \
+       New\x0a     \
+         </span>\
+\x0a          </div\
+>\x0a        Manage\
+ and compare pro\
+mpts\x0a      </div\
+>\x0a\x0a    \x0a</a></li\
+>\x0a\x0a             \
+       <li>\x0a  <a\
+ class=\x22HeaderMe\
+nu-dropdown-link\
+ d-block no-unde\
+rline position-r\
+elative py-2 Lin\
+k--secondary d-f\
+lex flex-items-c\
+enter Link--has-\
+description pb-l\
+g-3\x22 data-analyt\
+ics-event=\x22{&quo\
+t;location&quot;\
+:&quot;navbar&qu\
+ot;,&quot;action\
+&quot;:&quot;git\
+hub_advanced_sec\
+urity&quot;,&quo\
+t;context&quot;:\
+&quot;product&qu\
+ot;,&quot;tag&qu\
+ot;:&quot;link&q\
+uot;,&quot;label\
+&quot;:&quot;git\
+hub_advanced_sec\
+urity_link_produ\
+ct_navbar&quot;}\
+\x22 href=\x22https://\
+github.com/secur\
+ity/advanced-sec\
+urity\x22>\x0a      <s\
+vg aria-hidden=\x22\
+true\x22 height=\x2224\
+\x22 viewBox=\x220 0 2\
+4 24\x22 version=\x221\
+.1\x22 width=\x2224\x22 d\
+ata-view-compone\
+nt=\x22true\x22 class=\
+\x22octicon octicon\
+-shield-check co\
+lor-fg-subtle mr\
+-3\x22>\x0a    <path d\
+=\x22M16.53 9.78a.7\
+5.75 0 0 0-1.06-\
+1.06L11 13.19l-1\
+.97-1.97a.75.75 \
+0 0 0-1.06 1.06l\
+2.5 2.5a.75.75 0\
+ 0 0 1.06 0l5-5Z\
+\x22></path><path d\
+=\x22m12.54.637 8.2\
+5 2.675A1.75 1.7\
+5 0 0 1 22 4.976\
+V10c0 6.19-3.771\
+ 10.704-9.401 12\
+.83a1.704 1.704 \
+0 0 1-1.198 0C5.\
+77 20.705 2 16.1\
+9 2 10V4.976c0-.\
+758.489-1.43 1.2\
+1-1.664L11.46.63\
+7a1.748 1.748 0 \
+0 1 1.08 0Zm-.61\
+7 1.426-8.25 2.6\
+76a.249.249 0 0 \
+0-.173.237V10c0 \
+5.46 3.28 9.483 \
+8.43 11.426a.199\
+.199 0 0 0 .14 0\
+C17.22 19.483 20\
+.5 15.461 20.5 1\
+0V4.976a.25.25 0\
+ 0 0-.173-.237l-\
+8.25-2.676a.253.\
+253 0 0 0-.154 0\
+Z\x22></path>\x0a</svg\
+>\x0a      <div>\x0a  \
+        <div cla\
+ss=\x22color-fg-def\
+ault h4\x22>\x0a      \
+      GitHub Adv\
+anced Security\x0a \
+         </div>\x0a\
+        Find and\
+ fix vulnerabili\
+ties\x0a      </div\
+>\x0a\x0a    \x0a</a></li\
+>\x0a\x0a             \
+       <li>\x0a  <a\
+ class=\x22HeaderMe\
+nu-dropdown-link\
+ d-block no-unde\
+rline position-r\
+elative py-2 Lin\
+k--secondary d-f\
+lex flex-items-c\
+enter Link--has-\
+description pb-l\
+g-3\x22 data-analyt\
+ics-event=\x22{&quo\
+t;location&quot;\
+:&quot;navbar&qu\
+ot;,&quot;action\
+&quot;:&quot;act\
+ions&quot;,&quot\
+;context&quot;:&\
+quot;product&quo\
+t;,&quot;tag&quo\
+t;:&quot;link&qu\
+ot;,&quot;label&\
+quot;:&quot;acti\
+ons_link_product\
+_navbar&quot;}\x22 \
+href=\x22https://gi\
+thub.com/feature\
+s/actions\x22>\x0a    \
+  <svg aria-hidd\
+en=\x22true\x22 height\
+=\x2224\x22 viewBox=\x220\
+ 0 24 24\x22 versio\
+n=\x221.1\x22 width=\x222\
+4\x22 data-view-com\
+ponent=\x22true\x22 cl\
+ass=\x22octicon oct\
+icon-workflow co\
+lor-fg-subtle mr\
+-3\x22>\x0a    <path d\
+=\x22M1 3a2 2 0 0 1\
+ 2-2h6.5a2 2 0 0\
+ 1 2 2v6.5a2 2 0\
+ 0 1-2 2H7v4.063\
+C7 16.355 7.644 \
+17 8.438 17H12.5\
+v-2.5a2 2 0 0 1 \
+2-2H21a2 2 0 0 1\
+ 2 2V21a2 2 0 0 \
+1-2 2h-6.5a2 2 0\
+ 0 1-2-2v-2.5H8.\
+437A2.939 2.939 \
+0 0 1 5.5 15.562\
+V11.5H3a2 2 0 0 \
+1-2-2Zm2-.5a.5.5\
+ 0 0 0-.5.5v6.5a\
+.5.5 0 0 0 .5.5h\
+6.5a.5.5 0 0 0 .\
+5-.5V3a.5.5 0 0 \
+0-.5-.5ZM14.5 14\
+a.5.5 0 0 0-.5.5\
+V21a.5.5 0 0 0 .\
+5.5H21a.5.5 0 0 \
+0 .5-.5v-6.5a.5.\
+5 0 0 0-.5-.5Z\x22>\
+</path>\x0a</svg>\x0a \
+     <div>\x0a     \
+     <div class=\
+\x22color-fg-defaul\
+t h4\x22>\x0a         \
+   Actions\x0a     \
+     </div>\x0a    \
+    Automate any\
+ workflow\x0a      \
+</div>\x0a\x0a    \x0a</a\
+></li>\x0a\x0a        \
+            \x0a   \
+             </u\
+l>\x0a             \
+ </div>\x0a        \
+  </div>\x0a       \
+   <div class=\x22H\
+eaderMenu-column\
+ pl-lg-4 px-lg-4\
+ pb-3 pb-lg-0\x22>\x0a\
+              <d\
+iv class=\x22border\
+-bottom border-l\
+g-bottom-0 pb-3\x22\
+>\x0a\x0a             \
+   <ul class=\x22li\
+st-style-none f5\
+\x22 >\x0a            \
+        <li>\x0a  <\
+a class=\x22HeaderM\
+enu-dropdown-lin\
+k d-block no-und\
+erline position-\
+relative py-2 Li\
+nk--secondary d-\
+flex flex-items-\
+center Link--has\
+-description pb-\
+lg-3\x22 data-analy\
+tics-event=\x22{&qu\
+ot;location&quot\
+;:&quot;navbar&q\
+uot;,&quot;actio\
+n&quot;:&quot;co\
+despaces&quot;,&\
+quot;context&quo\
+t;:&quot;product\
+&quot;,&quot;tag\
+&quot;:&quot;lin\
+k&quot;,&quot;la\
+bel&quot;:&quot;\
+codespaces_link_\
+product_navbar&q\
+uot;}\x22 href=\x22htt\
+ps://github.com/\
+features/codespa\
+ces\x22>\x0a      <svg\
+ aria-hidden=\x22tr\
+ue\x22 height=\x2224\x22 \
+viewBox=\x220 0 24 \
+24\x22 version=\x221.1\
+\x22 width=\x2224\x22 dat\
+a-view-component\
+=\x22true\x22 class=\x22o\
+cticon octicon-c\
+odespaces color-\
+fg-subtle mr-3\x22>\
+\x0a    <path d=\x22M3\
+.5 3.75C3.5 2.78\
+4 4.284 2 5.25 2\
+h13.5c.966 0 1.7\
+5.784 1.75 1.75v\
+7.5A1.75 1.75 0 \
+0 1 18.75 13H5.2\
+5a1.75 1.75 0 0 \
+1-1.75-1.75Zm-2 \
+12c0-.966.784-1.\
+75 1.75-1.75h17.\
+5c.966 0 1.75.78\
+4 1.75 1.75v4a1.\
+75 1.75 0 0 1-1.\
+75 1.75H3.25a1.7\
+5 1.75 0 0 1-1.7\
+5-1.75ZM5.25 3.5\
+a.25.25 0 0 0-.2\
+5.25v7.5c0 .138.\
+112.25.25.25h13.\
+5a.25.25 0 0 0 .\
+25-.25v-7.5a.25.\
+25 0 0 0-.25-.25\
+Zm-2 12a.25.25 0\
+ 0 0-.25.25v4c0 \
+.138.112.25.25.2\
+5h17.5a.25.25 0 \
+0 0 .25-.25v-4a.\
+25.25 0 0 0-.25-\
+.25Z\x22></path><pa\
+th d=\x22M10 17.75a\
+.75.75 0 0 1 .75\
+-.75h6.5a.75.75 \
+0 0 1 0 1.5h-6.5\
+a.75.75 0 0 1-.7\
+5-.75Zm-4 0a.75.\
+75 0 0 1 .75-.75\
+h.5a.75.75 0 0 1\
+ 0 1.5h-.5a.75.7\
+5 0 0 1-.75-.75Z\
+\x22></path>\x0a</svg>\
+\x0a      <div>\x0a   \
+       <div clas\
+s=\x22color-fg-defa\
+ult h4\x22>\x0a       \
+     Codespaces\x0a\
+          </div>\
+\x0a        Instant\
+ dev environment\
+s\x0a      </div>\x0a\x0a\
+    \x0a</a></li>\x0a\x0a\
+                \
+    <li>\x0a  <a cl\
+ass=\x22HeaderMenu-\
+dropdown-link d-\
+block no-underli\
+ne position-rela\
+tive py-2 Link--\
+secondary d-flex\
+ flex-items-cent\
+er Link--has-des\
+cription pb-lg-3\
+\x22 data-analytics\
+-event=\x22{&quot;l\
+ocation&quot;:&q\
+uot;navbar&quot;\
+,&quot;action&qu\
+ot;:&quot;issues\
+&quot;,&quot;con\
+text&quot;:&quot\
+;product&quot;,&\
+quot;tag&quot;:&\
+quot;link&quot;,\
+&quot;label&quot\
+;:&quot;issues_l\
+ink_product_navb\
+ar&quot;}\x22 href=\
+\x22https://github.\
+com/features/iss\
+ues\x22>\x0a      <svg\
+ aria-hidden=\x22tr\
+ue\x22 height=\x2224\x22 \
+viewBox=\x220 0 24 \
+24\x22 version=\x221.1\
+\x22 width=\x2224\x22 dat\
+a-view-component\
+=\x22true\x22 class=\x22o\
+cticon octicon-i\
+ssue-opened colo\
+r-fg-subtle mr-3\
+\x22>\x0a    <path d=\x22\
+M12 1c6.075 0 11\
+ 4.925 11 11s-4.\
+925 11-11 11S1 1\
+8.075 1 12 5.925\
+ 1 12 1ZM2.5 12a\
+9.5 9.5 0 0 0 9.\
+5 9.5 9.5 9.5 0 \
+0 0 9.5-9.5A9.5 \
+9.5 0 0 0 12 2.5\
+ 9.5 9.5 0 0 0 2\
+.5 12Zm9.5 2a2 2\
+ 0 1 1-.001-3.99\
+9A2 2 0 0 1 12 1\
+4Z\x22></path>\x0a</sv\
+g>\x0a      <div>\x0a \
+         <div cl\
+ass=\x22color-fg-de\
+fault h4\x22>\x0a     \
+       Issues\x0a  \
+        </div>\x0a \
+       Plan and \
+track work\x0a     \
+ </div>\x0a\x0a    \x0a</\
+a></li>\x0a\x0a       \
+             <li\
+>\x0a  <a class=\x22He\
+aderMenu-dropdow\
+n-link d-block n\
+o-underline posi\
+tion-relative py\
+-2 Link--seconda\
+ry d-flex flex-i\
+tems-center Link\
+--has-descriptio\
+n pb-lg-3\x22 data-\
+analytics-event=\
+\x22{&quot;location\
+&quot;:&quot;nav\
+bar&quot;,&quot;\
+action&quot;:&qu\
+ot;code_review&q\
+uot;,&quot;conte\
+xt&quot;:&quot;p\
+roduct&quot;,&qu\
+ot;tag&quot;:&qu\
+ot;link&quot;,&q\
+uot;label&quot;:\
+&quot;code_revie\
+w_link_product_n\
+avbar&quot;}\x22 hr\
+ef=\x22https://gith\
+ub.com/features/\
+code-review\x22>\x0a  \
+    <svg aria-hi\
+dden=\x22true\x22 heig\
+ht=\x2224\x22 viewBox=\
+\x220 0 24 24\x22 vers\
+ion=\x221.1\x22 width=\
+\x2224\x22 data-view-c\
+omponent=\x22true\x22 \
+class=\x22octicon o\
+cticon-code-revi\
+ew color-fg-subt\
+le mr-3\x22>\x0a    <p\
+ath d=\x22M10.3 6.7\
+4a.75.75 0 0 1-.\
+04 1.06l-2.908 2\
+.7 2.908 2.7a.75\
+.75 0 1 1-1.02 1\
+.1l-3.5-3.25a.75\
+.75 0 0 1 0-1.1l\
+3.5-3.25a.75.75 \
+0 0 1 1.06.04Zm3\
+.44 1.06a.75.75 \
+0 1 1 1.02-1.1l3\
+.5 3.25a.75.75 0\
+ 0 1 0 1.1l-3.5 \
+3.25a.75.75 0 1 \
+1-1.02-1.1l2.908\
+-2.7-2.908-2.7Z\x22\
+></path><path d=\
+\x22M1.5 4.25c0-.96\
+6.784-1.75 1.75-\
+1.75h17.5c.966 0\
+ 1.75.784 1.75 1\
+.75v12.5a1.75 1.\
+75 0 0 1-1.75 1.\
+75h-9.69l-3.573 \
+3.573A1.458 1.45\
+8 0 0 1 5 21.043\
+V18.5H3.25a1.75 \
+1.75 0 0 1-1.75-\
+1.75ZM3.25 4a.25\
+.25 0 0 0-.25.25\
+v12.5c0 .138.112\
+.25.25.25h2.5a.7\
+5.75 0 0 1 .75.7\
+5v3.19l3.72-3.72\
+a.749.749 0 0 1 \
+.53-.22h10a.25.2\
+5 0 0 0 .25-.25V\
+4.25a.25.25 0 0 \
+0-.25-.25Z\x22></pa\
+th>\x0a</svg>\x0a     \
+ <div>\x0a         \
+ <div class=\x22col\
+or-fg-default h4\
+\x22>\x0a            C\
+ode Review\x0a     \
+     </div>\x0a    \
+    Manage code \
+changes\x0a      </\
+div>\x0a\x0a    \x0a</a><\
+/li>\x0a\x0a          \
+          <li>\x0a \
+ <a class=\x22Heade\
+rMenu-dropdown-l\
+ink d-block no-u\
+nderline positio\
+n-relative py-2 \
+Link--secondary \
+d-flex flex-item\
+s-center Link--h\
+as-description p\
+b-lg-3\x22 data-ana\
+lytics-event=\x22{&\
+quot;location&qu\
+ot;:&quot;navbar\
+&quot;,&quot;act\
+ion&quot;:&quot;\
+discussions&quot\
+;,&quot;context&\
+quot;:&quot;prod\
+uct&quot;,&quot;\
+tag&quot;:&quot;\
+link&quot;,&quot\
+;label&quot;:&qu\
+ot;discussions_l\
+ink_product_navb\
+ar&quot;}\x22 href=\
+\x22https://github.\
+com/features/dis\
+cussions\x22>\x0a     \
+ <svg aria-hidde\
+n=\x22true\x22 height=\
+\x2224\x22 viewBox=\x220 \
+0 24 24\x22 version\
+=\x221.1\x22 width=\x2224\
+\x22 data-view-comp\
+onent=\x22true\x22 cla\
+ss=\x22octicon octi\
+con-comment-disc\
+ussion color-fg-\
+subtle mr-3\x22>\x0a  \
+  <path d=\x22M1.75\
+ 1h12.5c.966 0 1\
+.75.784 1.75 1.7\
+5v9.5A1.75 1.75 \
+0 0 1 14.25 14H8\
+.061l-2.574 2.57\
+3A1.458 1.458 0 \
+0 1 3 15.543V14H\
+1.75A1.75 1.75 0\
+ 0 1 0 12.25v-9.\
+5C0 1.784.784 1 \
+1.75 1ZM1.5 2.75\
+v9.5c0 .138.112.\
+25.25.25h2a.75.7\
+5 0 0 1 .75.75v2\
+.19l2.72-2.72a.7\
+49.749 0 0 1 .53\
+-.22h6.5a.25.25 \
+0 0 0 .25-.25v-9\
+.5a.25.25 0 0 0-\
+.25-.25H1.75a.25\
+.25 0 0 0-.25.25\
+Z\x22></path><path \
+d=\x22M22.5 8.75a.2\
+5.25 0 0 0-.25-.\
+25h-3.5a.75.75 0\
+ 0 1 0-1.5h3.5c.\
+966 0 1.75.784 1\
+.75 1.75v9.5A1.7\
+5 1.75 0 0 1 22.\
+25 20H21v1.543a1\
+.457 1.457 0 0 1\
+-2.487 1.03L15.9\
+39 20H10.75A1.75\
+ 1.75 0 0 1 9 18\
+.25v-1.465a.75.7\
+5 0 0 1 1.5 0v1.\
+465c0 .138.112.2\
+5.25.25h5.5a.75.\
+75 0 0 1 .53.22l\
+2.72 2.72v-2.19a\
+.75.75 0 0 1 .75\
+-.75h2a.25.25 0 \
+0 0 .25-.25v-9.5\
+Z\x22></path>\x0a</svg\
+>\x0a      <div>\x0a  \
+        <div cla\
+ss=\x22color-fg-def\
+ault h4\x22>\x0a      \
+      Discussion\
+s\x0a          </di\
+v>\x0a        Colla\
+borate outside o\
+f code\x0a      </d\
+iv>\x0a\x0a    \x0a</a></\
+li>\x0a\x0a           \
+         <li>\x0a  \
+<a class=\x22Header\
+Menu-dropdown-li\
+nk d-block no-un\
+derline position\
+-relative py-2 L\
+ink--secondary d\
+-flex flex-items\
+-center Link--ha\
+s-description\x22 d\
+ata-analytics-ev\
+ent=\x22{&quot;loca\
+tion&quot;:&quot\
+;navbar&quot;,&q\
+uot;action&quot;\
+:&quot;code_sear\
+ch&quot;,&quot;c\
+ontext&quot;:&qu\
+ot;product&quot;\
+,&quot;tag&quot;\
+:&quot;link&quot\
+;,&quot;label&qu\
+ot;:&quot;code_s\
+earch_link_produ\
+ct_navbar&quot;}\
+\x22 href=\x22https://\
+github.com/featu\
+res/code-search\x22\
+>\x0a      <svg ari\
+a-hidden=\x22true\x22 \
+height=\x2224\x22 view\
+Box=\x220 0 24 24\x22 \
+version=\x221.1\x22 wi\
+dth=\x2224\x22 data-vi\
+ew-component=\x22tr\
+ue\x22 class=\x22octic\
+on octicon-code-\
+square color-fg-\
+subtle mr-3\x22>\x0a  \
+  <path d=\x22M10.3\
+ 8.24a.75.75 0 0\
+ 1-.04 1.06L7.35\
+2 12l2.908 2.7a.\
+75.75 0 1 1-1.02\
+ 1.1l-3.5-3.25a.\
+75.75 0 0 1 0-1.\
+1l3.5-3.25a.75.7\
+5 0 0 1 1.06.04Z\
+m3.44 1.06a.75.7\
+5 0 1 1 1.02-1.1\
+l3.5 3.25a.75.75\
+ 0 0 1 0 1.1l-3.\
+5 3.25a.75.75 0 \
+1 1-1.02-1.1l2.9\
+08-2.7-2.908-2.7\
+Z\x22></path><path \
+d=\x22M2 3.75C2 2.7\
+84 2.784 2 3.75 \
+2h16.5c.966 0 1.\
+75.784 1.75 1.75\
+v16.5A1.75 1.75 \
+0 0 1 20.25 22H3\
+.75A1.75 1.75 0 \
+0 1 2 20.25Zm1.7\
+5-.25a.25.25 0 0\
+ 0-.25.25v16.5c0\
+ .138.112.25.25.\
+25h16.5a.25.25 0\
+ 0 0 .25-.25V3.7\
+5a.25.25 0 0 0-.\
+25-.25Z\x22></path>\
+\x0a</svg>\x0a      <d\
+iv>\x0a          <d\
+iv class=\x22color-\
+fg-default h4\x22>\x0a\
+            Code\
+ Search\x0a        \
+  </div>\x0a       \
+ Find more, sear\
+ch less\x0a      </\
+div>\x0a\x0a    \x0a</a><\
+/li>\x0a\x0a          \
+      </ul>\x0a    \
+          </div>\
+\x0a          </div\
+>\x0a          <div\
+ class=\x22HeaderMe\
+nu-column pl-lg-\
+4 border-lg-left\
+ pr-lg-7\x22>\x0a     \
+         <div cl\
+ass=\x22border-bott\
+om border-lg-bot\
+tom-0 border-bot\
+tom-0\x22>\x0a        \
+            <spa\
+n class=\x22d-block\
+ h4 color-fg-def\
+ault my-1\x22 id=\x22p\
+roduct-explore-h\
+eading\x22>Explore<\
+/span>\x0a\x0a        \
+        <ul clas\
+s=\x22list-style-no\
+ne f5\x22 aria-labe\
+lledby=\x22product-\
+explore-heading\x22\
+>\x0a              \
+      <li>\x0a  <a \
+class=\x22HeaderMen\
+u-dropdown-link \
+d-block no-under\
+line position-re\
+lative py-2 Link\
+--secondary\x22 dat\
+a-analytics-even\
+t=\x22{&quot;locati\
+on&quot;:&quot;n\
+avbar&quot;,&quo\
+t;action&quot;:&\
+quot;why_github&\
+quot;,&quot;cont\
+ext&quot;:&quot;\
+product&quot;,&q\
+uot;tag&quot;:&q\
+uot;link&quot;,&\
+quot;label&quot;\
+:&quot;why_githu\
+b_link_product_n\
+avbar&quot;}\x22 hr\
+ef=\x22https://gith\
+ub.com/why-githu\
+b\x22>\x0a      Why Gi\
+tHub\x0a\x0a    \x0a</a><\
+/li>\x0a\x0a          \
+          <li>\x0a \
+ <a class=\x22Heade\
+rMenu-dropdown-l\
+ink d-block no-u\
+nderline positio\
+n-relative py-2 \
+Link--secondary\x22\
+ data-analytics-\
+event=\x22{&quot;lo\
+cation&quot;:&qu\
+ot;navbar&quot;,\
+&quot;action&quo\
+t;:&quot;all_fea\
+tures&quot;,&quo\
+t;context&quot;:\
+&quot;product&qu\
+ot;,&quot;tag&qu\
+ot;:&quot;link&q\
+uot;,&quot;label\
+&quot;:&quot;all\
+_features_link_p\
+roduct_navbar&qu\
+ot;}\x22 href=\x22http\
+s://github.com/f\
+eatures\x22>\x0a      \
+All features\x0a\x0a  \
+  \x0a</a></li>\x0a\x0a  \
+                \
+  <li>\x0a  <a clas\
+s=\x22HeaderMenu-dr\
+opdown-link d-bl\
+ock no-underline\
+ position-relati\
+ve py-2 Link--se\
+condary Link--ex\
+ternal\x22 target=\x22\
+_blank\x22 data-ana\
+lytics-event=\x22{&\
+quot;location&qu\
+ot;:&quot;navbar\
+&quot;,&quot;act\
+ion&quot;:&quot;\
+documentation&qu\
+ot;,&quot;contex\
+t&quot;:&quot;pr\
+oduct&quot;,&quo\
+t;tag&quot;:&quo\
+t;link&quot;,&qu\
+ot;label&quot;:&\
+quot;documentati\
+on_link_product_\
+navbar&quot;}\x22 h\
+ref=\x22https://doc\
+s.github.com\x22>\x0a \
+     Documentati\
+on\x0a\x0a    <svg ari\
+a-hidden=\x22true\x22 \
+height=\x2216\x22 view\
+Box=\x220 0 16 16\x22 \
+version=\x221.1\x22 wi\
+dth=\x2216\x22 data-vi\
+ew-component=\x22tr\
+ue\x22 class=\x22octic\
+on octicon-link-\
+external HeaderM\
+enu-external-ico\
+n color-fg-subtl\
+e\x22>\x0a    <path d=\
+\x22M3.75 2h3.5a.75\
+.75 0 0 1 0 1.5h\
+-3.5a.25.25 0 0 \
+0-.25.25v8.5c0 .\
+138.112.25.25.25\
+h8.5a.25.25 0 0 \
+0 .25-.25v-3.5a.\
+75.75 0 0 1 1.5 \
+0v3.5A1.75 1.75 \
+0 0 1 12.25 14h-\
+8.5A1.75 1.75 0 \
+0 1 2 12.25v-8.5\
+C2 2.784 2.784 2\
+ 3.75 2Zm6.854-1\
+h4.146a.25.25 0 \
+0 1 .25.25v4.146\
+a.25.25 0 0 1-.4\
+27.177L13.03 4.0\
+3 9.28 7.78a.751\
+.751 0 0 1-1.042\
+-.018.751.751 0 \
+0 1-.018-1.042l3\
+.75-3.75-1.543-1\
+.543A.25.25 0 0 \
+1 10.604 1Z\x22></p\
+ath>\x0a</svg>\x0a</a>\
+</li>\x0a\x0a         \
+           <li>\x0a\
+  <a class=\x22Head\
+erMenu-dropdown-\
+link d-block no-\
+underline positi\
+on-relative py-2\
+ Link--secondary\
+ Link--external\x22\
+ target=\x22_blank\x22\
+ data-analytics-\
+event=\x22{&quot;lo\
+cation&quot;:&qu\
+ot;navbar&quot;,\
+&quot;action&quo\
+t;:&quot;github_\
+skills&quot;,&qu\
+ot;context&quot;\
+:&quot;product&q\
+uot;,&quot;tag&q\
+uot;:&quot;link&\
+quot;,&quot;labe\
+l&quot;:&quot;gi\
+thub_skills_link\
+_product_navbar&\
+quot;}\x22 href=\x22ht\
+tps://skills.git\
+hub.com\x22>\x0a      \
+GitHub Skills\x0a\x0a \
+   <svg aria-hid\
+den=\x22true\x22 heigh\
+t=\x2216\x22 viewBox=\x22\
+0 0 16 16\x22 versi\
+on=\x221.1\x22 width=\x22\
+16\x22 data-view-co\
+mponent=\x22true\x22 c\
+lass=\x22octicon oc\
+ticon-link-exter\
+nal HeaderMenu-e\
+xternal-icon col\
+or-fg-subtle\x22>\x0a \
+   <path d=\x22M3.7\
+5 2h3.5a.75.75 0\
+ 0 1 0 1.5h-3.5a\
+.25.25 0 0 0-.25\
+.25v8.5c0 .138.1\
+12.25.25.25h8.5a\
+.25.25 0 0 0 .25\
+-.25v-3.5a.75.75\
+ 0 0 1 1.5 0v3.5\
+A1.75 1.75 0 0 1\
+ 12.25 14h-8.5A1\
+.75 1.75 0 0 1 2\
+ 12.25v-8.5C2 2.\
+784 2.784 2 3.75\
+ 2Zm6.854-1h4.14\
+6a.25.25 0 0 1 .\
+25.25v4.146a.25.\
+25 0 0 1-.427.17\
+7L13.03 4.03 9.2\
+8 7.78a.751.751 \
+0 0 1-1.042-.018\
+.751.751 0 0 1-.\
+018-1.042l3.75-3\
+.75-1.543-1.543A\
+.25.25 0 0 1 10.\
+604 1Z\x22></path>\x0a\
+</svg>\x0a</a></li>\
+\x0a\x0a              \
+      <li>\x0a  <a \
+class=\x22HeaderMen\
+u-dropdown-link \
+d-block no-under\
+line position-re\
+lative py-2 Link\
+--secondary Link\
+--external\x22 targ\
+et=\x22_blank\x22 data\
+-analytics-event\
+=\x22{&quot;locatio\
+n&quot;:&quot;na\
+vbar&quot;,&quot\
+;action&quot;:&q\
+uot;blog&quot;,&\
+quot;context&quo\
+t;:&quot;product\
+&quot;,&quot;tag\
+&quot;:&quot;lin\
+k&quot;,&quot;la\
+bel&quot;:&quot;\
+blog_link_produc\
+t_navbar&quot;}\x22\
+ href=\x22https://g\
+ithub.blog\x22>\x0a   \
+   Blog\x0a\x0a    <sv\
+g aria-hidden=\x22t\
+rue\x22 height=\x2216\x22\
+ viewBox=\x220 0 16\
+ 16\x22 version=\x221.\
+1\x22 width=\x2216\x22 da\
+ta-view-componen\
+t=\x22true\x22 class=\x22\
+octicon octicon-\
+link-external He\
+aderMenu-externa\
+l-icon color-fg-\
+subtle\x22>\x0a    <pa\
+th d=\x22M3.75 2h3.\
+5a.75.75 0 0 1 0\
+ 1.5h-3.5a.25.25\
+ 0 0 0-.25.25v8.\
+5c0 .138.112.25.\
+25.25h8.5a.25.25\
+ 0 0 0 .25-.25v-\
+3.5a.75.75 0 0 1\
+ 1.5 0v3.5A1.75 \
+1.75 0 0 1 12.25\
+ 14h-8.5A1.75 1.\
+75 0 0 1 2 12.25\
+v-8.5C2 2.784 2.\
+784 2 3.75 2Zm6.\
+854-1h4.146a.25.\
+25 0 0 1 .25.25v\
+4.146a.25.25 0 0\
+ 1-.427.177L13.0\
+3 4.03 9.28 7.78\
+a.751.751 0 0 1-\
+1.042-.018.751.7\
+51 0 0 1-.018-1.\
+042l3.75-3.75-1.\
+543-1.543A.25.25\
+ 0 0 1 10.604 1Z\
+\x22></path>\x0a</svg>\
+\x0a</a></li>\x0a\x0a    \
+            </ul\
+>\x0a              \
+</div>\x0a         \
+ </div>\x0a\x0a      <\
+/div>\x0a</li>\x0a\x0a\x0a  \
+              <l\
+i class=\x22HeaderM\
+enu-item positio\
+n-relative flex-\
+wrap flex-justif\
+y-between flex-i\
+tems-center d-bl\
+ock d-lg-flex fl\
+ex-lg-nowrap fle\
+x-lg-items-cente\
+r js-details-con\
+tainer js-header\
+-menu-item\x22>\x0a   \
+   <button type=\
+\x22button\x22 class=\x22\
+HeaderMenu-link \
+border-0 width-f\
+ull width-lg-aut\
+o px-0 px-lg-2 p\
+y-lg-2 no-wrap d\
+-flex flex-items\
+-center flex-jus\
+tify-between js-\
+details-target\x22 \
+aria-expanded=\x22f\
+alse\x22>\x0a        S\
+olutions\x0a       \
+ <svg opacity=\x220\
+.5\x22 aria-hidden=\
+\x22true\x22 height=\x221\
+6\x22 viewBox=\x220 0 \
+16 16\x22 version=\x22\
+1.1\x22 width=\x2216\x22 \
+data-view-compon\
+ent=\x22true\x22 class\
+=\x22octicon octico\
+n-chevron-down H\
+eaderMenu-icon m\
+l-1\x22>\x0a    <path \
+d=\x22M12.78 5.22a.\
+749.749 0 0 1 0 \
+1.06l-4.25 4.25a\
+.749.749 0 0 1-1\
+.06 0L3.22 6.28a\
+.749.749 0 1 1 1\
+.06-1.06L8 8.939\
+l3.72-3.719a.749\
+.749 0 0 1 1.06 \
+0Z\x22></path>\x0a</sv\
+g>\x0a      </butto\
+n>\x0a\x0a      <div c\
+lass=\x22HeaderMenu\
+-dropdown dropdo\
+wn-menu rounded \
+m-0 p-0 pt-2 pt-\
+lg-4 position-re\
+lative position-\
+lg-absolute left\
+-0 left-lg-n3 d-\
+lg-flex flex-wra\
+p dropdown-menu-\
+wide\x22>\x0a         \
+ <div class=\x22Hea\
+derMenu-column p\
+l-lg-4 px-lg-4 p\
+b-3 pb-lg-0\x22>\x0a  \
+            <div\
+ class=\x22border-b\
+ottom border-lg-\
+bottom-0 mb-3 pb\
+-3\x22>\x0a           \
+         <span c\
+lass=\x22d-block h4\
+ color-fg-defaul\
+t my-1\x22 id=\x22solu\
+tions-by-company\
+-size-heading\x22>B\
+y company size</\
+span>\x0a\x0a         \
+       <ul class\
+=\x22list-style-non\
+e f5\x22 aria-label\
+ledby=\x22solutions\
+-by-company-size\
+-heading\x22>\x0a     \
+               <\
+li>\x0a  <a class=\x22\
+HeaderMenu-dropd\
+own-link d-block\
+ no-underline po\
+sition-relative \
+py-2 Link--secon\
+dary\x22 data-analy\
+tics-event=\x22{&qu\
+ot;location&quot\
+;:&quot;navbar&q\
+uot;,&quot;actio\
+n&quot;:&quot;en\
+terprises&quot;,\
+&quot;context&qu\
+ot;:&quot;soluti\
+ons&quot;,&quot;\
+tag&quot;:&quot;\
+link&quot;,&quot\
+;label&quot;:&qu\
+ot;enterprises_l\
+ink_solutions_na\
+vbar&quot;}\x22 hre\
+f=\x22https://githu\
+b.com/enterprise\
+\x22>\x0a      Enterpr\
+ises\x0a\x0a    \x0a</a><\
+/li>\x0a\x0a          \
+          <li>\x0a \
+ <a class=\x22Heade\
+rMenu-dropdown-l\
+ink d-block no-u\
+nderline positio\
+n-relative py-2 \
+Link--secondary\x22\
+ data-analytics-\
+event=\x22{&quot;lo\
+cation&quot;:&qu\
+ot;navbar&quot;,\
+&quot;action&quo\
+t;:&quot;small_a\
+nd_medium_teams&\
+quot;,&quot;cont\
+ext&quot;:&quot;\
+solutions&quot;,\
+&quot;tag&quot;:\
+&quot;link&quot;\
+,&quot;label&quo\
+t;:&quot;small_a\
+nd_medium_teams_\
+link_solutions_n\
+avbar&quot;}\x22 hr\
+ef=\x22https://gith\
+ub.com/team\x22>\x0a  \
+    Small and me\
+dium teams\x0a\x0a    \
+\x0a</a></li>\x0a\x0a    \
+                \
+<li>\x0a  <a class=\
+\x22HeaderMenu-drop\
+down-link d-bloc\
+k no-underline p\
+osition-relative\
+ py-2 Link--seco\
+ndary\x22 data-anal\
+ytics-event=\x22{&q\
+uot;location&quo\
+t;:&quot;navbar&\
+quot;,&quot;acti\
+on&quot;:&quot;s\
+tartups&quot;,&q\
+uot;context&quot\
+;:&quot;solution\
+s&quot;,&quot;ta\
+g&quot;:&quot;li\
+nk&quot;,&quot;l\
+abel&quot;:&quot\
+;startups_link_s\
+olutions_navbar&\
+quot;}\x22 href=\x22ht\
+tps://github.com\
+/enterprise/star\
+tups\x22>\x0a      Sta\
+rtups\x0a\x0a    \x0a</a>\
+</li>\x0a\x0a         \
+           <li>\x0a\
+  <a class=\x22Head\
+erMenu-dropdown-\
+link d-block no-\
+underline positi\
+on-relative py-2\
+ Link--secondary\
+\x22 data-analytics\
+-event=\x22{&quot;l\
+ocation&quot;:&q\
+uot;navbar&quot;\
+,&quot;action&qu\
+ot;:&quot;nonpro\
+fits&quot;,&quot\
+;context&quot;:&\
+quot;solutions&q\
+uot;,&quot;tag&q\
+uot;:&quot;link&\
+quot;,&quot;labe\
+l&quot;:&quot;no\
+nprofits_link_so\
+lutions_navbar&q\
+uot;}\x22 href=\x22/so\
+lutions/industry\
+/nonprofits\x22>\x0a  \
+    Nonprofits\x0a\x0a\
+    \x0a</a></li>\x0a\x0a\
+                \
+</ul>\x0a          \
+    </div>\x0a     \
+         <div cl\
+ass=\x22border-bott\
+om border-lg-bot\
+tom-0 pb-3\x22>\x0a   \
+                \
+ <span class=\x22d-\
+block h4 color-f\
+g-default my-1\x22 \
+id=\x22solutions-by\
+-use-case-headin\
+g\x22>By use case</\
+span>\x0a\x0a         \
+       <ul class\
+=\x22list-style-non\
+e f5\x22 aria-label\
+ledby=\x22solutions\
+-by-use-case-hea\
+ding\x22>\x0a         \
+           <li>\x0a\
+  <a class=\x22Head\
+erMenu-dropdown-\
+link d-block no-\
+underline positi\
+on-relative py-2\
+ Link--secondary\
+\x22 data-analytics\
+-event=\x22{&quot;l\
+ocation&quot;:&q\
+uot;navbar&quot;\
+,&quot;action&qu\
+ot;:&quot;devsec\
+ops&quot;,&quot;\
+context&quot;:&q\
+uot;solutions&qu\
+ot;,&quot;tag&qu\
+ot;:&quot;link&q\
+uot;,&quot;label\
+&quot;:&quot;dev\
+secops_link_solu\
+tions_navbar&quo\
+t;}\x22 href=\x22/solu\
+tions/use-case/d\
+evsecops\x22>\x0a     \
+ DevSecOps\x0a\x0a    \
+\x0a</a></li>\x0a\x0a    \
+                \
+<li>\x0a  <a class=\
+\x22HeaderMenu-drop\
+down-link d-bloc\
+k no-underline p\
+osition-relative\
+ py-2 Link--seco\
+ndary\x22 data-anal\
+ytics-event=\x22{&q\
+uot;location&quo\
+t;:&quot;navbar&\
+quot;,&quot;acti\
+on&quot;:&quot;d\
+evops&quot;,&quo\
+t;context&quot;:\
+&quot;solutions&\
+quot;,&quot;tag&\
+quot;:&quot;link\
+&quot;,&quot;lab\
+el&quot;:&quot;d\
+evops_link_solut\
+ions_navbar&quot\
+;}\x22 href=\x22/solut\
+ions/use-case/de\
+vops\x22>\x0a      Dev\
+Ops\x0a\x0a    \x0a</a></\
+li>\x0a\x0a           \
+         <li>\x0a  \
+<a class=\x22Header\
+Menu-dropdown-li\
+nk d-block no-un\
+derline position\
+-relative py-2 L\
+ink--secondary\x22 \
+data-analytics-e\
+vent=\x22{&quot;loc\
+ation&quot;:&quo\
+t;navbar&quot;,&\
+quot;action&quot\
+;:&quot;ci_cd&qu\
+ot;,&quot;contex\
+t&quot;:&quot;so\
+lutions&quot;,&q\
+uot;tag&quot;:&q\
+uot;link&quot;,&\
+quot;label&quot;\
+:&quot;ci_cd_lin\
+k_solutions_navb\
+ar&quot;}\x22 href=\
+\x22/solutions/use-\
+case/ci-cd\x22>\x0a   \
+   CI/CD\x0a\x0a    \x0a<\
+/a></li>\x0a\x0a      \
+              <l\
+i>\x0a  <a class=\x22H\
+eaderMenu-dropdo\
+wn-link d-block \
+no-underline pos\
+ition-relative p\
+y-2 Link--second\
+ary\x22 data-analyt\
+ics-event=\x22{&quo\
+t;location&quot;\
+:&quot;navbar&qu\
+ot;,&quot;action\
+&quot;:&quot;vie\
+w_all_use_cases&\
+quot;,&quot;cont\
+ext&quot;:&quot;\
+solutions&quot;,\
+&quot;tag&quot;:\
+&quot;link&quot;\
+,&quot;label&quo\
+t;:&quot;view_al\
+l_use_cases_link\
+_solutions_navba\
+r&quot;}\x22 href=\x22\
+/solutions/use-c\
+ase\x22>\x0a      View\
+ all use cases\x0a\x0a\
+    \x0a</a></li>\x0a\x0a\
+                \
+</ul>\x0a          \
+    </div>\x0a     \
+     </div>\x0a    \
+      <div class\
+=\x22HeaderMenu-col\
+umn pl-lg-4 bord\
+er-lg-left pr-lg\
+-7\x22>\x0a           \
+   <div class=\x22b\
+order-bottom bor\
+der-lg-bottom-0 \
+pb-3 pb-lg-0\x22>\x0a \
+                \
+   <span class=\x22\
+d-block h4 color\
+-fg-default my-1\
+\x22 id=\x22solutions-\
+by-industry-head\
+ing\x22>By industry\
+</span>\x0a\x0a       \
+         <ul cla\
+ss=\x22list-style-n\
+one f5\x22 aria-lab\
+elledby=\x22solutio\
+ns-by-industry-h\
+eading\x22>\x0a       \
+             <li\
+>\x0a  <a class=\x22He\
+aderMenu-dropdow\
+n-link d-block n\
+o-underline posi\
+tion-relative py\
+-2 Link--seconda\
+ry\x22 data-analyti\
+cs-event=\x22{&quot\
+;location&quot;:\
+&quot;navbar&quo\
+t;,&quot;action&\
+quot;:&quot;heal\
+thcare&quot;,&qu\
+ot;context&quot;\
+:&quot;solutions\
+&quot;,&quot;tag\
+&quot;:&quot;lin\
+k&quot;,&quot;la\
+bel&quot;:&quot;\
+healthcare_link_\
+solutions_navbar\
+&quot;}\x22 href=\x22/\
+solutions/indust\
+ry/healthcare\x22>\x0a\
+      Healthcare\
+\x0a\x0a    \x0a</a></li>\
+\x0a\x0a              \
+      <li>\x0a  <a \
+class=\x22HeaderMen\
+u-dropdown-link \
+d-block no-under\
+line position-re\
+lative py-2 Link\
+--secondary\x22 dat\
+a-analytics-even\
+t=\x22{&quot;locati\
+on&quot;:&quot;n\
+avbar&quot;,&quo\
+t;action&quot;:&\
+quot;financial_s\
+ervices&quot;,&q\
+uot;context&quot\
+;:&quot;solution\
+s&quot;,&quot;ta\
+g&quot;:&quot;li\
+nk&quot;,&quot;l\
+abel&quot;:&quot\
+;financial_servi\
+ces_link_solutio\
+ns_navbar&quot;}\
+\x22 href=\x22/solutio\
+ns/industry/fina\
+ncial-services\x22>\
+\x0a      Financial\
+ services\x0a\x0a    \x0a\
+</a></li>\x0a\x0a     \
+               <\
+li>\x0a  <a class=\x22\
+HeaderMenu-dropd\
+own-link d-block\
+ no-underline po\
+sition-relative \
+py-2 Link--secon\
+dary\x22 data-analy\
+tics-event=\x22{&qu\
+ot;location&quot\
+;:&quot;navbar&q\
+uot;,&quot;actio\
+n&quot;:&quot;ma\
+nufacturing&quot\
+;,&quot;context&\
+quot;:&quot;solu\
+tions&quot;,&quo\
+t;tag&quot;:&quo\
+t;link&quot;,&qu\
+ot;label&quot;:&\
+quot;manufacturi\
+ng_link_solution\
+s_navbar&quot;}\x22\
+ href=\x22/solution\
+s/industry/manuf\
+acturing\x22>\x0a     \
+ Manufacturing\x0a\x0a\
+    \x0a</a></li>\x0a\x0a\
+                \
+    <li>\x0a  <a cl\
+ass=\x22HeaderMenu-\
+dropdown-link d-\
+block no-underli\
+ne position-rela\
+tive py-2 Link--\
+secondary\x22 data-\
+analytics-event=\
+\x22{&quot;location\
+&quot;:&quot;nav\
+bar&quot;,&quot;\
+action&quot;:&qu\
+ot;government&qu\
+ot;,&quot;contex\
+t&quot;:&quot;so\
+lutions&quot;,&q\
+uot;tag&quot;:&q\
+uot;link&quot;,&\
+quot;label&quot;\
+:&quot;governmen\
+t_link_solutions\
+_navbar&quot;}\x22 \
+href=\x22/solutions\
+/industry/govern\
+ment\x22>\x0a      Gov\
+ernment\x0a\x0a    \x0a</\
+a></li>\x0a\x0a       \
+             <li\
+>\x0a  <a class=\x22He\
+aderMenu-dropdow\
+n-link d-block n\
+o-underline posi\
+tion-relative py\
+-2 Link--seconda\
+ry\x22 data-analyti\
+cs-event=\x22{&quot\
+;location&quot;:\
+&quot;navbar&quo\
+t;,&quot;action&\
+quot;:&quot;view\
+_all_industries&\
+quot;,&quot;cont\
+ext&quot;:&quot;\
+solutions&quot;,\
+&quot;tag&quot;:\
+&quot;link&quot;\
+,&quot;label&quo\
+t;:&quot;view_al\
+l_industries_lin\
+k_solutions_navb\
+ar&quot;}\x22 href=\
+\x22/solutions/indu\
+stry\x22>\x0a      Vie\
+w all industries\
+\x0a\x0a    \x0a</a></li>\
+\x0a\x0a              \
+  </ul>\x0a        \
+      </div>\x0a   \
+       </div>\x0a\x0a \
+        <div cla\
+ss=\x22HeaderMenu-t\
+railing-link rou\
+nded-bottom-2 fl\
+ex-shrink-0 mt-l\
+g-4 px-lg-4 py-4\
+ py-lg-3 f5 text\
+-semibold\x22>\x0a    \
+        <a href=\
+\x22/solutions\x22>\x0a  \
+            View\
+ all solutions\x0a \
+             <sv\
+g aria-hidden=\x22t\
+rue\x22 height=\x2216\x22\
+ viewBox=\x220 0 16\
+ 16\x22 version=\x221.\
+1\x22 width=\x2216\x22 da\
+ta-view-componen\
+t=\x22true\x22 class=\x22\
+octicon octicon-\
+chevron-right He\
+aderMenu-trailin\
+g-link-icon\x22>\x0a  \
+  <path d=\x22M6.22\
+ 3.22a.75.75 0 0\
+ 1 1.06 0l4.25 4\
+.25a.75.75 0 0 1\
+ 0 1.06l-4.25 4.\
+25a.751.751 0 0 \
+1-1.042-.018.751\
+.751 0 0 1-.018-\
+1.042L9.94 8 6.2\
+2 4.28a.75.75 0 \
+0 1 0-1.06Z\x22></p\
+ath>\x0a</svg>\x0a</a>\
+         </div>\x0a\
+      </div>\x0a</l\
+i>\x0a\x0a\x0a           \
+     <li class=\x22\
+HeaderMenu-item \
+position-relativ\
+e flex-wrap flex\
+-justify-between\
+ flex-items-cent\
+er d-block d-lg-\
+flex flex-lg-now\
+rap flex-lg-item\
+s-center js-deta\
+ils-container js\
+-header-menu-ite\
+m\x22>\x0a      <butto\
+n type=\x22button\x22 \
+class=\x22HeaderMen\
+u-link border-0 \
+width-full width\
+-lg-auto px-0 px\
+-lg-2 py-lg-2 no\
+-wrap d-flex fle\
+x-items-center f\
+lex-justify-betw\
+een js-details-t\
+arget\x22 aria-expa\
+nded=\x22false\x22>\x0a  \
+      Resources\x0a\
+        <svg opa\
+city=\x220.5\x22 aria-\
+hidden=\x22true\x22 he\
+ight=\x2216\x22 viewBo\
+x=\x220 0 16 16\x22 ve\
+rsion=\x221.1\x22 widt\
+h=\x2216\x22 data-view\
+-component=\x22true\
+\x22 class=\x22octicon\
+ octicon-chevron\
+-down HeaderMenu\
+-icon ml-1\x22>\x0a   \
+ <path d=\x22M12.78\
+ 5.22a.749.749 0\
+ 0 1 0 1.06l-4.2\
+5 4.25a.749.749 \
+0 0 1-1.06 0L3.2\
+2 6.28a.749.749 \
+0 1 1 1.06-1.06L\
+8 8.939l3.72-3.7\
+19a.749.749 0 0 \
+1 1.06 0Z\x22></pat\
+h>\x0a</svg>\x0a      \
+</button>\x0a\x0a     \
+ <div class=\x22Hea\
+derMenu-dropdown\
+ dropdown-menu r\
+ounded m-0 p-0 p\
+t-2 pt-lg-4 posi\
+tion-relative po\
+sition-lg-absolu\
+te left-0 left-l\
+g-n3 pb-2 pb-lg-\
+4 d-lg-flex flex\
+-wrap dropdown-m\
+enu-wide\x22>\x0a     \
+     <div class=\
+\x22HeaderMenu-colu\
+mn pl-lg-4 px-lg\
+-4 pb-3 pb-lg-0\x22\
+>\x0a              \
+<div class=\x22bord\
+er-bottom border\
+-lg-bottom-0 pb-\
+3\x22>\x0a            \
+        <span cl\
+ass=\x22d-block h4 \
+color-fg-default\
+ my-1\x22 id=\x22resou\
+rces-topics-head\
+ing\x22>Topics</spa\
+n>\x0a\x0a            \
+    <ul class=\x22l\
+ist-style-none f\
+5\x22 aria-labelled\
+by=\x22resources-to\
+pics-heading\x22>\x0a \
+                \
+   <li>\x0a  <a cla\
+ss=\x22HeaderMenu-d\
+ropdown-link d-b\
+lock no-underlin\
+e position-relat\
+ive py-2 Link--s\
+econdary\x22 data-a\
+nalytics-event=\x22\
+{&quot;location&\
+quot;:&quot;navb\
+ar&quot;,&quot;a\
+ction&quot;:&quo\
+t;ai&quot;,&quot\
+;context&quot;:&\
+quot;resources&q\
+uot;,&quot;tag&q\
+uot;:&quot;link&\
+quot;,&quot;labe\
+l&quot;:&quot;ai\
+_link_resources_\
+navbar&quot;}\x22 h\
+ref=\x22/resources/\
+articles/ai\x22>\x0a  \
+    AI\x0a\x0a    \x0a</a\
+></li>\x0a\x0a        \
+            <li>\
+\x0a  <a class=\x22Hea\
+derMenu-dropdown\
+-link d-block no\
+-underline posit\
+ion-relative py-\
+2 Link--secondar\
+y\x22 data-analytic\
+s-event=\x22{&quot;\
+location&quot;:&\
+quot;navbar&quot\
+;,&quot;action&q\
+uot;:&quot;devop\
+s&quot;,&quot;co\
+ntext&quot;:&quo\
+t;resources&quot\
+;,&quot;tag&quot\
+;:&quot;link&quo\
+t;,&quot;label&q\
+uot;:&quot;devop\
+s_link_resources\
+_navbar&quot;}\x22 \
+href=\x22/resources\
+/articles/devops\
+\x22>\x0a      DevOps\x0a\
+\x0a    \x0a</a></li>\x0a\
+\x0a               \
+     <li>\x0a  <a c\
+lass=\x22HeaderMenu\
+-dropdown-link d\
+-block no-underl\
+ine position-rel\
+ative py-2 Link-\
+-secondary\x22 data\
+-analytics-event\
+=\x22{&quot;locatio\
+n&quot;:&quot;na\
+vbar&quot;,&quot\
+;action&quot;:&q\
+uot;security&quo\
+t;,&quot;context\
+&quot;:&quot;res\
+ources&quot;,&qu\
+ot;tag&quot;:&qu\
+ot;link&quot;,&q\
+uot;label&quot;:\
+&quot;security_l\
+ink_resources_na\
+vbar&quot;}\x22 hre\
+f=\x22/resources/ar\
+ticles/security\x22\
+>\x0a      Security\
+\x0a\x0a    \x0a</a></li>\
+\x0a\x0a              \
+      <li>\x0a  <a \
+class=\x22HeaderMen\
+u-dropdown-link \
+d-block no-under\
+line position-re\
+lative py-2 Link\
+--secondary\x22 dat\
+a-analytics-even\
+t=\x22{&quot;locati\
+on&quot;:&quot;n\
+avbar&quot;,&quo\
+t;action&quot;:&\
+quot;software_de\
+velopment&quot;,\
+&quot;context&qu\
+ot;:&quot;resour\
+ces&quot;,&quot;\
+tag&quot;:&quot;\
+link&quot;,&quot\
+;label&quot;:&qu\
+ot;software_deve\
+lopment_link_res\
+ources_navbar&qu\
+ot;}\x22 href=\x22/res\
+ources/articles/\
+software-develop\
+ment\x22>\x0a      Sof\
+tware Developmen\
+t\x0a\x0a    \x0a</a></li\
+>\x0a\x0a             \
+       <li>\x0a  <a\
+ class=\x22HeaderMe\
+nu-dropdown-link\
+ d-block no-unde\
+rline position-r\
+elative py-2 Lin\
+k--secondary\x22 da\
+ta-analytics-eve\
+nt=\x22{&quot;locat\
+ion&quot;:&quot;\
+navbar&quot;,&qu\
+ot;action&quot;:\
+&quot;view_all&q\
+uot;,&quot;conte\
+xt&quot;:&quot;r\
+esources&quot;,&\
+quot;tag&quot;:&\
+quot;link&quot;,\
+&quot;label&quot\
+;:&quot;view_all\
+_link_resources_\
+navbar&quot;}\x22 h\
+ref=\x22/resources/\
+articles\x22>\x0a     \
+ View all\x0a\x0a    \x0a\
+</a></li>\x0a\x0a     \
+           </ul>\
+\x0a              <\
+/div>\x0a          \
+</div>\x0a         \
+ <div class=\x22Hea\
+derMenu-column p\
+l-lg-4 border-lg\
+-left pr-lg-7\x22>\x0a\
+              <d\
+iv class=\x22border\
+-bottom border-l\
+g-bottom-0 borde\
+r-bottom-0\x22>\x0a   \
+                \
+ <span class=\x22d-\
+block h4 color-f\
+g-default my-1\x22 \
+id=\x22resources-ex\
+plore-heading\x22>E\
+xplore</span>\x0a\x0a \
+               <\
+ul class=\x22list-s\
+tyle-none f5\x22 ar\
+ia-labelledby=\x22r\
+esources-explore\
+-heading\x22>\x0a     \
+               <\
+li>\x0a  <a class=\x22\
+HeaderMenu-dropd\
+own-link d-block\
+ no-underline po\
+sition-relative \
+py-2 Link--secon\
+dary Link--exter\
+nal\x22 target=\x22_bl\
+ank\x22 data-analyt\
+ics-event=\x22{&quo\
+t;location&quot;\
+:&quot;navbar&qu\
+ot;,&quot;action\
+&quot;:&quot;lea\
+rning_pathways&q\
+uot;,&quot;conte\
+xt&quot;:&quot;r\
+esources&quot;,&\
+quot;tag&quot;:&\
+quot;link&quot;,\
+&quot;label&quot\
+;:&quot;learning\
+_pathways_link_r\
+esources_navbar&\
+quot;}\x22 href=\x22ht\
+tps://resources.\
+github.com/learn\
+/pathways\x22>\x0a    \
+  Learning Pathw\
+ays\x0a\x0a    <svg ar\
+ia-hidden=\x22true\x22\
+ height=\x2216\x22 vie\
+wBox=\x220 0 16 16\x22\
+ version=\x221.1\x22 w\
+idth=\x2216\x22 data-v\
+iew-component=\x22t\
+rue\x22 class=\x22octi\
+con octicon-link\
+-external Header\
+Menu-external-ic\
+on color-fg-subt\
+le\x22>\x0a    <path d\
+=\x22M3.75 2h3.5a.7\
+5.75 0 0 1 0 1.5\
+h-3.5a.25.25 0 0\
+ 0-.25.25v8.5c0 \
+.138.112.25.25.2\
+5h8.5a.25.25 0 0\
+ 0 .25-.25v-3.5a\
+.75.75 0 0 1 1.5\
+ 0v3.5A1.75 1.75\
+ 0 0 1 12.25 14h\
+-8.5A1.75 1.75 0\
+ 0 1 2 12.25v-8.\
+5C2 2.784 2.784 \
+2 3.75 2Zm6.854-\
+1h4.146a.25.25 0\
+ 0 1 .25.25v4.14\
+6a.25.25 0 0 1-.\
+427.177L13.03 4.\
+03 9.28 7.78a.75\
+1.751 0 0 1-1.04\
+2-.018.751.751 0\
+ 0 1-.018-1.042l\
+3.75-3.75-1.543-\
+1.543A.25.25 0 0\
+ 1 10.604 1Z\x22></\
+path>\x0a</svg>\x0a</a\
+></li>\x0a\x0a        \
+            <li>\
+\x0a  <a class=\x22Hea\
+derMenu-dropdown\
+-link d-block no\
+-underline posit\
+ion-relative py-\
+2 Link--secondar\
+y Link--external\
+\x22 target=\x22_blank\
+\x22 data-analytics\
+-event=\x22{&quot;l\
+ocation&quot;:&q\
+uot;navbar&quot;\
+,&quot;action&qu\
+ot;:&quot;events\
+_amp_webinars&qu\
+ot;,&quot;contex\
+t&quot;:&quot;re\
+sources&quot;,&q\
+uot;tag&quot;:&q\
+uot;link&quot;,&\
+quot;label&quot;\
+:&quot;events_am\
+p_webinars_link_\
+resources_navbar\
+&quot;}\x22 href=\x22h\
+ttps://resources\
+.github.com\x22>\x0a  \
+    Events &amp;\
+ Webinars\x0a\x0a    <\
+svg aria-hidden=\
+\x22true\x22 height=\x221\
+6\x22 viewBox=\x220 0 \
+16 16\x22 version=\x22\
+1.1\x22 width=\x2216\x22 \
+data-view-compon\
+ent=\x22true\x22 class\
+=\x22octicon octico\
+n-link-external \
+HeaderMenu-exter\
+nal-icon color-f\
+g-subtle\x22>\x0a    <\
+path d=\x22M3.75 2h\
+3.5a.75.75 0 0 1\
+ 0 1.5h-3.5a.25.\
+25 0 0 0-.25.25v\
+8.5c0 .138.112.2\
+5.25.25h8.5a.25.\
+25 0 0 0 .25-.25\
+v-3.5a.75.75 0 0\
+ 1 1.5 0v3.5A1.7\
+5 1.75 0 0 1 12.\
+25 14h-8.5A1.75 \
+1.75 0 0 1 2 12.\
+25v-8.5C2 2.784 \
+2.784 2 3.75 2Zm\
+6.854-1h4.146a.2\
+5.25 0 0 1 .25.2\
+5v4.146a.25.25 0\
+ 0 1-.427.177L13\
+.03 4.03 9.28 7.\
+78a.751.751 0 0 \
+1-1.042-.018.751\
+.751 0 0 1-.018-\
+1.042l3.75-3.75-\
+1.543-1.543A.25.\
+25 0 0 1 10.604 \
+1Z\x22></path>\x0a</sv\
+g>\x0a</a></li>\x0a\x0a  \
+                \
+  <li>\x0a  <a clas\
+s=\x22HeaderMenu-dr\
+opdown-link d-bl\
+ock no-underline\
+ position-relati\
+ve py-2 Link--se\
+condary\x22 data-an\
+alytics-event=\x22{\
+&quot;location&q\
+uot;:&quot;navba\
+r&quot;,&quot;ac\
+tion&quot;:&quot\
+;ebooks_amp_whit\
+epapers&quot;,&q\
+uot;context&quot\
+;:&quot;resource\
+s&quot;,&quot;ta\
+g&quot;:&quot;li\
+nk&quot;,&quot;l\
+abel&quot;:&quot\
+;ebooks_amp_whit\
+epapers_link_res\
+ources_navbar&qu\
+ot;}\x22 href=\x22http\
+s://github.com/r\
+esources/whitepa\
+pers\x22>\x0a      Ebo\
+oks &amp; Whitep\
+apers\x0a\x0a    \x0a</a>\
+</li>\x0a\x0a         \
+           <li>\x0a\
+  <a class=\x22Head\
+erMenu-dropdown-\
+link d-block no-\
+underline positi\
+on-relative py-2\
+ Link--secondary\
+\x22 data-analytics\
+-event=\x22{&quot;l\
+ocation&quot;:&q\
+uot;navbar&quot;\
+,&quot;action&qu\
+ot;:&quot;custom\
+er_stories&quot;\
+,&quot;context&q\
+uot;:&quot;resou\
+rces&quot;,&quot\
+;tag&quot;:&quot\
+;link&quot;,&quo\
+t;label&quot;:&q\
+uot;customer_sto\
+ries_link_resour\
+ces_navbar&quot;\
+}\x22 href=\x22https:/\
+/github.com/cust\
+omer-stories\x22>\x0a \
+     Customer St\
+ories\x0a\x0a    \x0a</a>\
+</li>\x0a\x0a         \
+           <li>\x0a\
+  <a class=\x22Head\
+erMenu-dropdown-\
+link d-block no-\
+underline positi\
+on-relative py-2\
+ Link--secondary\
+ Link--external\x22\
+ target=\x22_blank\x22\
+ data-analytics-\
+event=\x22{&quot;lo\
+cation&quot;:&qu\
+ot;navbar&quot;,\
+&quot;action&quo\
+t;:&quot;partner\
+s&quot;,&quot;co\
+ntext&quot;:&quo\
+t;resources&quot\
+;,&quot;tag&quot\
+;:&quot;link&quo\
+t;,&quot;label&q\
+uot;:&quot;partn\
+ers_link_resourc\
+es_navbar&quot;}\
+\x22 href=\x22https://\
+partner.github.c\
+om\x22>\x0a      Partn\
+ers\x0a\x0a    <svg ar\
+ia-hidden=\x22true\x22\
+ height=\x2216\x22 vie\
+wBox=\x220 0 16 16\x22\
+ version=\x221.1\x22 w\
+idth=\x2216\x22 data-v\
+iew-component=\x22t\
+rue\x22 class=\x22octi\
+con octicon-link\
+-external Header\
+Menu-external-ic\
+on color-fg-subt\
+le\x22>\x0a    <path d\
+=\x22M3.75 2h3.5a.7\
+5.75 0 0 1 0 1.5\
+h-3.5a.25.25 0 0\
+ 0-.25.25v8.5c0 \
+.138.112.25.25.2\
+5h8.5a.25.25 0 0\
+ 0 .25-.25v-3.5a\
+.75.75 0 0 1 1.5\
+ 0v3.5A1.75 1.75\
+ 0 0 1 12.25 14h\
+-8.5A1.75 1.75 0\
+ 0 1 2 12.25v-8.\
+5C2 2.784 2.784 \
+2 3.75 2Zm6.854-\
+1h4.146a.25.25 0\
+ 0 1 .25.25v4.14\
+6a.25.25 0 0 1-.\
+427.177L13.03 4.\
+03 9.28 7.78a.75\
+1.751 0 0 1-1.04\
+2-.018.751.751 0\
+ 0 1-.018-1.042l\
+3.75-3.75-1.543-\
+1.543A.25.25 0 0\
+ 1 10.604 1Z\x22></\
+path>\x0a</svg>\x0a</a\
+></li>\x0a\x0a        \
+            <li>\
+\x0a  <a class=\x22Hea\
+derMenu-dropdown\
+-link d-block no\
+-underline posit\
+ion-relative py-\
+2 Link--secondar\
+y\x22 data-analytic\
+s-event=\x22{&quot;\
+location&quot;:&\
+quot;navbar&quot\
+;,&quot;action&q\
+uot;:&quot;execu\
+tive_insights&qu\
+ot;,&quot;contex\
+t&quot;:&quot;re\
+sources&quot;,&q\
+uot;tag&quot;:&q\
+uot;link&quot;,&\
+quot;label&quot;\
+:&quot;executive\
+_insights_link_r\
+esources_navbar&\
+quot;}\x22 href=\x22ht\
+tps://github.com\
+/solutions/execu\
+tive-insights\x22>\x0a\
+      Executive \
+Insights\x0a\x0a    \x0a<\
+/a></li>\x0a\x0a      \
+          </ul>\x0a\
+              </\
+div>\x0a          <\
+/div>\x0a\x0a      </d\
+iv>\x0a</li>\x0a\x0a\x0a    \
+            <li \
+class=\x22HeaderMen\
+u-item position-\
+relative flex-wr\
+ap flex-justify-\
+between flex-ite\
+ms-center d-bloc\
+k d-lg-flex flex\
+-lg-nowrap flex-\
+lg-items-center \
+js-details-conta\
+iner js-header-m\
+enu-item\x22>\x0a     \
+ <button type=\x22b\
+utton\x22 class=\x22He\
+aderMenu-link bo\
+rder-0 width-ful\
+l width-lg-auto \
+px-0 px-lg-2 py-\
+lg-2 no-wrap d-f\
+lex flex-items-c\
+enter flex-justi\
+fy-between js-de\
+tails-target\x22 ar\
+ia-expanded=\x22fal\
+se\x22>\x0a        Ope\
+n Source\x0a       \
+ <svg opacity=\x220\
+.5\x22 aria-hidden=\
+\x22true\x22 height=\x221\
+6\x22 viewBox=\x220 0 \
+16 16\x22 version=\x22\
+1.1\x22 width=\x2216\x22 \
+data-view-compon\
+ent=\x22true\x22 class\
+=\x22octicon octico\
+n-chevron-down H\
+eaderMenu-icon m\
+l-1\x22>\x0a    <path \
+d=\x22M12.78 5.22a.\
+749.749 0 0 1 0 \
+1.06l-4.25 4.25a\
+.749.749 0 0 1-1\
+.06 0L3.22 6.28a\
+.749.749 0 1 1 1\
+.06-1.06L8 8.939\
+l3.72-3.719a.749\
+.749 0 0 1 1.06 \
+0Z\x22></path>\x0a</sv\
+g>\x0a      </butto\
+n>\x0a\x0a      <div c\
+lass=\x22HeaderMenu\
+-dropdown dropdo\
+wn-menu rounded \
+m-0 p-0 pt-2 pt-\
+lg-4 position-re\
+lative position-\
+lg-absolute left\
+-0 left-lg-n3 pb\
+-2 pb-lg-4\x22>\x0a   \
+       <div clas\
+s=\x22HeaderMenu-co\
+lumn px-lg-4\x22>\x0a \
+             <di\
+v class=\x22border-\
+bottom mb-3 mb-l\
+g-3 pb-3\x22>\x0a\x0a    \
+            <ul \
+class=\x22list-styl\
+e-none f5\x22 >\x0a   \
+                \
+ <li>\x0a  <a class\
+=\x22HeaderMenu-dro\
+pdown-link d-blo\
+ck no-underline \
+position-relativ\
+e py-2 Link--sec\
+ondary d-flex fl\
+ex-items-center \
+Link--has-descri\
+ption\x22 data-anal\
+ytics-event=\x22{&q\
+uot;location&quo\
+t;:&quot;navbar&\
+quot;,&quot;acti\
+on&quot;:&quot;g\
+ithub_sponsors&q\
+uot;,&quot;conte\
+xt&quot;:&quot;o\
+pen_source&quot;\
+,&quot;tag&quot;\
+:&quot;link&quot\
+;,&quot;label&qu\
+ot;:&quot;github\
+_sponsors_link_o\
+pen_source_navba\
+r&quot;}\x22 href=\x22\
+/sponsors\x22>\x0a    \
+  \x0a      <div>\x0a \
+         <div cl\
+ass=\x22color-fg-de\
+fault h4\x22>\x0a     \
+       GitHub Sp\
+onsors\x0a         \
+ </div>\x0a        \
+Fund open source\
+ developers\x0a    \
+  </div>\x0a\x0a    \x0a<\
+/a></li>\x0a\x0a      \
+          </ul>\x0a\
+              </\
+div>\x0a           \
+   <div class=\x22b\
+order-bottom mb-\
+3 mb-lg-3 pb-3\x22>\
+\x0a\x0a              \
+  <ul class=\x22lis\
+t-style-none f5\x22\
+ >\x0a             \
+       <li>\x0a  <a\
+ class=\x22HeaderMe\
+nu-dropdown-link\
+ d-block no-unde\
+rline position-r\
+elative py-2 Lin\
+k--secondary d-f\
+lex flex-items-c\
+enter Link--has-\
+description\x22 dat\
+a-analytics-even\
+t=\x22{&quot;locati\
+on&quot;:&quot;n\
+avbar&quot;,&quo\
+t;action&quot;:&\
+quot;the_readme_\
+project&quot;,&q\
+uot;context&quot\
+;:&quot;open_sou\
+rce&quot;,&quot;\
+tag&quot;:&quot;\
+link&quot;,&quot\
+;label&quot;:&qu\
+ot;the_readme_pr\
+oject_link_open_\
+source_navbar&qu\
+ot;}\x22 href=\x22http\
+s://github.com/r\
+eadme\x22>\x0a      \x0a \
+     <div>\x0a     \
+     <div class=\
+\x22color-fg-defaul\
+t h4\x22>\x0a         \
+   The ReadME Pr\
+oject\x0a          \
+</div>\x0a        G\
+itHub community \
+articles\x0a      <\
+/div>\x0a\x0a    \x0a</a>\
+</li>\x0a\x0a         \
+       </ul>\x0a   \
+           </div\
+>\x0a              \
+<div class=\x22bord\
+er-bottom border\
+-bottom-0\x22>\x0a    \
+                \
+<span class=\x22d-b\
+lock h4 color-fg\
+-default my-1\x22 i\
+d=\x22open-source-r\
+epositories-head\
+ing\x22>Repositorie\
+s</span>\x0a\x0a      \
+          <ul cl\
+ass=\x22list-style-\
+none f5\x22 aria-la\
+belledby=\x22open-s\
+ource-repositori\
+es-heading\x22>\x0a   \
+                \
+ <li>\x0a  <a class\
+=\x22HeaderMenu-dro\
+pdown-link d-blo\
+ck no-underline \
+position-relativ\
+e py-2 Link--sec\
+ondary\x22 data-ana\
+lytics-event=\x22{&\
+quot;location&qu\
+ot;:&quot;navbar\
+&quot;,&quot;act\
+ion&quot;:&quot;\
+topics&quot;,&qu\
+ot;context&quot;\
+:&quot;open_sour\
+ce&quot;,&quot;t\
+ag&quot;:&quot;l\
+ink&quot;,&quot;\
+label&quot;:&quo\
+t;topics_link_op\
+en_source_navbar\
+&quot;}\x22 href=\x22h\
+ttps://github.co\
+m/topics\x22>\x0a     \
+ Topics\x0a\x0a    \x0a</\
+a></li>\x0a\x0a       \
+             <li\
+>\x0a  <a class=\x22He\
+aderMenu-dropdow\
+n-link d-block n\
+o-underline posi\
+tion-relative py\
+-2 Link--seconda\
+ry\x22 data-analyti\
+cs-event=\x22{&quot\
+;location&quot;:\
+&quot;navbar&quo\
+t;,&quot;action&\
+quot;:&quot;tren\
+ding&quot;,&quot\
+;context&quot;:&\
+quot;open_source\
+&quot;,&quot;tag\
+&quot;:&quot;lin\
+k&quot;,&quot;la\
+bel&quot;:&quot;\
+trending_link_op\
+en_source_navbar\
+&quot;}\x22 href=\x22h\
+ttps://github.co\
+m/trending\x22>\x0a   \
+   Trending\x0a\x0a   \
+ \x0a</a></li>\x0a\x0a   \
+                \
+ <li>\x0a  <a class\
+=\x22HeaderMenu-dro\
+pdown-link d-blo\
+ck no-underline \
+position-relativ\
+e py-2 Link--sec\
+ondary\x22 data-ana\
+lytics-event=\x22{&\
+quot;location&qu\
+ot;:&quot;navbar\
+&quot;,&quot;act\
+ion&quot;:&quot;\
+collections&quot\
+;,&quot;context&\
+quot;:&quot;open\
+_source&quot;,&q\
+uot;tag&quot;:&q\
+uot;link&quot;,&\
+quot;label&quot;\
+:&quot;collectio\
+ns_link_open_sou\
+rce_navbar&quot;\
+}\x22 href=\x22https:/\
+/github.com/coll\
+ections\x22>\x0a      \
+Collections\x0a\x0a   \
+ \x0a</a></li>\x0a\x0a   \
+             </u\
+l>\x0a             \
+ </div>\x0a        \
+  </div>\x0a\x0a      \
+</div>\x0a</li>\x0a\x0a\x0a \
+               <\
+li class=\x22Header\
+Menu-item positi\
+on-relative flex\
+-wrap flex-justi\
+fy-between flex-\
+items-center d-b\
+lock d-lg-flex f\
+lex-lg-nowrap fl\
+ex-lg-items-cent\
+er js-details-co\
+ntainer js-heade\
+r-menu-item\x22>\x0a  \
+    <button type\
+=\x22button\x22 class=\
+\x22HeaderMenu-link\
+ border-0 width-\
+full width-lg-au\
+to px-0 px-lg-2 \
+py-lg-2 no-wrap \
+d-flex flex-item\
+s-center flex-ju\
+stify-between js\
+-details-target\x22\
+ aria-expanded=\x22\
+false\x22>\x0a        \
+Enterprise\x0a     \
+   <svg opacity=\
+\x220.5\x22 aria-hidde\
+n=\x22true\x22 height=\
+\x2216\x22 viewBox=\x220 \
+0 16 16\x22 version\
+=\x221.1\x22 width=\x2216\
+\x22 data-view-comp\
+onent=\x22true\x22 cla\
+ss=\x22octicon octi\
+con-chevron-down\
+ HeaderMenu-icon\
+ ml-1\x22>\x0a    <pat\
+h d=\x22M12.78 5.22\
+a.749.749 0 0 1 \
+0 1.06l-4.25 4.2\
+5a.749.749 0 0 1\
+-1.06 0L3.22 6.2\
+8a.749.749 0 1 1\
+ 1.06-1.06L8 8.9\
+39l3.72-3.719a.7\
+49.749 0 0 1 1.0\
+6 0Z\x22></path>\x0a</\
+svg>\x0a      </but\
+ton>\x0a\x0a      <div\
+ class=\x22HeaderMe\
+nu-dropdown drop\
+down-menu rounde\
+d m-0 p-0 pt-2 p\
+t-lg-4 position-\
+relative positio\
+n-lg-absolute le\
+ft-0 left-lg-n3 \
+pb-2 pb-lg-4\x22>\x0a \
+         <div cl\
+ass=\x22HeaderMenu-\
+column px-lg-4\x22>\
+\x0a              <\
+div class=\x22borde\
+r-bottom mb-3 mb\
+-lg-3 pb-3\x22>\x0a\x0a  \
+              <u\
+l class=\x22list-st\
+yle-none f5\x22 >\x0a \
+                \
+   <li>\x0a  <a cla\
+ss=\x22HeaderMenu-d\
+ropdown-link d-b\
+lock no-underlin\
+e position-relat\
+ive py-2 Link--s\
+econdary d-flex \
+flex-items-cente\
+r Link--has-desc\
+ription\x22 data-an\
+alytics-event=\x22{\
+&quot;location&q\
+uot;:&quot;navba\
+r&quot;,&quot;ac\
+tion&quot;:&quot\
+;enterprise_plat\
+form&quot;,&quot\
+;context&quot;:&\
+quot;enterprise&\
+quot;,&quot;tag&\
+quot;:&quot;link\
+&quot;,&quot;lab\
+el&quot;:&quot;e\
+nterprise_platfo\
+rm_link_enterpri\
+se_navbar&quot;}\
+\x22 href=\x22/enterpr\
+ise\x22>\x0a      <svg\
+ aria-hidden=\x22tr\
+ue\x22 height=\x2224\x22 \
+viewBox=\x220 0 24 \
+24\x22 version=\x221.1\
+\x22 width=\x2224\x22 dat\
+a-view-component\
+=\x22true\x22 class=\x22o\
+cticon octicon-s\
+tack color-fg-su\
+btle mr-3\x22>\x0a    \
+<path d=\x22M11.063\
+ 1.456a1.749 1.7\
+49 0 0 1 1.874 0\
+l8.383 5.316a1.7\
+51 1.751 0 0 1 0\
+ 2.956l-8.383 5.\
+316a1.749 1.749 \
+0 0 1-1.874 0L2.\
+68 9.728a1.751 1\
+.751 0 0 1 0-2.9\
+56Zm1.071 1.267a\
+.25.25 0 0 0-.26\
+8 0L3.483 8.039a\
+.25.25 0 0 0 0 .\
+422l8.383 5.316a\
+.25.25 0 0 0 .26\
+8 0l8.383-5.316a\
+.25.25 0 0 0 0-.\
+422Z\x22></path><pa\
+th d=\x22M1.867 12.\
+324a.75.75 0 0 1\
+ 1.035-.232l8.96\
+4 5.685a.25.25 0\
+ 0 0 .268 0l8.96\
+4-5.685a.75.75 0\
+ 0 1 .804 1.267l\
+-8.965 5.685a1.7\
+49 1.749 0 0 1-1\
+.874 0l-8.965-5.\
+685a.75.75 0 0 1\
+-.231-1.035Z\x22></\
+path><path d=\x22M1\
+.867 16.324a.75.\
+75 0 0 1 1.035-.\
+232l8.964 5.685a\
+.25.25 0 0 0 .26\
+8 0l8.964-5.685a\
+.75.75 0 0 1 .80\
+4 1.267l-8.965 5\
+.685a1.749 1.749\
+ 0 0 1-1.874 0l-\
+8.965-5.685a.75.\
+75 0 0 1-.231-1.\
+035Z\x22></path>\x0a</\
+svg>\x0a      <div>\
+\x0a          <div \
+class=\x22color-fg-\
+default h4\x22>\x0a   \
+         Enterpr\
+ise platform\x0a   \
+       </div>\x0a  \
+      AI-powered\
+ developer platf\
+orm\x0a      </div>\
+\x0a\x0a    \x0a</a></li>\
+\x0a\x0a              \
+  </ul>\x0a        \
+      </div>\x0a   \
+           <div \
+class=\x22border-bo\
+ttom border-bott\
+om-0\x22>\x0a         \
+           <span\
+ class=\x22d-block \
+h4 color-fg-defa\
+ult my-1\x22 id=\x22en\
+terprise-availab\
+le-add-ons-headi\
+ng\x22>Available ad\
+d-ons</span>\x0a\x0a  \
+              <u\
+l class=\x22list-st\
+yle-none f5\x22 ari\
+a-labelledby=\x22en\
+terprise-availab\
+le-add-ons-headi\
+ng\x22>\x0a           \
+         <li>\x0a  \
+<a class=\x22Header\
+Menu-dropdown-li\
+nk d-block no-un\
+derline position\
+-relative py-2 L\
+ink--secondary d\
+-flex flex-items\
+-center Link--ha\
+s-description pb\
+-lg-3\x22 data-anal\
+ytics-event=\x22{&q\
+uot;location&quo\
+t;:&quot;navbar&\
+quot;,&quot;acti\
+on&quot;:&quot;g\
+ithub_advanced_s\
+ecurity&quot;,&q\
+uot;context&quot\
+;:&quot;enterpri\
+se&quot;,&quot;t\
+ag&quot;:&quot;l\
+ink&quot;,&quot;\
+label&quot;:&quo\
+t;github_advance\
+d_security_link_\
+enterprise_navba\
+r&quot;}\x22 href=\x22\
+https://github.c\
+om/security/adva\
+nced-security\x22>\x0a\
+      <svg aria-\
+hidden=\x22true\x22 he\
+ight=\x2224\x22 viewBo\
+x=\x220 0 24 24\x22 ve\
+rsion=\x221.1\x22 widt\
+h=\x2224\x22 data-view\
+-component=\x22true\
+\x22 class=\x22octicon\
+ octicon-shield-\
+check color-fg-s\
+ubtle mr-3\x22>\x0a   \
+ <path d=\x22M16.53\
+ 9.78a.75.75 0 0\
+ 0-1.06-1.06L11 \
+13.19l-1.97-1.97\
+a.75.75 0 0 0-1.\
+06 1.06l2.5 2.5a\
+.75.75 0 0 0 1.0\
+6 0l5-5Z\x22></path\
+><path d=\x22m12.54\
+.637 8.25 2.675A\
+1.75 1.75 0 0 1 \
+22 4.976V10c0 6.\
+19-3.771 10.704-\
+9.401 12.83a1.70\
+4 1.704 0 0 1-1.\
+198 0C5.77 20.70\
+5 2 16.19 2 10V4\
+.976c0-.758.489-\
+1.43 1.21-1.664L\
+11.46.637a1.748 \
+1.748 0 0 1 1.08\
+ 0Zm-.617 1.426-\
+8.25 2.676a.249.\
+249 0 0 0-.173.2\
+37V10c0 5.46 3.2\
+8 9.483 8.43 11.\
+426a.199.199 0 0\
+ 0 .14 0C17.22 1\
+9.483 20.5 15.46\
+1 20.5 10V4.976a\
+.25.25 0 0 0-.17\
+3-.237l-8.25-2.6\
+76a.253.253 0 0 \
+0-.154 0Z\x22></pat\
+h>\x0a</svg>\x0a      \
+<div>\x0a          \
+<div class=\x22colo\
+r-fg-default h4\x22\
+>\x0a            Gi\
+tHub Advanced Se\
+curity\x0a         \
+ </div>\x0a        \
+Enterprise-grade\
+ security featur\
+es\x0a      </div>\x0a\
+\x0a    \x0a</a></li>\x0a\
+\x0a               \
+     <li>\x0a  <a c\
+lass=\x22HeaderMenu\
+-dropdown-link d\
+-block no-underl\
+ine position-rel\
+ative py-2 Link-\
+-secondary d-fle\
+x flex-items-cen\
+ter Link--has-de\
+scription pb-lg-\
+3\x22 data-analytic\
+s-event=\x22{&quot;\
+location&quot;:&\
+quot;navbar&quot\
+;,&quot;action&q\
+uot;:&quot;copil\
+ot_for_business&\
+quot;,&quot;cont\
+ext&quot;:&quot;\
+enterprise&quot;\
+,&quot;tag&quot;\
+:&quot;link&quot\
+;,&quot;label&qu\
+ot;:&quot;copilo\
+t_for_business_l\
+ink_enterprise_n\
+avbar&quot;}\x22 hr\
+ef=\x22/features/co\
+pilot/copilot-bu\
+siness\x22>\x0a      <\
+svg aria-hidden=\
+\x22true\x22 height=\x222\
+4\x22 viewBox=\x220 0 \
+24 24\x22 version=\x22\
+1.1\x22 width=\x2224\x22 \
+data-view-compon\
+ent=\x22true\x22 class\
+=\x22octicon octico\
+n-copilot color-\
+fg-subtle mr-3\x22>\
+\x0a    <path d=\x22M2\
+3.922 16.992c-.8\
+61 1.495-5.859 5\
+.023-11.922 5.02\
+3-6.063 0-11.061\
+-3.528-11.922-5.\
+023A.641.641 0 0\
+ 1 0 16.736v-2.8\
+69a.841.841 0 0 \
+1 .053-.22c.372-\
+.935 1.347-2.292\
+ 2.605-2.656.167\
+-.429.414-1.055.\
+644-1.517a10.195\
+ 10.195 0 0 1-.0\
+52-1.086c0-1.331\
+.282-2.499 1.132\
+-3.368.397-.406.\
+89-.717 1.474-.9\
+52 1.399-1.136 3\
+.392-2.093 6.122\
+-2.093 2.731 0 4\
+.767.957 6.166 2\
+.093.584.235 1.0\
+77.546 1.474.952\
+.85.869 1.132 2.\
+037 1.132 3.368 \
+0 .368-.014.733-\
+.052 1.086.23.46\
+2.477 1.088.644 \
+1.517 1.258.364 \
+2.233 1.721 2.60\
+5 2.656a.832.832\
+ 0 0 1 .053.22v2\
+.869a.641.641 0 \
+0 1-.078.256ZM12\
+.172 11h-.344a4.\
+323 4.323 0 0 1-\
+.355.508C10.703 \
+12.455 9.555 13 \
+7.965 13c-1.725 \
+0-2.989-.359-3.7\
+82-1.259a2.005 2\
+.005 0 0 1-.085-\
+.104L4 11.741v6.\
+585c1.435.779 4.\
+514 2.179 8 2.17\
+9 3.486 0 6.565-\
+1.4 8-2.179v-6.5\
+85l-.098-.104s-.\
+033.045-.085.104\
+c-.793.9-2.057 1\
+.259-3.782 1.259\
+-1.59 0-2.738-.5\
+45-3.508-1.492a4\
+.323 4.323 0 0 1\
+-.355-.508h-.016\
+.016Zm.641-2.935\
+c.136 1.057.403 \
+1.913.878 2.497.\
+442.544 1.134.93\
+8 2.344.938 1.57\
+3 0 2.292-.337 2\
+.657-.751.384-.4\
+35.558-1.15.558-\
+2.361 0-1.14-.24\
+3-1.847-.705-2.3\
+19-.477-.488-1.3\
+19-.862-2.824-1.\
+025-1.487-.161-2\
+.192.138-2.533.5\
+29-.269.307-.437\
+.808-.438 1.578v\
+.021c0 .265.021.\
+562.063.893Zm-1.\
+626 0c.042-.331.\
+063-.628.063-.89\
+4v-.02c-.001-.77\
+-.169-1.271-.438\
+-1.578-.341-.391\
+-1.046-.69-2.533\
+-.529-1.505.163-\
+2.347.537-2.824 \
+1.025-.462.472-.\
+705 1.179-.705 2\
+.319 0 1.211.175\
+ 1.926.558 2.361\
+.365.414 1.084.7\
+51 2.657.751 1.2\
+1 0 1.902-.394 2\
+.344-.938.475-.5\
+84.742-1.44.878-\
+2.497Z\x22></path><\
+path d=\x22M14.5 14\
+.25a1 1 0 0 1 1 \
+1v2a1 1 0 0 1-2 \
+0v-2a1 1 0 0 1 1\
+-1Zm-5 0a1 1 0 0\
+ 1 1 1v2a1 1 0 0\
+ 1-2 0v-2a1 1 0 \
+0 1 1-1Z\x22></path\
+>\x0a</svg>\x0a      <\
+div>\x0a          <\
+div class=\x22color\
+-fg-default h4\x22>\
+\x0a            Cop\
+ilot for busines\
+s\x0a          </di\
+v>\x0a        Enter\
+prise-grade AI f\
+eatures\x0a      </\
+div>\x0a\x0a    \x0a</a><\
+/li>\x0a\x0a          \
+          <li>\x0a \
+ <a class=\x22Heade\
+rMenu-dropdown-l\
+ink d-block no-u\
+nderline positio\
+n-relative py-2 \
+Link--secondary \
+d-flex flex-item\
+s-center Link--h\
+as-description\x22 \
+data-analytics-e\
+vent=\x22{&quot;loc\
+ation&quot;:&quo\
+t;navbar&quot;,&\
+quot;action&quot\
+;:&quot;premium_\
+support&quot;,&q\
+uot;context&quot\
+;:&quot;enterpri\
+se&quot;,&quot;t\
+ag&quot;:&quot;l\
+ink&quot;,&quot;\
+label&quot;:&quo\
+t;premium_suppor\
+t_link_enterpris\
+e_navbar&quot;}\x22\
+ href=\x22/premium-\
+support\x22>\x0a      \
+<svg aria-hidden\
+=\x22true\x22 height=\x22\
+24\x22 viewBox=\x220 0\
+ 24 24\x22 version=\
+\x221.1\x22 width=\x2224\x22\
+ data-view-compo\
+nent=\x22true\x22 clas\
+s=\x22octicon octic\
+on-comment-discu\
+ssion color-fg-s\
+ubtle mr-3\x22>\x0a   \
+ <path d=\x22M1.75 \
+1h12.5c.966 0 1.\
+75.784 1.75 1.75\
+v9.5A1.75 1.75 0\
+ 0 1 14.25 14H8.\
+061l-2.574 2.573\
+A1.458 1.458 0 0\
+ 1 3 15.543V14H1\
+.75A1.75 1.75 0 \
+0 1 0 12.25v-9.5\
+C0 1.784.784 1 1\
+.75 1ZM1.5 2.75v\
+9.5c0 .138.112.2\
+5.25.25h2a.75.75\
+ 0 0 1 .75.75v2.\
+19l2.72-2.72a.74\
+9.749 0 0 1 .53-\
+.22h6.5a.25.25 0\
+ 0 0 .25-.25v-9.\
+5a.25.25 0 0 0-.\
+25-.25H1.75a.25.\
+25 0 0 0-.25.25Z\
+\x22></path><path d\
+=\x22M22.5 8.75a.25\
+.25 0 0 0-.25-.2\
+5h-3.5a.75.75 0 \
+0 1 0-1.5h3.5c.9\
+66 0 1.75.784 1.\
+75 1.75v9.5A1.75\
+ 1.75 0 0 1 22.2\
+5 20H21v1.543a1.\
+457 1.457 0 0 1-\
+2.487 1.03L15.93\
+9 20H10.75A1.75 \
+1.75 0 0 1 9 18.\
+25v-1.465a.75.75\
+ 0 0 1 1.5 0v1.4\
+65c0 .138.112.25\
+.25.25h5.5a.75.7\
+5 0 0 1 .53.22l2\
+.72 2.72v-2.19a.\
+75.75 0 0 1 .75-\
+.75h2a.25.25 0 0\
+ 0 .25-.25v-9.5Z\
+\x22></path>\x0a</svg>\
+\x0a      <div>\x0a   \
+       <div clas\
+s=\x22color-fg-defa\
+ult h4\x22>\x0a       \
+     Premium Sup\
+port\x0a          <\
+/div>\x0a        En\
+terprise-grade 2\
+4/7 support\x0a    \
+  </div>\x0a\x0a    \x0a<\
+/a></li>\x0a\x0a      \
+          </ul>\x0a\
+              </\
+div>\x0a          <\
+/div>\x0a\x0a      </d\
+iv>\x0a</li>\x0a\x0a\x0a    \
+            <li \
+class=\x22HeaderMen\
+u-item position-\
+relative flex-wr\
+ap flex-justify-\
+between flex-ite\
+ms-center d-bloc\
+k d-lg-flex flex\
+-lg-nowrap flex-\
+lg-items-center \
+js-details-conta\
+iner js-header-m\
+enu-item\x22>\x0a    <\
+a class=\x22HeaderM\
+enu-link no-unde\
+rline px-0 px-lg\
+-2 py-3 py-lg-2 \
+d-block d-lg-inl\
+ine-block\x22 data-\
+analytics-event=\
+\x22{&quot;location\
+&quot;:&quot;nav\
+bar&quot;,&quot;\
+action&quot;:&qu\
+ot;pricing&quot;\
+,&quot;context&q\
+uot;:&quot;globa\
+l&quot;,&quot;ta\
+g&quot;:&quot;li\
+nk&quot;,&quot;l\
+abel&quot;:&quot\
+;pricing_link_gl\
+obal_navbar&quot\
+;}\x22 href=\x22https:\
+//github.com/pri\
+cing\x22>Pricing</a\
+>\x0a</li>\x0a\x0a       \
+     </ul>\x0a     \
+     </nav>\x0a\x0a   \
+     <div class=\
+\x22d-flex flex-col\
+umn flex-lg-row \
+width-full flex-\
+justify-end flex\
+-lg-items-center\
+ text-center mt-\
+3 mt-lg-0 text-l\
+g-left ml-lg-3\x22>\
+\x0a               \
+ \x0a\x0a\x0a<qbsearch-in\
+put class=\x22searc\
+h-input\x22 data-sc\
+ope=\x22owner:rsms\x22\
+ data-custom-sco\
+pes-path=\x22/searc\
+h/custom_scopes\x22\
+ data-delete-cus\
+tom-scopes-csrf=\
+\x22TuZdPOfDbmXXpw3\
+q5TxBoyUXf3OgT5G\
+Nr3wz7xbWfLtQhmP\
+2JE8J9hFR53XJPhL\
+svBey1yt3og5i26V\
+-C9AGtw\x22 data-ma\
+x-custom-scopes=\
+\x2210\x22 data-header\
+-redesign-enable\
+d=\x22false\x22 data-i\
+nitial-value=\x22\x22 \
+data-blackbird-s\
+uggestions-path=\
+\x22/search/suggest\
+ions\x22 data-jump-\
+to-suggestions-p\
+ath=\x22/_graphql/G\
+etSuggestedNavig\
+ationDestination\
+s\x22 data-current-\
+repository=\x22\x22 da\
+ta-current-org=\x22\
+\x22 data-current-o\
+wner=\x22\x22 data-log\
+ged-in=\x22false\x22 d\
+ata-copilot-chat\
+-enabled=\x22false\x22\
+ data-nl-search-\
+enabled=\x22false\x22 \
+data-retain-scro\
+ll-position=\x22tru\
+e\x22>\x0a  <div\x0a    c\
+lass=\x22search-inp\
+ut-container sea\
+rch-with-dialog \
+position-relativ\
+e d-flex flex-ro\
+w flex-items-cen\
+ter mr-4 rounded\
+\x22\x0a    data-actio\
+n=\x22click:qbsearc\
+h-input#searchIn\
+putContainerClic\
+ked\x22\x0a  >\x0a      <\
+button\x0a        t\
+ype=\x22button\x22\x0a   \
+     class=\x22head\
+er-search-button\
+ placeholder  in\
+put-button form-\
+control d-flex f\
+lex-1 flex-self-\
+stretch flex-ite\
+ms-center no-wra\
+p width-full py-\
+0 pl-2 pr-0 text\
+-left border-0 b\
+ox-shadow-none\x22\x0a\
+        data-tar\
+get=\x22qbsearch-in\
+put.inputButton\x22\
+\x0a        aria-la\
+bel=\x22Search or j\
+ump to\xe2\x80\xa6\x22\x0a     \
+   aria-haspopup\
+=\x22dialog\x22\x0a      \
+  placeholder=\x22S\
+earch or jump to\
+...\x22\x0a        dat\
+a-hotkey=s,/\x0a   \
+     autocapital\
+ize=\x22off\x22\x0a      \
+  data-analytics\
+-event=\x22{&quot;l\
+ocation&quot;:&q\
+uot;navbar&quot;\
+,&quot;action&qu\
+ot;:&quot;search\
+bar&quot;,&quot;\
+context&quot;:&q\
+uot;global&quot;\
+,&quot;tag&quot;\
+:&quot;input&quo\
+t;,&quot;label&q\
+uot;:&quot;searc\
+hbar_input_globa\
+l_navbar&quot;}\x22\
+\x0a        data-ac\
+tion=\x22click:qbse\
+arch-input#handl\
+eExpand\x22\x0a      >\
+\x0a        <div cl\
+ass=\x22mr-2 color-\
+fg-muted\x22>\x0a     \
+     <svg aria-h\
+idden=\x22true\x22 hei\
+ght=\x2216\x22 viewBox\
+=\x220 0 16 16\x22 ver\
+sion=\x221.1\x22 width\
+=\x2216\x22 data-view-\
+component=\x22true\x22\
+ class=\x22octicon \
+octicon-search\x22>\
+\x0a    <path d=\x22M1\
+0.68 11.74a6 6 0\
+ 0 1-7.922-8.982\
+ 6 6 0 0 1 8.982\
+ 7.922l3.04 3.04\
+a.749.749 0 0 1-\
+.326 1.275.749.7\
+49 0 0 1-.734-.2\
+15ZM11.5 7a4.499\
+ 4.499 0 1 0-8.9\
+97 0A4.499 4.499\
+ 0 0 0 11.5 7Z\x22>\
+</path>\x0a</svg>\x0a \
+       </div>\x0a  \
+      <span clas\
+s=\x22flex-1\x22 data-\
+target=\x22qbsearch\
+-input.inputButt\
+onText\x22>Search o\
+r jump to...</sp\
+an>\x0a          <d\
+iv class=\x22d-flex\
+\x22 data-target=\x22q\
+bsearch-input.ho\
+tkeyIndicator\x22>\x0a\
+            <svg\
+ xmlns=\x22http://w\
+ww.w3.org/2000/s\
+vg\x22 width=\x2222\x22 h\
+eight=\x2220\x22 aria-\
+hidden=\x22true\x22 cl\
+ass=\x22mr-1\x22><path\
+ fill=\x22none\x22 str\
+oke=\x22#979A9C\x22 op\
+acity=\x22.4\x22 d=\x22M3\
+.5.5h12c1.7 0 3 \
+1.3 3 3v13c0 1.7\
+-1.3 3-3 3h-12c-\
+1.7 0-3-1.3-3-3v\
+-13c0-1.7 1.3-3 \
+3-3z\x22></path><pa\
+th fill=\x22#979A9C\
+\x22 d=\x22M11.8 6L8 1\
+5.1h-.9L10.8 6h1\
+z\x22></path></svg>\
+\x0a          </div\
+>\x0a      </button\
+>\x0a\x0a    <input ty\
+pe=\x22hidden\x22 name\
+=\x22type\x22 class=\x22j\
+s-site-search-ty\
+pe-field\x22>\x0a\x0a    \
+\x0a<div class=\x22Ove\
+rlay--hidden \x22 d\
+ata-modal-dialog\
+-overlay>\x0a  <mod\
+al-dialog data-a\
+ction=\x22close:qbs\
+earch-input#hand\
+leClose cancel:q\
+bsearch-input#ha\
+ndleClose\x22 data-\
+target=\x22qbsearch\
+-input.searchSug\
+gestionsDialog\x22 \
+role=\x22dialog\x22 id\
+=\x22search-suggest\
+ions-dialog\x22 ari\
+a-modal=\x22true\x22 a\
+ria-labelledby=\x22\
+search-suggestio\
+ns-dialog-header\
+\x22 data-view-comp\
+onent=\x22true\x22 cla\
+ss=\x22Overlay Over\
+lay--width-large\
+ Overlay--height\
+-auto\x22>\x0a      <h\
+1 id=\x22search-sug\
+gestions-dialog-\
+header\x22 class=\x22s\
+r-only\x22>Search c\
+ode, repositorie\
+s, users, issues\
+, pull requests.\
+..</h1>\x0a    <div\
+ class=\x22Overlay-\
+body Overlay-bod\
+y--paddingNone\x22>\
+\x0a      \x0a        \
+  <div data-view\
+-component=\x22true\
+\x22>        <div c\
+lass=\x22search-sug\
+gestions positio\
+n-fixed width-fu\
+ll color-shadow-\
+large border col\
+or-fg-default co\
+lor-bg-default o\
+verflow-hidden d\
+-flex flex-colum\
+n query-builder-\
+container\x22\x0a     \
+     style=\x22bord\
+er-radius: 12px;\
+\x22\x0a          data\
+-target=\x22qbsearc\
+h-input.queryBui\
+lderContainer\x22\x0a \
+         hidden\x0a\
+        >\x0a      \
+    <!-- '\x22` -->\
+<!-- </textarea>\
+</xmp> --></opti\
+on></form><form \
+id=\x22query-builde\
+r-test-form\x22 act\
+ion=\x22\x22 accept-ch\
+arset=\x22UTF-8\x22 me\
+thod=\x22get\x22>\x0a  <q\
+uery-builder dat\
+a-target=\x22qbsear\
+ch-input.queryBu\
+ilder\x22 id=\x22query\
+-builder-query-b\
+uilder-test\x22 dat\
+a-filter-key=\x22:\x22\
+ data-view-compo\
+nent=\x22true\x22 clas\
+s=\x22QueryBuilder \
+search-query-bui\
+lder\x22>\x0a    <div \
+class=\x22FormContr\
+ol FormControl--\
+fullWidth\x22>\x0a    \
+  <label id=\x22que\
+ry-builder-test-\
+label\x22 for=\x22quer\
+y-builder-test\x22 \
+class=\x22FormContr\
+ol-label sr-only\
+\x22>\x0a        Searc\
+h\x0a      </label>\
+\x0a      <div\x0a    \
+    class=\x22Query\
+Builder-StyledIn\
+put width-fit \x22\x0a\
+        data-tar\
+get=\x22query-build\
+er.styledInput\x22\x0a\
+      >\x0a        \
+  <span id=\x22quer\
+y-builder-test-l\
+eadingvisual-wra\
+p\x22 class=\x22FormCo\
+ntrol-input-lead\
+ingVisualWrap Qu\
+eryBuilder-leadi\
+ngVisualWrap\x22>\x0a \
+           <svg \
+aria-hidden=\x22tru\
+e\x22 height=\x2216\x22 v\
+iewBox=\x220 0 16 1\
+6\x22 version=\x221.1\x22\
+ width=\x2216\x22 data\
+-view-component=\
+\x22true\x22 class=\x22oc\
+ticon octicon-se\
+arch FormControl\
+-input-leadingVi\
+sual\x22>\x0a    <path\
+ d=\x22M10.68 11.74\
+a6 6 0 0 1-7.922\
+-8.982 6 6 0 0 1\
+ 8.982 7.922l3.0\
+4 3.04a.749.749 \
+0 0 1-.326 1.275\
+.749.749 0 0 1-.\
+734-.215ZM11.5 7\
+a4.499 4.499 0 1\
+ 0-8.997 0A4.499\
+ 4.499 0 0 0 11.\
+5 7Z\x22></path>\x0a</\
+svg>\x0a          <\
+/span>\x0a        <\
+div data-target=\
+\x22query-builder.s\
+tyledInputContai\
+ner\x22 class=\x22Quer\
+yBuilder-StyledI\
+nputContainer\x22>\x0a\
+          <div\x0a \
+           aria-\
+hidden=\x22true\x22\x0a  \
+          class=\
+\x22QueryBuilder-St\
+yledInputContent\
+\x22\x0a            da\
+ta-target=\x22query\
+-builder.styledI\
+nputContent\x22\x0a   \
+       ></div>\x0a \
+         <div cl\
+ass=\x22QueryBuilde\
+r-InputWrapper\x22>\
+\x0a            <di\
+v aria-hidden=\x22t\
+rue\x22 class=\x22Quer\
+yBuilder-Sizer\x22 \
+data-target=\x22que\
+ry-builder.sizer\
+\x22></div>\x0a       \
+     <input id=\x22\
+query-builder-te\
+st\x22 name=\x22query-\
+builder-test\x22 va\
+lue=\x22\x22 autocompl\
+ete=\x22off\x22 type=\x22\
+text\x22 role=\x22comb\
+obox\x22 spellcheck\
+=\x22false\x22 aria-ex\
+panded=\x22false\x22 a\
+ria-describedby=\
+\x22validation-8c5e\
+18e6-78a0-4086-b\
+10c-39c89231acfb\
+\x22 data-target=\x22q\
+uery-builder.inp\
+ut\x22 data-action=\
+\x22\x0a          inpu\
+t:query-builder#\
+inputChange\x0a    \
+      blur:query\
+-builder#inputBl\
+ur\x0a          key\
+down:query-build\
+er#inputKeydown\x0a\
+          focus:\
+query-builder#in\
+putFocus\x0a       \
+ \x22 data-view-com\
+ponent=\x22true\x22 cl\
+ass=\x22FormControl\
+-input QueryBuil\
+der-Input FormCo\
+ntrol-medium\x22 />\
+\x0a          </div\
+>\x0a        </div>\
+\x0a          <span\
+ class=\x22sr-only\x22\
+ id=\x22query-build\
+er-test-clear\x22>C\
+lear</span>\x0a    \
+      <button ro\
+le=\x22button\x22 id=\x22\
+query-builder-te\
+st-clear-button\x22\
+ aria-labelledby\
+=\x22query-builder-\
+test-clear query\
+-builder-test-la\
+bel\x22 data-target\
+=\x22query-builder.\
+clearButton\x22 dat\
+a-action=\x22\x0a     \
+           click\
+:query-builder#c\
+lear\x0a           \
+     focus:query\
+-builder#clearBu\
+ttonFocus\x0a      \
+          blur:q\
+uery-builder#cle\
+arButtonBlur\x0a   \
+           \x22 var\
+iant=\x22small\x22 hid\
+den=\x22hidden\x22 typ\
+e=\x22button\x22 data-\
+view-component=\x22\
+true\x22 class=\x22But\
+ton Button--icon\
+Only Button--inv\
+isible Button--m\
+edium mr-1 px-2 \
+py-0 d-flex flex\
+-items-center ro\
+unded-1 color-fg\
+-muted\x22>  <svg a\
+ria-hidden=\x22true\
+\x22 height=\x2216\x22 vi\
+ewBox=\x220 0 16 16\
+\x22 version=\x221.1\x22 \
+width=\x2216\x22 data-\
+view-component=\x22\
+true\x22 class=\x22oct\
+icon octicon-x-c\
+ircle-fill Butto\
+n-visual\x22>\x0a    <\
+path d=\x22M2.343 1\
+3.657A8 8 0 1 1 \
+13.658 2.343 8 8\
+ 0 0 1 2.343 13.\
+657ZM6.03 4.97a.\
+751.751 0 0 0-1.\
+042.018.751.751 \
+0 0 0-.018 1.042\
+L6.94 8 4.97 9.9\
+7a.749.749 0 0 0\
+ .326 1.275.749.\
+749 0 0 0 .734-.\
+215L8 9.06l1.97 \
+1.97a.749.749 0 \
+0 0 1.275-.326.7\
+49.749 0 0 0-.21\
+5-.734L9.06 8l1.\
+97-1.97a.749.749\
+ 0 0 0-.326-1.27\
+5.749.749 0 0 0-\
+.734.215L8 6.94Z\
+\x22></path>\x0a</svg>\
+\x0a</button>\x0a\x0a    \
+  </div>\x0a      <\
+template id=\x22sea\
+rch-icon\x22>\x0a  <sv\
+g aria-hidden=\x22t\
+rue\x22 height=\x2216\x22\
+ viewBox=\x220 0 16\
+ 16\x22 version=\x221.\
+1\x22 width=\x2216\x22 da\
+ta-view-componen\
+t=\x22true\x22 class=\x22\
+octicon octicon-\
+search\x22>\x0a    <pa\
+th d=\x22M10.68 11.\
+74a6 6 0 0 1-7.9\
+22-8.982 6 6 0 0\
+ 1 8.982 7.922l3\
+.04 3.04a.749.74\
+9 0 0 1-.326 1.2\
+75.749.749 0 0 1\
+-.734-.215ZM11.5\
+ 7a4.499 4.499 0\
+ 1 0-8.997 0A4.4\
+99 4.499 0 0 0 1\
+1.5 7Z\x22></path>\x0a\
+</svg>\x0a</templat\
+e>\x0a\x0a<template id\
+=\x22code-icon\x22>\x0a  \
+<svg aria-hidden\
+=\x22true\x22 height=\x22\
+16\x22 viewBox=\x220 0\
+ 16 16\x22 version=\
+\x221.1\x22 width=\x2216\x22\
+ data-view-compo\
+nent=\x22true\x22 clas\
+s=\x22octicon octic\
+on-code\x22>\x0a    <p\
+ath d=\x22m11.28 3.\
+22 4.25 4.25a.75\
+.75 0 0 1 0 1.06\
+l-4.25 4.25a.749\
+.749 0 0 1-1.275\
+-.326.749.749 0 \
+0 1 .215-.734L13\
+.94 8l-3.72-3.72\
+a.749.749 0 0 1 \
+.326-1.275.749.7\
+49 0 0 1 .734.21\
+5Zm-6.56 0a.751.\
+751 0 0 1 1.042.\
+018.751.751 0 0 \
+1 .018 1.042L2.0\
+6 8l3.72 3.72a.7\
+49.749 0 0 1-.32\
+6 1.275.749.749 \
+0 0 1-.734-.215L\
+.47 8.53a.75.75 \
+0 0 1 0-1.06Z\x22><\
+/path>\x0a</svg>\x0a</\
+template>\x0a\x0a<temp\
+late id=\x22file-co\
+de-icon\x22>\x0a  <svg\
+ aria-hidden=\x22tr\
+ue\x22 height=\x2216\x22 \
+viewBox=\x220 0 16 \
+16\x22 version=\x221.1\
+\x22 width=\x2216\x22 dat\
+a-view-component\
+=\x22true\x22 class=\x22o\
+cticon octicon-f\
+ile-code\x22>\x0a    <\
+path d=\x22M4 1.75C\
+4 .784 4.784 0 5\
+.75 0h5.586c.464\
+ 0 .909.184 1.23\
+7.513l2.914 2.91\
+4c.329.328.513.7\
+73.513 1.237v8.5\
+86A1.75 1.75 0 0\
+ 1 14.25 15h-9a.\
+75.75 0 0 1 0-1.\
+5h9a.25.25 0 0 0\
+ .25-.25V6h-2.75\
+A1.75 1.75 0 0 1\
+ 10 4.25V1.5H5.7\
+5a.25.25 0 0 0-.\
+25.25v2.5a.75.75\
+ 0 0 1-1.5 0Zm1.\
+72 4.97a.75.75 0\
+ 0 1 1.06 0l2 2a\
+.75.75 0 0 1 0 1\
+.06l-2 2a.749.74\
+9 0 0 1-1.275-.3\
+26.749.749 0 0 1\
+ .215-.734l1.47-\
+1.47-1.47-1.47a.\
+75.75 0 0 1 0-1.\
+06ZM3.28 7.78 1.\
+81 9.25l1.47 1.4\
+7a.751.751 0 0 1\
+-.018 1.042.751.\
+751 0 0 1-1.042.\
+018l-2-2a.75.75 \
+0 0 1 0-1.06l2-2\
+a.751.751 0 0 1 \
+1.042.018.751.75\
+1 0 0 1 .018 1.0\
+42Zm8.22-6.218V4\
+.25c0 .138.112.2\
+5.25.25h2.688l-.\
+011-.013-2.914-2\
+.914-.013-.011Z\x22\
+></path>\x0a</svg>\x0a\
+</template>\x0a\x0a<te\
+mplate id=\x22histo\
+ry-icon\x22>\x0a  <svg\
+ aria-hidden=\x22tr\
+ue\x22 height=\x2216\x22 \
+viewBox=\x220 0 16 \
+16\x22 version=\x221.1\
+\x22 width=\x2216\x22 dat\
+a-view-component\
+=\x22true\x22 class=\x22o\
+cticon octicon-h\
+istory\x22>\x0a    <pa\
+th d=\x22m.427 1.92\
+7 1.215 1.215a8.\
+002 8.002 0 1 1-\
+1.6 5.685.75.75 \
+0 1 1 1.493-.154\
+ 6.5 6.5 0 1 0 1\
+.18-4.458l1.358 \
+1.358A.25.25 0 0\
+ 1 3.896 6H.25A.\
+25.25 0 0 1 0 5.\
+75V2.104a.25.25 \
+0 0 1 .427-.177Z\
+M7.75 4a.75.75 0\
+ 0 1 .75.75v2.99\
+2l2.028.812a.75.\
+75 0 0 1-.557 1.\
+392l-2.5-1A.751.\
+751 0 0 1 7 8.25\
+v-3.5A.75.75 0 0\
+ 1 7.75 4Z\x22></pa\
+th>\x0a</svg>\x0a</tem\
+plate>\x0a\x0a<templat\
+e id=\x22repo-icon\x22\
+>\x0a  <svg aria-hi\
+dden=\x22true\x22 heig\
+ht=\x2216\x22 viewBox=\
+\x220 0 16 16\x22 vers\
+ion=\x221.1\x22 width=\
+\x2216\x22 data-view-c\
+omponent=\x22true\x22 \
+class=\x22octicon o\
+cticon-repo\x22>\x0a  \
+  <path d=\x22M2 2.\
+5A2.5 2.5 0 0 1 \
+4.5 0h8.75a.75.7\
+5 0 0 1 .75.75v1\
+2.5a.75.75 0 0 1\
+-.75.75h-2.5a.75\
+.75 0 0 1 0-1.5h\
+1.75v-2h-8a1 1 0\
+ 0 0-.714 1.7.75\
+.75 0 1 1-1.072 \
+1.05A2.495 2.495\
+ 0 0 1 2 11.5Zm1\
+0.5-1h-8a1 1 0 0\
+ 0-1 1v6.708A2.4\
+86 2.486 0 0 1 4\
+.5 9h8ZM5 12.25a\
+.25.25 0 0 1 .25\
+-.25h3.5a.25.25 \
+0 0 1 .25.25v3.2\
+5a.25.25 0 0 1-.\
+4.2l-1.45-1.087a\
+.249.249 0 0 0-.\
+3 0L5.4 15.7a.25\
+.25 0 0 1-.4-.2Z\
+\x22></path>\x0a</svg>\
+\x0a</template>\x0a\x0a<t\
+emplate id=\x22book\
+mark-icon\x22>\x0a  <s\
+vg aria-hidden=\x22\
+true\x22 height=\x2216\
+\x22 viewBox=\x220 0 1\
+6 16\x22 version=\x221\
+.1\x22 width=\x2216\x22 d\
+ata-view-compone\
+nt=\x22true\x22 class=\
+\x22octicon octicon\
+-bookmark\x22>\x0a    \
+<path d=\x22M3 2.75\
+C3 1.784 3.784 1\
+ 4.75 1h6.5c.966\
+ 0 1.75.784 1.75\
+ 1.75v11.5a.75.7\
+5 0 0 1-1.227.57\
+9L8 11.722l-3.77\
+3 3.107A.751.751\
+ 0 0 1 3 14.25Zm\
+1.75-.25a.25.25 \
+0 0 0-.25.25v9.9\
+1l3.023-2.489a.7\
+5.75 0 0 1 .954 \
+0l3.023 2.49V2.7\
+5a.25.25 0 0 0-.\
+25-.25Z\x22></path>\
+\x0a</svg>\x0a</templa\
+te>\x0a\x0a<template i\
+d=\x22plus-circle-i\
+con\x22>\x0a  <svg ari\
+a-hidden=\x22true\x22 \
+height=\x2216\x22 view\
+Box=\x220 0 16 16\x22 \
+version=\x221.1\x22 wi\
+dth=\x2216\x22 data-vi\
+ew-component=\x22tr\
+ue\x22 class=\x22octic\
+on octicon-plus-\
+circle\x22>\x0a    <pa\
+th d=\x22M8 0a8 8 0\
+ 1 1 0 16A8 8 0 \
+0 1 8 0ZM1.5 8a6\
+.5 6.5 0 1 0 13 \
+0 6.5 6.5 0 0 0-\
+13 0Zm7.25-3.25v\
+2.5h2.5a.75.75 0\
+ 0 1 0 1.5h-2.5v\
+2.5a.75.75 0 0 1\
+-1.5 0v-2.5h-2.5\
+a.75.75 0 0 1 0-\
+1.5h2.5v-2.5a.75\
+.75 0 0 1 1.5 0Z\
+\x22></path>\x0a</svg>\
+\x0a</template>\x0a\x0a<t\
+emplate id=\x22circ\
+le-icon\x22>\x0a  <svg\
+ aria-hidden=\x22tr\
+ue\x22 height=\x2216\x22 \
+viewBox=\x220 0 16 \
+16\x22 version=\x221.1\
+\x22 width=\x2216\x22 dat\
+a-view-component\
+=\x22true\x22 class=\x22o\
+cticon octicon-d\
+ot-fill\x22>\x0a    <p\
+ath d=\x22M8 4a4 4 \
+0 1 1 0 8 4 4 0 \
+0 1 0-8Z\x22></path\
+>\x0a</svg>\x0a</templ\
+ate>\x0a\x0a<template \
+id=\x22trash-icon\x22>\
+\x0a  <svg aria-hid\
+den=\x22true\x22 heigh\
+t=\x2216\x22 viewBox=\x22\
+0 0 16 16\x22 versi\
+on=\x221.1\x22 width=\x22\
+16\x22 data-view-co\
+mponent=\x22true\x22 c\
+lass=\x22octicon oc\
+ticon-trash\x22>\x0a  \
+  <path d=\x22M11 1\
+.75V3h2.25a.75.7\
+5 0 0 1 0 1.5H2.\
+75a.75.75 0 0 1 \
+0-1.5H5V1.75C5 .\
+784 5.784 0 6.75\
+ 0h2.5C10.216 0 \
+11 .784 11 1.75Z\
+M4.496 6.675l.66\
+ 6.6a.25.25 0 0 \
+0 .249.225h5.19a\
+.25.25 0 0 0 .24\
+9-.225l.66-6.6a.\
+75.75 0 0 1 1.49\
+2.149l-.66 6.6A1\
+.748 1.748 0 0 1\
+ 10.595 15h-5.19\
+a1.75 1.75 0 0 1\
+-1.741-1.575l-.6\
+6-6.6a.75.75 0 1\
+ 1 1.492-.15ZM6.\
+5 1.75V3h3V1.75a\
+.25.25 0 0 0-.25\
+-.25h-2.5a.25.25\
+ 0 0 0-.25.25Z\x22>\
+</path>\x0a</svg>\x0a<\
+/template>\x0a\x0a<tem\
+plate id=\x22team-i\
+con\x22>\x0a  <svg ari\
+a-hidden=\x22true\x22 \
+height=\x2216\x22 view\
+Box=\x220 0 16 16\x22 \
+version=\x221.1\x22 wi\
+dth=\x2216\x22 data-vi\
+ew-component=\x22tr\
+ue\x22 class=\x22octic\
+on octicon-peopl\
+e\x22>\x0a    <path d=\
+\x22M2 5.5a3.5 3.5 \
+0 1 1 5.898 2.54\
+9 5.508 5.508 0 \
+0 1 3.034 4.084.\
+75.75 0 1 1-1.48\
+2.235 4 4 0 0 0-\
+7.9 0 .75.75 0 0\
+ 1-1.482-.236A5.\
+507 5.507 0 0 1 \
+3.102 8.05 3.493\
+ 3.493 0 0 1 2 5\
+.5ZM11 4a3.001 3\
+.001 0 0 1 2.22 \
+5.018 5.01 5.01 \
+0 0 1 2.56 3.012\
+.749.749 0 0 1-.\
+885.954.752.752 \
+0 0 1-.549-.514 \
+3.507 3.507 0 0 \
+0-2.522-2.372.75\
+.75 0 0 1-.574-.\
+73v-.352a.75.75 \
+0 0 1 .416-.672A\
+1.5 1.5 0 0 0 11\
+ 5.5.75.75 0 0 1\
+ 11 4Zm-5.5-.5a2\
+ 2 0 1 0-.001 3.\
+999A2 2 0 0 0 5.\
+5 3.5Z\x22></path>\x0a\
+</svg>\x0a</templat\
+e>\x0a\x0a<template id\
+=\x22project-icon\x22>\
+\x0a  <svg aria-hid\
+den=\x22true\x22 heigh\
+t=\x2216\x22 viewBox=\x22\
+0 0 16 16\x22 versi\
+on=\x221.1\x22 width=\x22\
+16\x22 data-view-co\
+mponent=\x22true\x22 c\
+lass=\x22octicon oc\
+ticon-project\x22>\x0a\
+    <path d=\x22M1.\
+75 0h12.5C15.216\
+ 0 16 .784 16 1.\
+75v12.5A1.75 1.7\
+5 0 0 1 14.25 16\
+H1.75A1.75 1.75 \
+0 0 1 0 14.25V1.\
+75C0 .784.784 0 \
+1.75 0ZM1.5 1.75\
+v12.5c0 .138.112\
+.25.25.25h12.5a.\
+25.25 0 0 0 .25-\
+.25V1.75a.25.25 \
+0 0 0-.25-.25H1.\
+75a.25.25 0 0 0-\
+.25.25ZM11.75 3a\
+.75.75 0 0 1 .75\
+.75v7.5a.75.75 0\
+ 0 1-1.5 0v-7.5a\
+.75.75 0 0 1 .75\
+-.75Zm-8.25.75a.\
+75.75 0 0 1 1.5 \
+0v5.5a.75.75 0 0\
+ 1-1.5 0ZM8 3a.7\
+5.75 0 0 1 .75.7\
+5v3.5a.75.75 0 0\
+ 1-1.5 0v-3.5A.7\
+5.75 0 0 1 8 3Z\x22\
+></path>\x0a</svg>\x0a\
+</template>\x0a\x0a<te\
+mplate id=\x22penci\
+l-icon\x22>\x0a  <svg \
+aria-hidden=\x22tru\
+e\x22 height=\x2216\x22 v\
+iewBox=\x220 0 16 1\
+6\x22 version=\x221.1\x22\
+ width=\x2216\x22 data\
+-view-component=\
+\x22true\x22 class=\x22oc\
+ticon octicon-pe\
+ncil\x22>\x0a    <path\
+ d=\x22M11.013 1.42\
+7a1.75 1.75 0 0 \
+1 2.474 0l1.086 \
+1.086a1.75 1.75 \
+0 0 1 0 2.474l-8\
+.61 8.61c-.21.21\
+-.47.364-.756.44\
+5l-3.251.93a.75.\
+75 0 0 1-.927-.9\
+28l.929-3.25c.08\
+1-.286.235-.547.\
+445-.758l8.61-8.\
+61Zm.176 4.823L9\
+.75 4.81l-6.286 \
+6.287a.253.253 0\
+ 0 0-.064.108l-.\
+558 1.953 1.953-\
+.558a.253.253 0 \
+0 0 .108-.064Zm1\
+.238-3.763a.25.2\
+5 0 0 0-.354 0L1\
+0.811 3.75l1.439\
+ 1.44 1.263-1.26\
+3a.25.25 0 0 0 0\
+-.354Z\x22></path>\x0a\
+</svg>\x0a</templat\
+e>\x0a\x0a<template id\
+=\x22copilot-icon\x22>\
+\x0a  <svg aria-hid\
+den=\x22true\x22 heigh\
+t=\x2216\x22 viewBox=\x22\
+0 0 16 16\x22 versi\
+on=\x221.1\x22 width=\x22\
+16\x22 data-view-co\
+mponent=\x22true\x22 c\
+lass=\x22octicon oc\
+ticon-copilot\x22>\x0a\
+    <path d=\x22M7.\
+998 15.035c-4.56\
+2 0-7.873-2.914-\
+7.998-3.749V9.33\
+8c.085-.628.677-\
+1.686 1.588-2.06\
+5.013-.07.024-.1\
+43.036-.218.029-\
+.183.06-.384.126\
+-.612-.201-.508-\
+.254-1.084-.254-\
+1.656 0-.87.128-\
+1.769.693-2.484.\
+579-.733 1.494-1\
+.124 2.724-1.261\
+ 1.206-.134 2.26\
+2.034 2.944.765.\
+05.053.096.108.1\
+39.165.044-.057.\
+094-.112.143-.16\
+5.682-.731 1.738\
+-.899 2.944-.765\
+ 1.23.137 2.145.\
+528 2.724 1.261.\
+566.715.693 1.61\
+4.693 2.484 0 .5\
+72-.053 1.148-.2\
+54 1.656.066.228\
+.098.429.126.612\
+.012.076.024.148\
+.037.218.924.385\
+ 1.522 1.471 1.5\
+91 2.095v1.872c0\
+ .766-3.351 3.79\
+5-8.002 3.795Zm0\
+-1.485c2.28 0 4.\
+584-1.11 5.002-1\
+.433V7.862l-.023\
+-.116c-.49.21-1.\
+075.291-1.727.29\
+1-1.146 0-2.059-\
+.327-2.71-.991A3\
+.222 3.222 0 0 1\
+ 8 6.303a3.24 3.\
+24 0 0 1-.544.74\
+3c-.65.664-1.563\
+.991-2.71.991-.6\
+52 0-1.236-.081-\
+1.727-.291l-.023\
+.116v4.255c.419.\
+323 2.722 1.433 \
+5.002 1.433ZM6.7\
+62 2.83c-.193-.2\
+06-.637-.413-1.6\
+82-.297-1.019.11\
+3-1.479.404-1.71\
+3.7-.247.312-.36\
+9.789-.369 1.554\
+ 0 .793.129 1.17\
+1.308 1.371.162.\
+181.519.379 1.44\
+2.379.853 0 1.33\
+9-.235 1.638-.54\
+.315-.322.527-.8\
+27.617-1.553.117\
+-.935-.037-1.395\
+-.241-1.614Zm4.1\
+55-.297c-1.044-.\
+116-1.488.091-1.\
+681.297-.204.219\
+-.359.679-.242 1\
+.614.091.726.303\
+ 1.231.618 1.553\
+.299.305.784.54 \
+1.638.54.922 0 1\
+.28-.198 1.442-.\
+379.179-.2.308-.\
+578.308-1.371 0-\
+.765-.123-1.242-\
+.37-1.554-.233-.\
+296-.693-.587-1.\
+713-.7Z\x22></path>\
+<path d=\x22M6.25 9\
+.037a.75.75 0 0 \
+1 .75.75v1.501a.\
+75.75 0 0 1-1.5 \
+0V9.787a.75.75 0\
+ 0 1 .75-.75Zm4.\
+25.75v1.501a.75.\
+75 0 0 1-1.5 0V9\
+.787a.75.75 0 0 \
+1 1.5 0Z\x22></path\
+>\x0a</svg>\x0a</templ\
+ate>\x0a\x0a<template \
+id=\x22copilot-erro\
+r-icon\x22>\x0a  <svg \
+aria-hidden=\x22tru\
+e\x22 height=\x2216\x22 v\
+iewBox=\x220 0 16 1\
+6\x22 version=\x221.1\x22\
+ width=\x2216\x22 data\
+-view-component=\
+\x22true\x22 class=\x22oc\
+ticon octicon-co\
+pilot-error\x22>\x0a  \
+  <path d=\x22M16 1\
+1.24c0 .112-.072\
+.274-.21.467L13 \
+9.688V7.862l-.02\
+3-.116c-.49.21-1\
+.075.291-1.727.2\
+91-.198 0-.388-.\
+009-.571-.029L6.\
+833 5.226a4.01 4\
+.01 0 0 0 .17-.7\
+82c.117-.935-.03\
+7-1.395-.241-1.6\
+14-.193-.206-.63\
+7-.413-1.682-.29\
+7-.683.076-1.115\
+.231-1.395.415l-\
+1.257-.91c.579-.\
+564 1.413-.877 2\
+.485-.996 1.206-\
+.134 2.262.034 2\
+.944.765.05.053.\
+096.108.139.165.\
+044-.057.094-.11\
+2.143-.165.682-.\
+731 1.738-.899 2\
+.944-.765 1.23.1\
+37 2.145.528 2.7\
+24 1.261.566.715\
+.693 1.614.693 2\
+.484 0 .572-.053\
+ 1.148-.254 1.65\
+6.066.228.098.42\
+9.126.612.012.07\
+6.024.148.037.21\
+8.924.385 1.522 \
+1.471 1.591 2.09\
+5Zm-5.083-8.707c\
+-1.044-.116-1.48\
+8.091-1.681.297-\
+.204.219-.359.67\
+9-.242 1.614.091\
+.726.303 1.231.6\
+18 1.553.299.305\
+.784.54 1.638.54\
+.922 0 1.28-.198\
+ 1.442-.379.179-\
+.2.308-.578.308-\
+1.371 0-.765-.12\
+3-1.242-.37-1.55\
+4-.233-.296-.693\
+-.587-1.713-.7Zm\
+2.511 11.074c-1.\
+393.776-3.272 1.\
+428-5.43 1.428-4\
+.562 0-7.873-2.9\
+14-7.998-3.749V9\
+.338c.085-.628.6\
+77-1.686 1.588-2\
+.065.013-.07.024\
+-.143.036-.218.0\
+29-.183.06-.384.\
+126-.612-.18-.45\
+5-.241-.963-.252\
+-1.475L.31 4.107\
+A.747.747 0 0 1 \
+0 3.509V3.49a.74\
+8.748 0 0 1 .625\
+-.73c.156-.026.3\
+06.047.435.139l1\
+4.667 10.578a.59\
+2.592 0 0 1 .227\
+.264.752.752 0 0\
+ 1 .046.249v.022\
+a.75.75 0 0 1-1.\
+19.596Zm-1.367-.\
+991L5.635 7.964a\
+5.128 5.128 0 0 \
+1-.889.073c-.652\
+ 0-1.236-.081-1.\
+727-.291l-.023.1\
+16v4.255c.419.32\
+3 2.722 1.433 5.\
+002 1.433 1.539 \
+0 3.089-.505 4.0\
+63-.934Z\x22></path\
+>\x0a</svg>\x0a</templ\
+ate>\x0a\x0a<template \
+id=\x22workflow-ico\
+n\x22>\x0a  <svg aria-\
+hidden=\x22true\x22 he\
+ight=\x2216\x22 viewBo\
+x=\x220 0 16 16\x22 ve\
+rsion=\x221.1\x22 widt\
+h=\x2216\x22 data-view\
+-component=\x22true\
+\x22 class=\x22octicon\
+ octicon-workflo\
+w\x22>\x0a    <path d=\
+\x22M0 1.75C0 .784.\
+784 0 1.75 0h3.5\
+C6.216 0 7 .784 \
+7 1.75v3.5A1.75 \
+1.75 0 0 1 5.25 \
+7H4v4a1 1 0 0 0 \
+1 1h4v-1.25C9 9.\
+784 9.784 9 10.7\
+5 9h3.5c.966 0 1\
+.75.784 1.75 1.7\
+5v3.5A1.75 1.75 \
+0 0 1 14.25 16h-\
+3.5A1.75 1.75 0 \
+0 1 9 14.25v-.75\
+H5A2.5 2.5 0 0 1\
+ 2.5 11V7h-.75A1\
+.75 1.75 0 0 1 0\
+ 5.25Zm1.75-.25a\
+.25.25 0 0 0-.25\
+.25v3.5c0 .138.1\
+12.25.25.25h3.5a\
+.25.25 0 0 0 .25\
+-.25v-3.5a.25.25\
+ 0 0 0-.25-.25Zm\
+9 9a.25.25 0 0 0\
+-.25.25v3.5c0 .1\
+38.112.25.25.25h\
+3.5a.25.25 0 0 0\
+ .25-.25v-3.5a.2\
+5.25 0 0 0-.25-.\
+25Z\x22></path>\x0a</s\
+vg>\x0a</template>\x0a\
+\x0a<template id=\x22b\
+ook-icon\x22>\x0a  <sv\
+g aria-hidden=\x22t\
+rue\x22 height=\x2216\x22\
+ viewBox=\x220 0 16\
+ 16\x22 version=\x221.\
+1\x22 width=\x2216\x22 da\
+ta-view-componen\
+t=\x22true\x22 class=\x22\
+octicon octicon-\
+book\x22>\x0a    <path\
+ d=\x22M0 1.75A.75.\
+75 0 0 1 .75 1h4\
+.253c1.227 0 2.3\
+17.59 3 1.501A3.\
+743 3.743 0 0 1 \
+11.006 1h4.245a.\
+75.75 0 0 1 .75.\
+75v10.5a.75.75 0\
+ 0 1-.75.75h-4.5\
+07a2.25 2.25 0 0\
+ 0-1.591.659l-.6\
+22.621a.75.75 0 \
+0 1-1.06 0l-.622\
+-.621A2.25 2.25 \
+0 0 0 5.258 13H.\
+75a.75.75 0 0 1-\
+.75-.75Zm7.251 1\
+0.324.004-5.073-\
+.002-2.253A2.25 \
+2.25 0 0 0 5.003\
+ 2.5H1.5v9h3.757\
+a3.75 3.75 0 0 1\
+ 1.994.574ZM8.75\
+5 4.75l-.004 7.3\
+22a3.752 3.752 0\
+ 0 1 1.992-.572H\
+14.5v-9h-3.495a2\
+.25 2.25 0 0 0-2\
+.25 2.25Z\x22></pat\
+h>\x0a</svg>\x0a</temp\
+late>\x0a\x0a<template\
+ id=\x22code-review\
+-icon\x22>\x0a  <svg a\
+ria-hidden=\x22true\
+\x22 height=\x2216\x22 vi\
+ewBox=\x220 0 16 16\
+\x22 version=\x221.1\x22 \
+width=\x2216\x22 data-\
+view-component=\x22\
+true\x22 class=\x22oct\
+icon octicon-cod\
+e-review\x22>\x0a    <\
+path d=\x22M1.75 1h\
+12.5c.966 0 1.75\
+.784 1.75 1.75v8\
+.5A1.75 1.75 0 0\
+ 1 14.25 13H8.06\
+1l-2.574 2.573A1\
+.458 1.458 0 0 1\
+ 3 14.543V13H1.7\
+5A1.75 1.75 0 0 \
+1 0 11.25v-8.5C0\
+ 1.784.784 1 1.7\
+5 1ZM1.5 2.75v8.\
+5c0 .138.112.25.\
+25.25h2a.75.75 0\
+ 0 1 .75.75v2.19\
+l2.72-2.72a.749.\
+749 0 0 1 .53-.2\
+2h6.5a.25.25 0 0\
+ 0 .25-.25v-8.5a\
+.25.25 0 0 0-.25\
+-.25H1.75a.25.25\
+ 0 0 0-.25.25Zm5\
+.28 1.72a.75.75 \
+0 0 1 0 1.06L5.3\
+1 7l1.47 1.47a.7\
+51.751 0 0 1-.01\
+8 1.042.751.751 \
+0 0 1-1.042.018l\
+-2-2a.75.75 0 0 \
+1 0-1.06l2-2a.75\
+.75 0 0 1 1.06 0\
+Zm2.44 0a.75.75 \
+0 0 1 1.06 0l2 2\
+a.75.75 0 0 1 0 \
+1.06l-2 2a.751.7\
+51 0 0 1-1.042-.\
+018.751.751 0 0 \
+1-.018-1.042L10.\
+69 7 9.22 5.53a.\
+75.75 0 0 1 0-1.\
+06Z\x22></path>\x0a</s\
+vg>\x0a</template>\x0a\
+\x0a<template id=\x22c\
+odespaces-icon\x22>\
+\x0a  <svg aria-hid\
+den=\x22true\x22 heigh\
+t=\x2216\x22 viewBox=\x22\
+0 0 16 16\x22 versi\
+on=\x221.1\x22 width=\x22\
+16\x22 data-view-co\
+mponent=\x22true\x22 c\
+lass=\x22octicon oc\
+ticon-codespaces\
+\x22>\x0a    <path d=\x22\
+M0 11.25c0-.966.\
+784-1.75 1.75-1.\
+75h12.5c.966 0 1\
+.75.784 1.75 1.7\
+5v3A1.75 1.75 0 \
+0 1 14.25 16H1.7\
+5A1.75 1.75 0 0 \
+1 0 14.25Zm2-9.5\
+C2 .784 2.784 0 \
+3.75 0h8.5C13.21\
+6 0 14 .784 14 1\
+.75v5a1.75 1.75 \
+0 0 1-1.75 1.75h\
+-8.5A1.75 1.75 0\
+ 0 1 2 6.75Zm1.7\
+5-.25a.25.25 0 0\
+ 0-.25.25v5c0 .1\
+38.112.25.25.25h\
+8.5a.25.25 0 0 0\
+ .25-.25v-5a.25.\
+25 0 0 0-.25-.25\
+Zm-2 9.5a.25.25 \
+0 0 0-.25.25v3c0\
+ .138.112.25.25.\
+25h12.5a.25.25 0\
+ 0 0 .25-.25v-3a\
+.25.25 0 0 0-.25\
+-.25Z\x22></path><p\
+ath d=\x22M7 12.75a\
+.75.75 0 0 1 .75\
+-.75h4.5a.75.75 \
+0 0 1 0 1.5h-4.5\
+a.75.75 0 0 1-.7\
+5-.75Zm-4 0a.75.\
+75 0 0 1 .75-.75\
+h.5a.75.75 0 0 1\
+ 0 1.5h-.5a.75.7\
+5 0 0 1-.75-.75Z\
+\x22></path>\x0a</svg>\
+\x0a</template>\x0a\x0a<t\
+emplate id=\x22comm\
+ent-icon\x22>\x0a  <sv\
+g aria-hidden=\x22t\
+rue\x22 height=\x2216\x22\
+ viewBox=\x220 0 16\
+ 16\x22 version=\x221.\
+1\x22 width=\x2216\x22 da\
+ta-view-componen\
+t=\x22true\x22 class=\x22\
+octicon octicon-\
+comment\x22>\x0a    <p\
+ath d=\x22M1 2.75C1\
+ 1.784 1.784 1 2\
+.75 1h10.5c.966 \
+0 1.75.784 1.75 \
+1.75v7.5A1.75 1.\
+75 0 0 1 13.25 1\
+2H9.06l-2.573 2.\
+573A1.458 1.458 \
+0 0 1 4 13.543V1\
+2H2.75A1.75 1.75\
+ 0 0 1 1 10.25Zm\
+1.75-.25a.25.25 \
+0 0 0-.25.25v7.5\
+c0 .138.112.25.2\
+5.25h2a.75.75 0 \
+0 1 .75.75v2.19l\
+2.72-2.72a.749.7\
+49 0 0 1 .53-.22\
+h4.5a.25.25 0 0 \
+0 .25-.25v-7.5a.\
+25.25 0 0 0-.25-\
+.25Z\x22></path>\x0a</\
+svg>\x0a</template>\
+\x0a\x0a<template id=\x22\
+comment-discussi\
+on-icon\x22>\x0a  <svg\
+ aria-hidden=\x22tr\
+ue\x22 height=\x2216\x22 \
+viewBox=\x220 0 16 \
+16\x22 version=\x221.1\
+\x22 width=\x2216\x22 dat\
+a-view-component\
+=\x22true\x22 class=\x22o\
+cticon octicon-c\
+omment-discussio\
+n\x22>\x0a    <path d=\
+\x22M1.75 1h8.5c.96\
+6 0 1.75.784 1.7\
+5 1.75v5.5A1.75 \
+1.75 0 0 1 10.25\
+ 10H7.061l-2.574\
+ 2.573A1.458 1.4\
+58 0 0 1 2 11.54\
+3V10h-.25A1.75 1\
+.75 0 0 1 0 8.25\
+v-5.5C0 1.784.78\
+4 1 1.75 1ZM1.5 \
+2.75v5.5c0 .138.\
+112.25.25.25h1a.\
+75.75 0 0 1 .75.\
+75v2.19l2.72-2.7\
+2a.749.749 0 0 1\
+ .53-.22h3.5a.25\
+.25 0 0 0 .25-.2\
+5v-5.5a.25.25 0 \
+0 0-.25-.25h-8.5\
+a.25.25 0 0 0-.2\
+5.25Zm13 2a.25.2\
+5 0 0 0-.25-.25h\
+-.5a.75.75 0 0 1\
+ 0-1.5h.5c.966 0\
+ 1.75.784 1.75 1\
+.75v5.5A1.75 1.7\
+5 0 0 1 14.25 12\
+H14v1.543a1.458 \
+1.458 0 0 1-2.48\
+7 1.03L9.22 12.2\
+8a.749.749 0 0 1\
+ .326-1.275.749.\
+749 0 0 1 .734.2\
+15l2.22 2.22v-2.\
+19a.75.75 0 0 1 \
+.75-.75h1a.25.25\
+ 0 0 0 .25-.25Z\x22\
+></path>\x0a</svg>\x0a\
+</template>\x0a\x0a<te\
+mplate id=\x22organ\
+ization-icon\x22>\x0a \
+ <svg aria-hidde\
+n=\x22true\x22 height=\
+\x2216\x22 viewBox=\x220 \
+0 16 16\x22 version\
+=\x221.1\x22 width=\x2216\
+\x22 data-view-comp\
+onent=\x22true\x22 cla\
+ss=\x22octicon octi\
+con-organization\
+\x22>\x0a    <path d=\x22\
+M1.75 16A1.75 1.\
+75 0 0 1 0 14.25\
+V1.75C0 .784.784\
+ 0 1.75 0h8.5C11\
+.216 0 12 .784 1\
+2 1.75v12.5c0 .0\
+85-.006.168-.018\
+.25h2.268a.25.25\
+ 0 0 0 .25-.25V8\
+.285a.25.25 0 0 \
+0-.111-.208l-1.0\
+55-.703a.749.749\
+ 0 1 1 .832-1.24\
+8l1.055.703c.487\
+.325.779.871.779\
+ 1.456v5.965A1.7\
+5 1.75 0 0 1 14.\
+25 16h-3.5a.766.\
+766 0 0 1-.197-.\
+026c-.099.017-.2\
+.026-.303.026h-3\
+a.75.75 0 0 1-.7\
+5-.75V14h-1v1.25\
+a.75.75 0 0 1-.7\
+5.75Zm-.25-1.75c\
+0 .138.112.25.25\
+.25H4v-1.25a.75.\
+75 0 0 1 .75-.75\
+h2.5a.75.75 0 0 \
+1 .75.75v1.25h2.\
+25a.25.25 0 0 0 \
+.25-.25V1.75a.25\
+.25 0 0 0-.25-.2\
+5h-8.5a.25.25 0 \
+0 0-.25.25ZM3.75\
+ 6h.5a.75.75 0 0\
+ 1 0 1.5h-.5a.75\
+.75 0 0 1 0-1.5Z\
+M3 3.75A.75.75 0\
+ 0 1 3.75 3h.5a.\
+75.75 0 0 1 0 1.\
+5h-.5A.75.75 0 0\
+ 1 3 3.75Zm4 3A.\
+75.75 0 0 1 7.75\
+ 6h.5a.75.75 0 0\
+ 1 0 1.5h-.5A.75\
+.75 0 0 1 7 6.75\
+ZM7.75 3h.5a.75.\
+75 0 0 1 0 1.5h-\
+.5a.75.75 0 0 1 \
+0-1.5ZM3 9.75A.7\
+5.75 0 0 1 3.75 \
+9h.5a.75.75 0 0 \
+1 0 1.5h-.5A.75.\
+75 0 0 1 3 9.75Z\
+M7.75 9h.5a.75.7\
+5 0 0 1 0 1.5h-.\
+5a.75.75 0 0 1 0\
+-1.5Z\x22></path>\x0a<\
+/svg>\x0a</template\
+>\x0a\x0a<template id=\
+\x22rocket-icon\x22>\x0a \
+ <svg aria-hidde\
+n=\x22true\x22 height=\
+\x2216\x22 viewBox=\x220 \
+0 16 16\x22 version\
+=\x221.1\x22 width=\x2216\
+\x22 data-view-comp\
+onent=\x22true\x22 cla\
+ss=\x22octicon octi\
+con-rocket\x22>\x0a   \
+ <path d=\x22M14.06\
+4 0h.186C15.216 \
+0 16 .784 16 1.7\
+5v.186a8.752 8.7\
+52 0 0 1-2.564 6\
+.186l-.458.459c-\
+.314.314-.641.61\
+6-.979.904v3.207\
+c0 .608-.315 1.1\
+72-.833 1.49l-2.\
+774 1.707a.749.7\
+49 0 0 1-1.11-.4\
+18l-.954-3.102a1\
+.214 1.214 0 0 1\
+-.145-.125L3.754\
+ 9.816a1.218 1.2\
+18 0 0 1-.124-.1\
+45L.528 8.717a.7\
+49.749 0 0 1-.41\
+8-1.11l1.71-2.77\
+4A1.748 1.748 0 \
+0 1 3.31 4h3.204\
+c.288-.338.59-.6\
+65.904-.979l.459\
+-.458A8.749 8.74\
+9 0 0 1 14.064 0\
+ZM8.938 3.623h-.\
+002l-.458.458c-.\
+76.76-1.437 1.59\
+8-2.02 2.5l-1.5 \
+2.317 2.143 2.14\
+3 2.317-1.5c.902\
+-.583 1.74-1.26 \
+2.499-2.02l.459-\
+.458a7.25 7.25 0\
+ 0 0 2.123-5.127\
+V1.75a.25.25 0 0\
+ 0-.25-.25h-.186\
+a7.249 7.249 0 0\
+ 0-5.125 2.123ZM\
+3.56 14.56c-.732\
+.732-2.334 1.045\
+-3.005 1.148a.23\
+4.234 0 0 1-.201\
+-.064.234.234 0 \
+0 1-.064-.201c.1\
+03-.671.416-2.27\
+3 1.15-3.003a1.5\
+02 1.502 0 1 1 2\
+.12 2.12Zm6.94-3\
+.935c-.088.06-.1\
+77.118-.266.175l\
+-2.35 1.521.548 \
+1.783 1.949-1.2a\
+.25.25 0 0 0 .11\
+9-.213ZM3.678 8.\
+116 5.2 5.766c.0\
+58-.09.117-.178.\
+176-.266H3.309a.\
+25.25 0 0 0-.213\
+.119l-1.2 1.95ZM\
+12 5a1 1 0 1 1-2\
+ 0 1 1 0 0 1 2 0\
+Z\x22></path>\x0a</svg\
+>\x0a</template>\x0a\x0a<\
+template id=\x22shi\
+eld-check-icon\x22>\
+\x0a  <svg aria-hid\
+den=\x22true\x22 heigh\
+t=\x2216\x22 viewBox=\x22\
+0 0 16 16\x22 versi\
+on=\x221.1\x22 width=\x22\
+16\x22 data-view-co\
+mponent=\x22true\x22 c\
+lass=\x22octicon oc\
+ticon-shield-che\
+ck\x22>\x0a    <path d\
+=\x22m8.533.133 5.2\
+5 1.68A1.75 1.75\
+ 0 0 1 15 3.48V7\
+c0 1.566-.32 3.1\
+82-1.303 4.682-.\
+983 1.498-2.585 \
+2.813-5.032 3.85\
+5a1.697 1.697 0 \
+0 1-1.33 0c-2.44\
+7-1.042-4.049-2.\
+357-5.032-3.855C\
+1.32 10.182 1 8.\
+566 1 7V3.48a1.7\
+5 1.75 0 0 1 1.2\
+17-1.667l5.25-1.\
+68a1.748 1.748 0\
+ 0 1 1.066 0Zm-.\
+61 1.429.001.001\
+-5.25 1.68a.251.\
+251 0 0 0-.174.2\
+37V7c0 1.36.275 \
+2.666 1.057 3.85\
+9.784 1.194 2.12\
+1 2.342 4.366 3.\
+298a.196.196 0 0\
+ 0 .154 0c2.245-\
+.957 3.582-2.103\
+ 4.366-3.297C13.\
+225 9.666 13.5 8\
+.358 13.5 7V3.48\
+a.25.25 0 0 0-.1\
+74-.238l-5.25-1.\
+68a.25.25 0 0 0-\
+.153 0ZM11.28 6.\
+28l-3.5 3.5a.75.\
+75 0 0 1-1.06 0l\
+-1.5-1.5a.749.74\
+9 0 0 1 .326-1.2\
+75.749.749 0 0 1\
+ .734.215l.97.97\
+ 2.97-2.97a.751.\
+751 0 0 1 1.042.\
+018.751.751 0 0 \
+1 .018 1.042Z\x22><\
+/path>\x0a</svg>\x0a</\
+template>\x0a\x0a<temp\
+late id=\x22heart-i\
+con\x22>\x0a  <svg ari\
+a-hidden=\x22true\x22 \
+height=\x2216\x22 view\
+Box=\x220 0 16 16\x22 \
+version=\x221.1\x22 wi\
+dth=\x2216\x22 data-vi\
+ew-component=\x22tr\
+ue\x22 class=\x22octic\
+on octicon-heart\
+\x22>\x0a    <path d=\x22\
+m8 14.25.345.666\
+a.75.75 0 0 1-.6\
+9 0l-.008-.004-.\
+018-.01a7.152 7.\
+152 0 0 1-.31-.1\
+7 22.055 22.055 \
+0 0 1-3.434-2.41\
+4C2.045 10.731 0\
+ 8.35 0 5.5 0 2.\
+836 2.086 1 4.25\
+ 1 5.797 1 7.153\
+ 1.802 8 3.02 8.\
+847 1.802 10.203\
+ 1 11.75 1 13.91\
+4 1 16 2.836 16 \
+5.5c0 2.85-2.045\
+ 5.231-3.885 6.8\
+18a22.066 22.066\
+ 0 0 1-3.744 2.5\
+84l-.018.01-.006\
+.003h-.002ZM4.25\
+ 2.5c-1.336 0-2.\
+75 1.164-2.75 3 \
+0 2.15 1.58 4.14\
+4 3.365 5.682A20\
+.58 20.58 0 0 0 \
+8 13.393a20.58 2\
+0.58 0 0 0 3.135\
+-2.211C12.92 9.6\
+44 14.5 7.65 14.\
+5 5.5c0-1.836-1.\
+414-3-2.75-3-1.3\
+73 0-2.609.986-3\
+.029 2.456a.749.\
+749 0 0 1-1.442 \
+0C6.859 3.486 5.\
+623 2.5 4.25 2.5\
+Z\x22></path>\x0a</svg\
+>\x0a</template>\x0a\x0a<\
+template id=\x22ser\
+ver-icon\x22>\x0a  <sv\
+g aria-hidden=\x22t\
+rue\x22 height=\x2216\x22\
+ viewBox=\x220 0 16\
+ 16\x22 version=\x221.\
+1\x22 width=\x2216\x22 da\
+ta-view-componen\
+t=\x22true\x22 class=\x22\
+octicon octicon-\
+server\x22>\x0a    <pa\
+th d=\x22M1.75 1h12\
+.5c.966 0 1.75.7\
+84 1.75 1.75v4c0\
+ .372-.116.717-.\
+314 1 .198.283.3\
+14.628.314 1v4a1\
+.75 1.75 0 0 1-1\
+.75 1.75H1.75A1.\
+75 1.75 0 0 1 0 \
+12.75v-4c0-.358.\
+109-.707.314-1a1\
+.739 1.739 0 0 1\
+-.314-1v-4C0 1.7\
+84.784 1 1.75 1Z\
+M1.5 2.75v4c0 .1\
+38.112.25.25.25h\
+12.5a.25.25 0 0 \
+0 .25-.25v-4a.25\
+.25 0 0 0-.25-.2\
+5H1.75a.25.25 0 \
+0 0-.25.25Zm.25 \
+5.75a.25.25 0 0 \
+0-.25.25v4c0 .13\
+8.112.25.25.25h1\
+2.5a.25.25 0 0 0\
+ .25-.25v-4a.25.\
+25 0 0 0-.25-.25\
+ZM7 4.75A.75.75 \
+0 0 1 7.75 4h4.5\
+a.75.75 0 0 1 0 \
+1.5h-4.5A.75.75 \
+0 0 1 7 4.75ZM7.\
+75 10h4.5a.75.75\
+ 0 0 1 0 1.5h-4.\
+5a.75.75 0 0 1 0\
+-1.5ZM3 4.75A.75\
+.75 0 0 1 3.75 4\
+h.5a.75.75 0 0 1\
+ 0 1.5h-.5A.75.7\
+5 0 0 1 3 4.75ZM\
+3.75 10h.5a.75.7\
+5 0 0 1 0 1.5h-.\
+5a.75.75 0 0 1 0\
+-1.5Z\x22></path>\x0a<\
+/svg>\x0a</template\
+>\x0a\x0a<template id=\
+\x22globe-icon\x22>\x0a  \
+<svg aria-hidden\
+=\x22true\x22 height=\x22\
+16\x22 viewBox=\x220 0\
+ 16 16\x22 version=\
+\x221.1\x22 width=\x2216\x22\
+ data-view-compo\
+nent=\x22true\x22 clas\
+s=\x22octicon octic\
+on-globe\x22>\x0a    <\
+path d=\x22M8 0a8 8\
+ 0 1 1 0 16A8 8 \
+0 0 1 8 0ZM5.78 \
+8.75a9.64 9.64 0\
+ 0 0 1.363 4.177\
+c.255.426.542.83\
+2.857 1.215.245-\
+.296.551-.705.85\
+7-1.215A9.64 9.6\
+4 0 0 0 10.22 8.\
+75Zm4.44-1.5a9.6\
+4 9.64 0 0 0-1.3\
+63-4.177c-.307-.\
+51-.612-.919-.85\
+7-1.215a9.927 9.\
+927 0 0 0-.857 1\
+.215A9.64 9.64 0\
+ 0 0 5.78 7.25Zm\
+-5.944 1.5H1.543\
+a6.507 6.507 0 0\
+ 0 4.666 5.5c-.1\
+23-.181-.24-.365\
+-.352-.552-.715-\
+1.192-1.437-2.87\
+4-1.581-4.948Zm-\
+2.733-1.5h2.733c\
+.144-2.074.866-3\
+.756 1.58-4.948.\
+12-.197.237-.381\
+.353-.552a6.507 \
+6.507 0 0 0-4.66\
+6 5.5Zm10.181 1.\
+5c-.144 2.074-.8\
+66 3.756-1.58 4.\
+948-.12.197-.237\
+.381-.353.552a6.\
+507 6.507 0 0 0 \
+4.666-5.5Zm2.733\
+-1.5a6.507 6.507\
+ 0 0 0-4.666-5.5\
+c.123.181.24.365\
+.353.552.714 1.1\
+92 1.436 2.874 1\
+.58 4.948Z\x22></pa\
+th>\x0a</svg>\x0a</tem\
+plate>\x0a\x0a<templat\
+e id=\x22issue-open\
+ed-icon\x22>\x0a  <svg\
+ aria-hidden=\x22tr\
+ue\x22 height=\x2216\x22 \
+viewBox=\x220 0 16 \
+16\x22 version=\x221.1\
+\x22 width=\x2216\x22 dat\
+a-view-component\
+=\x22true\x22 class=\x22o\
+cticon octicon-i\
+ssue-opened\x22>\x0a  \
+  <path d=\x22M8 9.\
+5a1.5 1.5 0 1 0 \
+0-3 1.5 1.5 0 0 \
+0 0 3Z\x22></path><\
+path d=\x22M8 0a8 8\
+ 0 1 1 0 16A8 8 \
+0 0 1 8 0ZM1.5 8\
+a6.5 6.5 0 1 0 1\
+3 0 6.5 6.5 0 0 \
+0-13 0Z\x22></path>\
+\x0a</svg>\x0a</templa\
+te>\x0a\x0a<template i\
+d=\x22device-mobile\
+-icon\x22>\x0a  <svg a\
+ria-hidden=\x22true\
+\x22 height=\x2216\x22 vi\
+ewBox=\x220 0 16 16\
+\x22 version=\x221.1\x22 \
+width=\x2216\x22 data-\
+view-component=\x22\
+true\x22 class=\x22oct\
+icon octicon-dev\
+ice-mobile\x22>\x0a   \
+ <path d=\x22M3.75 \
+0h8.5C13.216 0 1\
+4 .784 14 1.75v1\
+2.5A1.75 1.75 0 \
+0 1 12.25 16h-8.\
+5A1.75 1.75 0 0 \
+1 2 14.25V1.75C2\
+ .784 2.784 0 3.\
+75 0ZM3.5 1.75v1\
+2.5c0 .138.112.2\
+5.25.25h8.5a.25.\
+25 0 0 0 .25-.25\
+V1.75a.25.25 0 0\
+ 0-.25-.25h-8.5a\
+.25.25 0 0 0-.25\
+.25ZM8 13a1 1 0 \
+1 1 0-2 1 1 0 0 \
+1 0 2Z\x22></path>\x0a\
+</svg>\x0a</templat\
+e>\x0a\x0a<template id\
+=\x22package-icon\x22>\
+\x0a  <svg aria-hid\
+den=\x22true\x22 heigh\
+t=\x2216\x22 viewBox=\x22\
+0 0 16 16\x22 versi\
+on=\x221.1\x22 width=\x22\
+16\x22 data-view-co\
+mponent=\x22true\x22 c\
+lass=\x22octicon oc\
+ticon-package\x22>\x0a\
+    <path d=\x22m8.\
+878.392 5.25 3.0\
+45c.54.314.872.8\
+9.872 1.514v6.09\
+8a1.75 1.75 0 0 \
+1-.872 1.514l-5.\
+25 3.045a1.75 1.\
+75 0 0 1-1.756 0\
+l-5.25-3.045A1.7\
+5 1.75 0 0 1 1 1\
+1.049V4.951c0-.6\
+24.332-1.201.872\
+-1.514L7.122.392\
+a1.75 1.75 0 0 1\
+ 1.756 0ZM7.875 \
+1.69l-4.63 2.685\
+L8 7.133l4.755-2\
+.758-4.63-2.685a\
+.248.248 0 0 0-.\
+25 0ZM2.5 5.677v\
+5.372c0 .09.047.\
+171.125.216l4.62\
+5 2.683V8.432Zm6\
+.25 8.271 4.625-\
+2.683a.25.25 0 0\
+ 0 .125-.216V5.6\
+77L8.75 8.432Z\x22>\
+</path>\x0a</svg>\x0a<\
+/template>\x0a\x0a<tem\
+plate id=\x22credit\
+-card-icon\x22>\x0a  <\
+svg aria-hidden=\
+\x22true\x22 height=\x221\
+6\x22 viewBox=\x220 0 \
+16 16\x22 version=\x22\
+1.1\x22 width=\x2216\x22 \
+data-view-compon\
+ent=\x22true\x22 class\
+=\x22octicon octico\
+n-credit-card\x22>\x0a\
+    <path d=\x22M10\
+.75 9a.75.75 0 0\
+ 0 0 1.5h1.5a.75\
+.75 0 0 0 0-1.5h\
+-1.5Z\x22></path><p\
+ath d=\x22M0 3.75C0\
+ 2.784.784 2 1.7\
+5 2h12.5c.966 0 \
+1.75.784 1.75 1.\
+75v8.5A1.75 1.75\
+ 0 0 1 14.25 14H\
+1.75A1.75 1.75 0\
+ 0 1 0 12.25ZM14\
+.5 6.5h-13v5.75c\
+0 .138.112.25.25\
+.25h12.5a.25.25 \
+0 0 0 .25-.25Zm0\
+-2.75a.25.25 0 0\
+ 0-.25-.25H1.75a\
+.25.25 0 0 0-.25\
+.25V5h13Z\x22></pat\
+h>\x0a</svg>\x0a</temp\
+late>\x0a\x0a<template\
+ id=\x22play-icon\x22>\
+\x0a  <svg aria-hid\
+den=\x22true\x22 heigh\
+t=\x2216\x22 viewBox=\x22\
+0 0 16 16\x22 versi\
+on=\x221.1\x22 width=\x22\
+16\x22 data-view-co\
+mponent=\x22true\x22 c\
+lass=\x22octicon oc\
+ticon-play\x22>\x0a   \
+ <path d=\x22M8 0a8\
+ 8 0 1 1 0 16A8 \
+8 0 0 1 8 0ZM1.5\
+ 8a6.5 6.5 0 1 0\
+ 13 0 6.5 6.5 0 \
+0 0-13 0Zm4.879-\
+2.773 4.264 2.55\
+9a.25.25 0 0 1 0\
+ .428l-4.264 2.5\
+59A.25.25 0 0 1 \
+6 10.559V5.442a.\
+25.25 0 0 1 .379\
+-.215Z\x22></path>\x0a\
+</svg>\x0a</templat\
+e>\x0a\x0a<template id\
+=\x22gift-icon\x22>\x0a  \
+<svg aria-hidden\
+=\x22true\x22 height=\x22\
+16\x22 viewBox=\x220 0\
+ 16 16\x22 version=\
+\x221.1\x22 width=\x2216\x22\
+ data-view-compo\
+nent=\x22true\x22 clas\
+s=\x22octicon octic\
+on-gift\x22>\x0a    <p\
+ath d=\x22M2 2.75A2\
+.75 2.75 0 0 1 4\
+.75 0c.983 0 1.8\
+73.42 2.57 1.232\
+.268.318.497.668\
+.68 1.042.183-.3\
+75.411-.725.68-1\
+.044C9.376.42 10\
+.266 0 11.25 0a2\
+.75 2.75 0 0 1 2\
+.45 4h.55c.966 0\
+ 1.75.784 1.75 1\
+.75v2c0 .698-.40\
+9 1.301-1 1.582v\
+4.918A1.75 1.75 \
+0 0 1 13.25 16H2\
+.75A1.75 1.75 0 \
+0 1 1 14.25V9.33\
+2C.409 9.05 0 8.\
+448 0 7.75v-2C0 \
+4.784.784 4 1.75\
+ 4h.55c-.192-.37\
+5-.3-.8-.3-1.25Z\
+M7.25 9.5H2.5v4.\
+75c0 .138.112.25\
+.25.25h4.5Zm1.5 \
+0v5h4.5a.25.25 0\
+ 0 0 .25-.25V9.5\
+Zm0-4V8h5.5a.25.\
+25 0 0 0 .25-.25\
+v-2a.25.25 0 0 0\
+-.25-.25Zm-7 0a.\
+25.25 0 0 0-.25.\
+25v2c0 .138.112.\
+25.25.25h5.5V5.5\
+h-5.5Zm3-4a1.25 \
+1.25 0 0 0 0 2.5\
+h2.309c-.233-.81\
+8-.542-1.401-.87\
+8-1.793-.43-.502\
+-.915-.707-1.431\
+-.707ZM8.941 4h2\
+.309a1.25 1.25 0\
+ 0 0 0-2.5c-.516\
+ 0-1 .205-1.43.7\
+07-.337.392-.646\
+.975-.879 1.793Z\
+\x22></path>\x0a</svg>\
+\x0a</template>\x0a\x0a<t\
+emplate id=\x22code\
+-square-icon\x22>\x0a \
+ <svg aria-hidde\
+n=\x22true\x22 height=\
+\x2216\x22 viewBox=\x220 \
+0 16 16\x22 version\
+=\x221.1\x22 width=\x2216\
+\x22 data-view-comp\
+onent=\x22true\x22 cla\
+ss=\x22octicon octi\
+con-code-square\x22\
+>\x0a    <path d=\x22M\
+0 1.75C0 .784.78\
+4 0 1.75 0h12.5C\
+15.216 0 16 .784\
+ 16 1.75v12.5A1.\
+75 1.75 0 0 1 14\
+.25 16H1.75A1.75\
+ 1.75 0 0 1 0 14\
+.25Zm1.75-.25a.2\
+5.25 0 0 0-.25.2\
+5v12.5c0 .138.11\
+2.25.25.25h12.5a\
+.25.25 0 0 0 .25\
+-.25V1.75a.25.25\
+ 0 0 0-.25-.25Zm\
+7.47 3.97a.75.75\
+ 0 0 1 1.06 0l2 \
+2a.75.75 0 0 1 0\
+ 1.06l-2 2a.749.\
+749 0 0 1-1.275-\
+.326.749.749 0 0\
+ 1 .215-.734L10.\
+69 8 9.22 6.53a.\
+75.75 0 0 1 0-1.\
+06ZM6.78 6.53 5.\
+31 8l1.47 1.47a.\
+749.749 0 0 1-.3\
+26 1.275.749.749\
+ 0 0 1-.734-.215\
+l-2-2a.75.75 0 0\
+ 1 0-1.06l2-2a.7\
+51.751 0 0 1 1.0\
+42.018.751.751 0\
+ 0 1 .018 1.042Z\
+\x22></path>\x0a</svg>\
+\x0a</template>\x0a\x0a<t\
+emplate id=\x22devi\
+ce-desktop-icon\x22\
+>\x0a  <svg aria-hi\
+dden=\x22true\x22 heig\
+ht=\x2216\x22 viewBox=\
+\x220 0 16 16\x22 vers\
+ion=\x221.1\x22 width=\
+\x2216\x22 data-view-c\
+omponent=\x22true\x22 \
+class=\x22octicon o\
+cticon-device-de\
+sktop\x22>\x0a    <pat\
+h d=\x22M14.25 1c.9\
+66 0 1.75.784 1.\
+75 1.75v7.5A1.75\
+ 1.75 0 0 1 14.2\
+5 12h-3.727c.099\
+ 1.041.52 1.872 \
+1.292 2.757A.752\
+.752 0 0 1 11.25\
+ 16h-6.5a.75.75 \
+0 0 1-.565-1.243\
+c.772-.885 1.192\
+-1.716 1.292-2.7\
+57H1.75A1.75 1.7\
+5 0 0 1 0 10.25v\
+-7.5C0 1.784.784\
+ 1 1.75 1ZM1.75 \
+2.5a.25.25 0 0 0\
+-.25.25v7.5c0 .1\
+38.112.25.25.25h\
+12.5a.25.25 0 0 \
+0 .25-.25v-7.5a.\
+25.25 0 0 0-.25-\
+.25ZM9.018 12H6.\
+982a5.72 5.72 0 \
+0 1-.765 2.5h3.5\
+66a5.72 5.72 0 0\
+ 1-.765-2.5Z\x22></\
+path>\x0a</svg>\x0a</t\
+emplate>\x0a\x0a      \
+  <div class=\x22po\
+sition-relative\x22\
+>\x0a              \
+  <ul\x0a          \
+        role=\x22li\
+stbox\x22\x0a         \
+         class=\x22\
+ActionListWrap Q\
+ueryBuilder-List\
+Wrap\x22\x0a          \
+        aria-lab\
+el=\x22Suggestions\x22\
+\x0a               \
+   data-action=\x22\
+\x0a               \
+     combobox-co\
+mmit:query-build\
+er#comboboxCommi\
+t\x0a              \
+      mousedown:\
+query-builder#re\
+sultsMousedown\x0a \
+                \
+ \x22\x0a             \
+     data-target\
+=\x22query-builder.\
+resultsList\x22\x0a   \
+               d\
+ata-persist-list\
+=false\x0a         \
+         id=\x22que\
+ry-builder-test-\
+results\x22\x0a       \
+           tabin\
+dex=\x22-1\x22\x0a       \
+         ></ul>\x0a\
+        </div>\x0a \
+     <div class=\
+\x22FormControl-inl\
+ineValidation\x22 i\
+d=\x22validation-8c\
+5e18e6-78a0-4086\
+-b10c-39c89231ac\
+fb\x22 hidden=\x22hidd\
+en\x22>\x0a        <sp\
+an class=\x22FormCo\
+ntrol-inlineVali\
+dation--visual\x22>\
+\x0a          <svg \
+aria-hidden=\x22tru\
+e\x22 height=\x2212\x22 v\
+iewBox=\x220 0 12 1\
+2\x22 version=\x221.1\x22\
+ width=\x2212\x22 data\
+-view-component=\
+\x22true\x22 class=\x22oc\
+ticon octicon-al\
+ert-fill\x22>\x0a    <\
+path d=\x22M4.855.7\
+08c.5-.896 1.79-\
+.896 2.29 0l4.67\
+5 8.351a1.312 1.\
+312 0 0 1-1.146 \
+1.954H1.33A1.313\
+ 1.313 0 0 1 .18\
+3 9.058ZM7 7V3H5\
+v4Zm-1 3a1 1 0 1\
+ 0 0-2 1 1 0 0 0\
+ 0 2Z\x22></path>\x0a<\
+/svg>\x0a        </\
+span>\x0a        <s\
+pan></span>\x0a</di\
+v>    </div>\x0a   \
+ <div data-targe\
+t=\x22query-builder\
+.screenReaderFee\
+dback\x22 aria-live\
+=\x22polite\x22 aria-a\
+tomic=\x22true\x22 cla\
+ss=\x22sr-only\x22></d\
+iv>\x0a</query-buil\
+der></form>\x0a    \
+      <div class\
+=\x22d-flex flex-ro\
+w color-fg-muted\
+ px-3 text-small\
+ color-bg-defaul\
+t search-feedbac\
+k-prompt\x22>\x0a     \
+       <a target\
+=\x22_blank\x22 href=\x22\
+https://docs.git\
+hub.com/search-g\
+ithub/github-cod\
+e-search/underst\
+anding-github-co\
+de-search-syntax\
+\x22 data-view-comp\
+onent=\x22true\x22 cla\
+ss=\x22Link color-f\
+g-accent text-no\
+rmal ml-2\x22>Searc\
+h syntax tips</a\
+>            <di\
+v class=\x22d-flex \
+flex-1\x22></div>\x0a \
+         </div>\x0a\
+        </div>\x0a<\
+/div>\x0a\x0a    </div\
+>\x0a</modal-dialog\
+></div>\x0a  </div>\
+\x0a  <div data-act\
+ion=\x22click:qbsea\
+rch-input#retrac\
+t\x22 class=\x22dark-b\
+ackdrop position\
+-fixed\x22 hidden d\
+ata-target=\x22qbse\
+arch-input.darkB\
+ackdrop\x22></div>\x0a\
+  <div class=\x22co\
+lor-fg-default\x22>\
+\x0a    \x0a<dialog-he\
+lper>\x0a  <dialog \
+data-target=\x22qbs\
+earch-input.feed\
+backDialog\x22 data\
+-action=\x22close:q\
+bsearch-input#ha\
+ndleDialogClose \
+cancel:qbsearch-\
+input#handleDial\
+ogClose\x22 id=\x22fee\
+dback-dialog\x22 ar\
+ia-modal=\x22true\x22 \
+aria-labelledby=\
+\x22feedback-dialog\
+-title\x22 aria-des\
+cribedby=\x22feedba\
+ck-dialog-descri\
+ption\x22 data-view\
+-component=\x22true\
+\x22 class=\x22Overlay\
+ Overlay-whenNar\
+row Overlay--siz\
+e-medium Overlay\
+--motion-scaleFa\
+de Overlay--disa\
+bleScroll\x22>\x0a    \
+<div data-view-c\
+omponent=\x22true\x22 \
+class=\x22Overlay-h\
+eader\x22>\x0a  <div c\
+lass=\x22Overlay-he\
+aderContentWrap\x22\
+>\x0a    <div class\
+=\x22Overlay-titleW\
+rap\x22>\x0a      <h1 \
+class=\x22Overlay-t\
+itle \x22 id=\x22feedb\
+ack-dialog-title\
+\x22>\x0a        Provi\
+de feedback\x0a    \
+  </h1>\x0a        \
+\x0a    </div>\x0a    \
+<div class=\x22Over\
+lay-actionWrap\x22>\
+\x0a      <button d\
+ata-close-dialog\
+-id=\x22feedback-di\
+alog\x22 aria-label\
+=\x22Close\x22 aria-la\
+bel=\x22Close\x22 type\
+=\x22button\x22 data-v\
+iew-component=\x22t\
+rue\x22 class=\x22clos\
+e-button Overlay\
+-closeButton\x22><s\
+vg aria-hidden=\x22\
+true\x22 height=\x2216\
+\x22 viewBox=\x220 0 1\
+6 16\x22 version=\x221\
+.1\x22 width=\x2216\x22 d\
+ata-view-compone\
+nt=\x22true\x22 class=\
+\x22octicon octicon\
+-x\x22>\x0a    <path d\
+=\x22M3.72 3.72a.75\
+.75 0 0 1 1.06 0\
+L8 6.94l3.22-3.2\
+2a.749.749 0 0 1\
+ 1.275.326.749.7\
+49 0 0 1-.215.73\
+4L9.06 8l3.22 3.\
+22a.749.749 0 0 \
+1-.326 1.275.749\
+.749 0 0 1-.734-\
+.215L8 9.06l-3.2\
+2 3.22a.751.751 \
+0 0 1-1.042-.018\
+.751.751 0 0 1-.\
+018-1.042L6.94 8\
+ 3.72 4.78a.75.7\
+5 0 0 1 0-1.06Z\x22\
+></path>\x0a</svg><\
+/button>\x0a    </d\
+iv>\x0a  </div>\x0a  \x0a\
+</div>\x0a      <sc\
+rollable-region \
+data-labelled-by\
+=\x22feedback-dialo\
+g-title\x22>\x0a      \
+  <div data-view\
+-component=\x22true\
+\x22 class=\x22Overlay\
+-body\x22>        <\
+!-- '\x22` --><!-- \
+</textarea></xmp\
+> --></option></\
+form><form id=\x22c\
+ode-search-feedb\
+ack-form\x22 data-t\
+urbo=\x22false\x22 act\
+ion=\x22/search/fee\
+dback\x22 accept-ch\
+arset=\x22UTF-8\x22 me\
+thod=\x22post\x22><inp\
+ut type=\x22hidden\x22\
+ name=\x22authentic\
+ity_token\x22 value\
+=\x22gkb5UAFfOHSjI-\
+092dwEG31U9-Xpwo\
+Xix-T-UyA4guWc5I\
+CMd3QjS0HefmWcAQ\
+SbpVtlg7bsIOEdNW\
+1xZqtLmQ\x22 />\x0a   \
+       <p>We rea\
+d every piece of\
+ feedback, and t\
+ake your input v\
+ery seriously.</\
+p>\x0a          <te\
+xtarea name=\x22fee\
+dback\x22 class=\x22fo\
+rm-control width\
+-full mb-2\x22 styl\
+e=\x22height: 120px\
+\x22 id=\x22feedback\x22>\
+</textarea>\x0a    \
+      <input nam\
+e=\x22include_email\
+\x22 id=\x22include_em\
+ail\x22 aria-label=\
+\x22Include my emai\
+l address so I c\
+an be contacted\x22\
+ class=\x22form-con\
+trol mr-2\x22 type=\
+\x22checkbox\x22>\x0a    \
+      <label for\
+=\x22include_email\x22\
+ style=\x22font-wei\
+ght: normal\x22>Inc\
+lude my email ad\
+dress so I can b\
+e contacted</lab\
+el>\x0a</form></div\
+>\x0a      </scroll\
+able-region>\x0a   \
+   <div data-vie\
+w-component=\x22tru\
+e\x22 class=\x22Overla\
+y-footer Overlay\
+-footer--alignEn\
+d\x22>          <bu\
+tton data-close-\
+dialog-id=\x22feedb\
+ack-dialog\x22 type\
+=\x22button\x22 data-v\
+iew-component=\x22t\
+rue\x22 class=\x22btn\x22\
+>    Cancel\x0a</bu\
+tton>\x0a          \
+<button form=\x22co\
+de-search-feedba\
+ck-form\x22 data-ac\
+tion=\x22click:qbse\
+arch-input#submi\
+tFeedback\x22 type=\
+\x22submit\x22 data-vi\
+ew-component=\x22tr\
+ue\x22 class=\x22btn-p\
+rimary btn\x22>    \
+Submit feedback\x0a\
+</button>\x0a</div>\
+\x0a</dialog></dial\
+og-helper>\x0a\x0a    \
+<custom-scopes d\
+ata-target=\x22qbse\
+arch-input.custo\
+mScopesManager\x22>\
+\x0a    \x0a<dialog-he\
+lper>\x0a  <dialog \
+data-target=\x22cus\
+tom-scopes.custo\
+mScopesModalDial\
+og\x22 data-action=\
+\x22close:qbsearch-\
+input#handleDial\
+ogClose cancel:q\
+bsearch-input#ha\
+ndleDialogClose\x22\
+ id=\x22custom-scop\
+es-dialog\x22 aria-\
+modal=\x22true\x22 ari\
+a-labelledby=\x22cu\
+stom-scopes-dial\
+og-title\x22 aria-d\
+escribedby=\x22cust\
+om-scopes-dialog\
+-description\x22 da\
+ta-view-componen\
+t=\x22true\x22 class=\x22\
+Overlay Overlay-\
+whenNarrow Overl\
+ay--size-medium \
+Overlay--motion-\
+scaleFade Overla\
+y--disableScroll\
+\x22>\x0a    <div data\
+-view-component=\
+\x22true\x22 class=\x22Ov\
+erlay-header Ove\
+rlay-header--div\
+ided\x22>\x0a  <div cl\
+ass=\x22Overlay-hea\
+derContentWrap\x22>\
+\x0a    <div class=\
+\x22Overlay-titleWr\
+ap\x22>\x0a      <h1 c\
+lass=\x22Overlay-ti\
+tle \x22 id=\x22custom\
+-scopes-dialog-t\
+itle\x22>\x0a        S\
+aved searches\x0a  \
+    </h1>\x0a      \
+  <h2 id=\x22custom\
+-scopes-dialog-d\
+escription\x22 clas\
+s=\x22Overlay-descr\
+iption\x22>Use save\
+d searches to fi\
+lter your result\
+s more quickly</\
+h2>\x0a    </div>\x0a \
+   <div class=\x22O\
+verlay-actionWra\
+p\x22>\x0a      <butto\
+n data-close-dia\
+log-id=\x22custom-s\
+copes-dialog\x22 ar\
+ia-label=\x22Close\x22\
+ aria-label=\x22Clo\
+se\x22 type=\x22button\
+\x22 data-view-comp\
+onent=\x22true\x22 cla\
+ss=\x22close-button\
+ Overlay-closeBu\
+tton\x22><svg aria-\
+hidden=\x22true\x22 he\
+ight=\x2216\x22 viewBo\
+x=\x220 0 16 16\x22 ve\
+rsion=\x221.1\x22 widt\
+h=\x2216\x22 data-view\
+-component=\x22true\
+\x22 class=\x22octicon\
+ octicon-x\x22>\x0a   \
+ <path d=\x22M3.72 \
+3.72a.75.75 0 0 \
+1 1.06 0L8 6.94l\
+3.22-3.22a.749.7\
+49 0 0 1 1.275.3\
+26.749.749 0 0 1\
+-.215.734L9.06 8\
+l3.22 3.22a.749.\
+749 0 0 1-.326 1\
+.275.749.749 0 0\
+ 1-.734-.215L8 9\
+.06l-3.22 3.22a.\
+751.751 0 0 1-1.\
+042-.018.751.751\
+ 0 0 1-.018-1.04\
+2L6.94 8 3.72 4.\
+78a.75.75 0 0 1 \
+0-1.06Z\x22></path>\
+\x0a</svg></button>\
+\x0a    </div>\x0a  </\
+div>\x0a  \x0a</div>\x0a \
+     <scrollable\
+-region data-lab\
+elled-by=\x22custom\
+-scopes-dialog-t\
+itle\x22>\x0a        <\
+div data-view-co\
+mponent=\x22true\x22 c\
+lass=\x22Overlay-bo\
+dy\x22>        <div\
+ data-target=\x22cu\
+stom-scopes.cust\
+omScopesModalDia\
+logFlash\x22></div>\
+\x0a\x0a        <div h\
+idden class=\x22cre\
+ate-custom-scope\
+-form\x22 data-targ\
+et=\x22custom-scope\
+s.createCustomSc\
+opeForm\x22>\x0a      \
+  <!-- '\x22` --><!\
+-- </textarea></\
+xmp> --></option\
+></form><form id\
+=\x22custom-scopes-\
+dialog-form\x22 dat\
+a-turbo=\x22false\x22 \
+action=\x22/search/\
+custom_scopes\x22 a\
+ccept-charset=\x22U\
+TF-8\x22 method=\x22po\
+st\x22><input type=\
+\x22hidden\x22 name=\x22a\
+uthenticity_toke\
+n\x22 value=\x229Hfrw9\
+qmGBO7e8djFz7KNx\
+vtk4CUmAyxlMTKmO\
+9sytKnEULi2nuhB4\
+yv6v6FZJ4Tozddo1\
+1H1F3aGrL_cY4n-g\
+\x22 />\x0a          <\
+div data-target=\
+\x22custom-scopes.c\
+ustomScopesModal\
+DialogFlash\x22></d\
+iv>\x0a\x0a          <\
+input type=\x22hidd\
+en\x22 id=\x22custom_s\
+cope_id\x22 name=\x22c\
+ustom_scope_id\x22 \
+data-target=\x22cus\
+tom-scopes.custo\
+mScopesIdField\x22>\
+\x0a\x0a          <div\
+ class=\x22form-gro\
+up\x22>\x0a           \
+ <label for=\x22cus\
+tom_scope_name\x22>\
+Name</label>\x0a   \
+         <auto-c\
+heck src=\x22/searc\
+h/custom_scopes/\
+check_name\x22 requ\
+ired>\x0a          \
+    <input\x0a     \
+           type=\
+\x22text\x22\x0a         \
+       name=\x22cus\
+tom_scope_name\x22\x0a\
+                \
+id=\x22custom_scope\
+_name\x22\x0a         \
+       data-targ\
+et=\x22custom-scope\
+s.customScopesNa\
+meField\x22\x0a       \
+         class=\x22\
+form-control\x22\x0a  \
+              au\
+tocomplete=\x22off\x22\
+\x0a               \
+ placeholder=\x22gi\
+thub-ruby\x22\x0a     \
+           requi\
+red\x0a            \
+    maxlength=\x225\
+0\x22>\x0a            \
+  <input type=\x22h\
+idden\x22 value=\x22FG\
+afa-iQQYmH5P20Ab\
+va7rwkPsVJuT8Rb0\
+hsgvC3Bxti6YxRDC\
+UrEw9z_v1pf5Eeaw\
+vi0xzGcyIayGthaF\
+Z-Ag\x22 data-csrf=\
+\x22true\x22 />\x0a      \
+      </auto-che\
+ck>\x0a          </\
+div>\x0a\x0a          \
+<div class=\x22form\
+-group\x22>\x0a       \
+     <label for=\
+\x22custom_scope_qu\
+ery\x22>Query</labe\
+l>\x0a            <\
+input\x0a          \
+    type=\x22text\x22\x0a\
+              na\
+me=\x22custom_scope\
+_query\x22\x0a        \
+      id=\x22custom\
+_scope_query\x22\x0a  \
+            data\
+-target=\x22custom-\
+scopes.customSco\
+pesQueryField\x22\x0a \
+             cla\
+ss=\x22form-control\
+\x22\x0a              \
+autocomplete=\x22of\
+f\x22\x0a             \
+ placeholder=\x22(r\
+epo:mona/a OR re\
+po:mona/b) AND l\
+ang:python\x22\x0a    \
+          requir\
+ed\x0a             \
+ maxlength=\x22500\x22\
+>\x0a          </di\
+v>\x0a\x0a          <p\
+ class=\x22text-sma\
+ll color-fg-mute\
+d\x22>\x0a            \
+To see all avail\
+able qualifiers,\
+ see our <a clas\
+s=\x22Link--inTextB\
+lock\x22 href=\x22http\
+s://docs.github.\
+com/search-githu\
+b/github-code-se\
+arch/understandi\
+ng-github-code-s\
+earch-syntax\x22>do\
+cumentation</a>.\
+\x0a          </p>\x0a\
+</form>        <\
+/div>\x0a\x0a        <\
+div data-target=\
+\x22custom-scopes.m\
+anageCustomScope\
+sForm\x22>\x0a        \
+  <div data-targ\
+et=\x22custom-scope\
+s.list\x22></div>\x0a \
+       </div>\x0a\x0a<\
+/div>\x0a      </sc\
+rollable-region>\
+\x0a      <div data\
+-view-component=\
+\x22true\x22 class=\x22Ov\
+erlay-footer Ove\
+rlay-footer--ali\
+gnEnd Overlay-fo\
+oter--divided\x22> \
+         <button\
+ data-action=\x22cl\
+ick:custom-scope\
+s#customScopesCa\
+ncel\x22 type=\x22butt\
+on\x22 data-view-co\
+mponent=\x22true\x22 c\
+lass=\x22btn\x22>    C\
+ancel\x0a</button>\x0a\
+          <butto\
+n form=\x22custom-s\
+copes-dialog-for\
+m\x22 data-action=\x22\
+click:custom-sco\
+pes#customScopes\
+Submit\x22 data-tar\
+get=\x22custom-scop\
+es.customScopesS\
+ubmitButton\x22 typ\
+e=\x22submit\x22 data-\
+view-component=\x22\
+true\x22 class=\x22btn\
+-primary btn\x22>  \
+  Create saved s\
+earch\x0a</button>\x0a\
+</div>\x0a</dialog>\
+</dialog-helper>\
+\x0a    </custom-sc\
+opes>\x0a  </div>\x0a<\
+/qbsearch-input>\
+\x0a\x0a\x0a            <\
+div class=\x22posit\
+ion-relative Hea\
+derMenu-link-wra\
+p d-lg-inline-bl\
+ock\x22>\x0a          \
+    <a\x0a         \
+       href=\x22/lo\
+gin?return_to=ht\
+tps%3A%2F%2Fgith\
+ub.com%2Frsms%2F\
+inter%2Fraw%2Fma\
+ster%2Fdocs%2Ffo\
+nt-files%2FInter\
+-Regular.ttf\x22\x0a  \
+              cl\
+ass=\x22HeaderMenu-\
+link HeaderMenu-\
+link--sign-in He\
+aderMenu-button \
+flex-shrink-0 no\
+-underline d-non\
+e d-lg-inline-fl\
+ex border border\
+-lg-0 rounded px\
+-2 py-1\x22\x0a       \
+         style=\x22\
+margin-left: 12p\
+x;\x22\x0a            \
+    data-hydro-c\
+lick=\x22{&quot;eve\
+nt_type&quot;:&q\
+uot;authenticati\
+on.click&quot;,&\
+quot;payload&quo\
+t;:{&quot;locati\
+on_in_page&quot;\
+:&quot;site head\
+er menu&quot;,&q\
+uot;repository_i\
+d&quot;:null,&qu\
+ot;auth_type&quo\
+t;:&quot;SIGN_UP\
+&quot;,&quot;ori\
+ginating_url&quo\
+t;:&quot;https:/\
+/github.com/rsms\
+/inter/raw/maste\
+r/docs/font-file\
+s/Inter-Regular.\
+ttf&quot;,&quot;\
+user_id&quot;:nu\
+ll}}\x22 data-hydro\
+-click-hmac=\x22f00\
+e075e0d159f39944\
+bc90cd67cc91eba3\
+bfcbad1281a4c323\
+9310f2059b020\x22\x0a \
+               d\
+ata-analytics-ev\
+ent=\x22{&quot;cate\
+gory&quot;:&quot\
+;Marketing nav&q\
+uot;,&quot;actio\
+n&quot;:&quot;cl\
+ick to go to hom\
+epage&quot;,&quo\
+t;label&quot;:&q\
+uot;ref_page:Mar\
+keting;ref_cta:S\
+ign in;ref_loc:H\
+eader&quot;}\x22\x0a  \
+            >\x0a  \
+              Si\
+gn in\x0a          \
+    </a>\x0a       \
+         <div st\
+yle=\x22right: -30%\
+; background-col\
+or: transparent;\
+ border: none\x22 d\
+ata-view-compone\
+nt=\x22true\x22 class=\
+\x22auth-form-body \
+Popover position\
+-absolute d-none\
+ d-sm-none d-md-\
+none d-lg-block\x22\
+>\x0a  <div style=\x22\
+width: 300px\x22 da\
+ta-view-componen\
+t=\x22true\x22 class=\x22\
+Popover-message \
+Box Popover-mess\
+age--top-right c\
+olor-fg-default \
+p-4 mt-2 mx-auto\
+ text-left\x22>\x0a   \
+ <h4 data-view-c\
+omponent=\x22true\x22 \
+class=\x22color-fg-\
+default mb-2\x22>  \
+                \
+  Sign in to Git\
+Hub\x0a</h4>\x0a      \
+                \
+  \x0a<!-- '\x22` --><\
+!-- </textarea><\
+/xmp> --></optio\
+n></form><form d\
+ata-turbo=\x22false\
+\x22 action=\x22/sessi\
+on\x22 accept-chars\
+et=\x22UTF-8\x22 metho\
+d=\x22post\x22><input \
+type=\x22hidden\x22 na\
+me=\x22authenticity\
+_token\x22 value=\x22U\
+H9jytLBVAT7l2Y9V\
+ERPsM8hxMOiHohh9\
+9kWc-CeJVu-3ED2o\
+1_PCQ4JPbB1i0wA7\
+fsWjR5Ezz4n2nRxm\
+UbPBA\x22 />  <inpu\
+t type=\x22hidden\x22 \
+name=\x22add_accoun\
+t\x22 id=\x22add_accou\
+nt\x22 autocomplete\
+=\x22off\x22 class=\x22fo\
+rm-control\x22 />\x0a\x0a\
+    <label for=\x22\
+login_field\x22>\x0a  \
+    Username or \
+email address\x0a  \
+  </label>\x0a    <\
+input type=\x22text\
+\x22 name=\x22login\x22 i\
+d=\x22login_field\x22 \
+class=\x22form-cont\
+rol input-block \
+js-login-field\x22 \
+autocapitalize=\x22\
+off\x22 autocorrect\
+=\x22off\x22 autocompl\
+ete=\x22username\x22 a\
+utofocus=\x22autofo\
+cus\x22 required=\x22r\
+equired\x22 />\x0a\x0a  <\
+div class=\x22posit\
+ion-relative\x22>\x0a \
+   <label for=\x22p\
+assword\x22>\x0a      \
+Password\x0a    </l\
+abel>\x0a    <input\
+ type=\x22password\x22\
+ name=\x22password\x22\
+ id=\x22password\x22 c\
+lass=\x22form-contr\
+ol form-control \
+input-block js-p\
+assword-field\x22 a\
+utocomplete=\x22cur\
+rent-password\x22 r\
+equired=\x22require\
+d\x22 />\x0a    <a cla\
+ss=\x22label-link p\
+osition-absolute\
+ top-0 right-0\x22 \
+id=\x22forgot-passw\
+ord\x22 href=\x22/pass\
+word_reset\x22>Forg\
+ot password?</a>\
+\x0a    \x0a<input typ\
+e=\x22hidden\x22 name=\
+\x22webauthn-condit\
+ional\x22 value=\x22un\
+defined\x22>\x0a<input\
+ type=\x22hidden\x22 c\
+lass=\x22js-support\
+\x22 name=\x22javascri\
+pt-support\x22 valu\
+e=\x22unknown\x22>\x0a<in\
+put type=\x22hidden\
+\x22 class=\x22js-weba\
+uthn-support\x22 na\
+me=\x22webauthn-sup\
+port\x22 value=\x22unk\
+nown\x22>\x0a<input ty\
+pe=\x22hidden\x22 clas\
+s=\x22js-webauthn-i\
+uvpaa-support\x22 n\
+ame=\x22webauthn-iu\
+vpaa-support\x22 va\
+lue=\x22unknown\x22>\x0a<\
+input type=\x22hidd\
+en\x22 name=\x22return\
+_to\x22 id=\x22return_\
+to\x22 value=\x22https\
+://github.com/rs\
+ms/inter/raw/mas\
+ter/docs/font-fi\
+les/Inter-Regula\
+r.ttf\x22 autocompl\
+ete=\x22off\x22 class=\
+\x22form-control\x22 /\
+>\x0a<input type=\x22h\
+idden\x22 name=\x22all\
+ow_signup\x22 id=\x22a\
+llow_signup\x22 aut\
+ocomplete=\x22off\x22 \
+class=\x22form-cont\
+rol\x22 />\x0a<input t\
+ype=\x22hidden\x22 nam\
+e=\x22client_id\x22 id\
+=\x22client_id\x22 aut\
+ocomplete=\x22off\x22 \
+class=\x22form-cont\
+rol\x22 />\x0a<input t\
+ype=\x22hidden\x22 nam\
+e=\x22integration\x22 \
+id=\x22integration\x22\
+ autocomplete=\x22o\
+ff\x22 class=\x22form-\
+control\x22 />\x0a<inp\
+ut type=\x22text\x22 n\
+ame=\x22required_fi\
+eld_6deb\x22 hidden\
+=\x22hidden\x22 class=\
+\x22form-control\x22 /\
+><input type=\x22hi\
+dden\x22 name=\x22time\
+stamp\x22 value=\x2217\
+55133993925\x22 aut\
+ocomplete=\x22off\x22 \
+class=\x22form-cont\
+rol\x22 /><input ty\
+pe=\x22hidden\x22 name\
+=\x22timestamp_secr\
+et\x22 value=\x226d7c1\
+380d6de0865fc231\
+87c75d13b006bfdd\
+d18faf31bda8a342\
+672317e8c89\x22 aut\
+ocomplete=\x22off\x22 \
+class=\x22form-cont\
+rol\x22 />\x0a\x0a    <in\
+put type=\x22submit\
+\x22 name=\x22commit\x22 \
+value=\x22Sign in\x22 \
+class=\x22btn btn-p\
+rimary btn-block\
+ js-sign-in-butt\
+on\x22 data-disable\
+-with=\x22Signing i\
+n\xe2\x80\xa6\x22 data-signi\
+n-label=\x22Sign in\
+\x22 data-sso-label\
+=\x22Sign in with y\
+our identity pro\
+vider\x22 developme\
+nt=\x22false\x22 disab\
+le-emu-sso=\x22fals\
+e\x22 />\x0a  </div>\x0a<\
+/form>  <webauth\
+n-status class=\x22\
+js-webauthn-logi\
+n-emu-control\x22>\x0a\
+        <div dat\
+a-target=\x22webaut\
+hn-status.partia\
+l\x22 class=\x22d-flex\
+ flex-justify-be\
+tween flex-colum\
+n mt-3 mb-0\x22 hid\
+den>\x0a          <\
+a href=\x22/login?r\
+eturn_to=https%3\
+A%2F%2Fgithub.co\
+m%2Frsms%2Finter\
+%2Fraw%2Fmaster%\
+2Fdocs%2Ffont-fi\
+les%2FInter-Regu\
+lar.ttf\x22 data-an\
+alytics-event=\x22{\
+&quot;category&q\
+uot;:&quot;passk\
+ey_404_login&quo\
+t;,&quot;action&\
+quot;:&quot;clic\
+ked&quot;,&quot;\
+label&quot;:null\
+}\x22 data-view-com\
+ponent=\x22true\x22 cl\
+ass=\x22Button--lin\
+k Button--medium\
+ Button\x22>  <span\
+ class=\x22Button-c\
+ontent\x22>\x0a    <sp\
+an class=\x22Button\
+-label\x22>or conti\
+nue with other m\
+ethods</span>\x0a  \
+</span>\x0a</a>\x0a   \
+     </div>\x0a  </\
+webauthn-status>\
+\x0a\x0a\x0a</div></div> \
+           </div\
+>\x0a\x0a             \
+ <a href=\x22/signu\
+p?ref_cta=Sign+u\
+p&amp;ref_loc=he\
+ader+logged+out&\
+amp;ref_page=%2F\
+rsms%2Finter%2Fr\
+aw%2Fmaster%2Fdo\
+cs%2Ffont-files%\
+2FInter-Regular.\
+ttf&amp;source=h\
+eader\x22\x0a         \
+       class=\x22He\
+aderMenu-link He\
+aderMenu-link--s\
+ign-up HeaderMen\
+u-button flex-sh\
+rink-0 d-flex d-\
+lg-inline-flex n\
+o-underline bord\
+er color-border-\
+default rounded \
+px-2 py-1\x22\x0a     \
+           data-\
+hydro-click=\x22{&q\
+uot;event_type&q\
+uot;:&quot;authe\
+ntication.click&\
+quot;,&quot;payl\
+oad&quot;:{&quot\
+;location_in_pag\
+e&quot;:&quot;si\
+te header menu&q\
+uot;,&quot;repos\
+itory_id&quot;:n\
+ull,&quot;auth_t\
+ype&quot;:&quot;\
+SIGN_UP&quot;,&q\
+uot;originating_\
+url&quot;:&quot;\
+https://github.c\
+om/rsms/inter/ra\
+w/master/docs/fo\
+nt-files/Inter-R\
+egular.ttf&quot;\
+,&quot;user_id&q\
+uot;:null}}\x22 dat\
+a-hydro-click-hm\
+ac=\x22f00e075e0d15\
+9f39944bc90cd67c\
+c91eba3bfcbad128\
+1a4c3239310f2059\
+b020\x22\x0a          \
+      data-analy\
+tics-event=\x22{&qu\
+ot;category&quot\
+;:&quot;Sign up&\
+quot;,&quot;acti\
+on&quot;:&quot;c\
+lick to sign up \
+for account&quot\
+;,&quot;label&qu\
+ot;:&quot;ref_pa\
+ge:/rsms/inter/r\
+aw/master/docs/f\
+ont-files/Inter-\
+Regular.ttf;ref_\
+cta:Sign up;ref_\
+loc:header logge\
+d out&quot;}\x22\x0a  \
+            >\x0a  \
+              Si\
+gn up\x0a          \
+    </a>\x0a\x0a      \
+          <div c\
+lass=\x22AppHeader-\
+appearanceSettin\
+gs\x22>\x0a    <react-\
+partial-anchor>\x0a\
+      <button da\
+ta-target=\x22react\
+-partial-anchor.\
+anchor\x22 id=\x22icon\
+-button-c2fdadd2\
+-1fe0-4b45-84a2-\
+bf9ce6840d4a\x22 ar\
+ia-labelledby=\x22t\
+ooltip-dc95acc2-\
+a0c0-4269-922a-8\
+656758247c1\x22 typ\
+e=\x22button\x22 disab\
+led=\x22disabled\x22 d\
+ata-view-compone\
+nt=\x22true\x22 class=\
+\x22Button Button--\
+iconOnly Button-\
+-invisible Butto\
+n--medium AppHea\
+der-button Heade\
+rMenu-link borde\
+r cursor-wait\x22> \
+ <svg aria-hidde\
+n=\x22true\x22 height=\
+\x2216\x22 viewBox=\x220 \
+0 16 16\x22 version\
+=\x221.1\x22 width=\x2216\
+\x22 data-view-comp\
+onent=\x22true\x22 cla\
+ss=\x22octicon octi\
+con-sliders Butt\
+on-visual\x22>\x0a    \
+<path d=\x22M15 2.7\
+5a.75.75 0 0 1-.\
+75.75h-4a.75.75 \
+0 0 1 0-1.5h4a.7\
+5.75 0 0 1 .75.7\
+5Zm-8.5.75v1.25a\
+.75.75 0 0 0 1.5\
+ 0v-4a.75.75 0 0\
+ 0-1.5 0V2H1.75a\
+.75.75 0 0 0 0 1\
+.5H6.5Zm1.25 5.2\
+5a.75.75 0 0 0 0\
+-1.5h-6a.75.75 0\
+ 0 0 0 1.5h6ZM15\
+ 8a.75.75 0 0 1-\
+.75.75H11.5V10a.\
+75.75 0 1 1-1.5 \
+0V6a.75.75 0 0 1\
+ 1.5 0v1.25h2.75\
+A.75.75 0 0 1 15\
+ 8Zm-9 5.25v-2a.\
+75.75 0 0 0-1.5 \
+0v1.25H1.75a.75.\
+75 0 0 0 0 1.5H4\
+.5v1.25a.75.75 0\
+ 0 0 1.5 0v-2Zm9\
+ 0a.75.75 0 0 1-\
+.75.75h-6a.75.75\
+ 0 0 1 0-1.5h6a.\
+75.75 0 0 1 .75.\
+75Z\x22></path>\x0a</s\
+vg>\x0a</button><to\
+ol-tip id=\x22toolt\
+ip-dc95acc2-a0c0\
+-4269-922a-86567\
+58247c1\x22 for=\x22ic\
+on-button-c2fdad\
+d2-1fe0-4b45-84a\
+2-bf9ce6840d4a\x22 \
+popover=\x22manual\x22\
+ data-direction=\
+\x22s\x22 data-type=\x22l\
+abel\x22 data-view-\
+component=\x22true\x22\
+ class=\x22sr-only \
+position-absolut\
+e\x22>Appearance se\
+ttings</tool-tip\
+>\x0a\x0a      <templa\
+te data-target=\x22\
+react-partial-an\
+chor.template\x22>\x0a\
+        <link cr\
+ossorigin=\x22anony\
+mous\x22 media=\x22all\
+\x22 rel=\x22styleshee\
+t\x22 href=\x22https:/\
+/github.githubas\
+sets.com/assets/\
+primer-react.837\
+d55d8a7f64d93bd2\
+8.module.css\x22 />\
+\x0a<link crossorig\
+in=\x22anonymous\x22 m\
+edia=\x22all\x22 rel=\x22\
+stylesheet\x22 href\
+=\x22https://github\
+.githubassets.co\
+m/assets/appeara\
+nce-settings.762\
+59b61ecc82226574\
+9.module.css\x22 />\
+\x0a\x0a<react-partial\
+\x0a  partial-name=\
+\x22appearance-sett\
+ings\x22\x0a  data-ssr\
+=\x22false\x22\x0a  data-\
+attempted-ssr=\x22f\
+alse\x22\x0a  data-rea\
+ct-profiling=\x22fa\
+lse\x22\x0a>\x0a  \x0a  <scr\
+ipt type=\x22applic\
+ation/json\x22 data\
+-target=\x22react-p\
+artial.embeddedD\
+ata\x22>{\x22props\x22:{}\
+}</script>\x0a  <di\
+v data-target=\x22r\
+eact-partial.rea\
+ctRoot\x22></div>\x0a<\
+/react-partial>\x0a\
+\x0a\x0a      </templa\
+te>\x0a    </react-\
+partial-anchor>\x0a\
+  </div>\x0a\x0a      \
+    <button type\
+=\x22button\x22 class=\
+\x22sr-only js-head\
+er-menu-focus-tr\
+ap d-block d-lg-\
+none\x22>Resetting \
+focus</button>\x0a \
+       </div>\x0a  \
+    </div>\x0a    <\
+/div>\x0a  </div>\x0a<\
+/header>\x0a\x0a      \
+<div hidden=\x22hid\
+den\x22 data-view-c\
+omponent=\x22true\x22 \
+class=\x22js-stale-\
+session-flash st\
+ale-session-flas\
+h flash flash-wa\
+rn flash-full\x22>\x0a\
+  \x0a        <svg \
+aria-hidden=\x22tru\
+e\x22 height=\x2216\x22 v\
+iewBox=\x220 0 16 1\
+6\x22 version=\x221.1\x22\
+ width=\x2216\x22 data\
+-view-component=\
+\x22true\x22 class=\x22oc\
+ticon octicon-al\
+ert\x22>\x0a    <path \
+d=\x22M6.457 1.047c\
+.659-1.234 2.427\
+-1.234 3.086 0l6\
+.082 11.378A1.75\
+ 1.75 0 0 1 14.0\
+82 15H1.918a1.75\
+ 1.75 0 0 1-1.54\
+3-2.575Zm1.763.7\
+07a.25.25 0 0 0-\
+.44 0L1.698 13.1\
+32a.25.25 0 0 0 \
+.22.368h12.164a.\
+25.25 0 0 0 .22-\
+.368Zm.53 3.996v\
+2.5a.75.75 0 0 1\
+-1.5 0v-2.5a.75.\
+75 0 0 1 1.5 0ZM\
+9 11a1 1 0 1 1-2\
+ 0 1 1 0 0 1 2 0\
+Z\x22></path>\x0a</svg\
+>\x0a        <span \
+class=\x22js-stale-\
+session-flash-si\
+gned-in\x22 hidden>\
+You signed in wi\
+th another tab o\
+r window. <a cla\
+ss=\x22Link--inText\
+Block\x22 href=\x22\x22>R\
+eload</a> to ref\
+resh your sessio\
+n.</span>\x0a      \
+  <span class=\x22j\
+s-stale-session-\
+flash-signed-out\
+\x22 hidden>You sig\
+ned out in anoth\
+er tab or window\
+. <a class=\x22Link\
+--inTextBlock\x22 h\
+ref=\x22\x22>Reload</a\
+> to refresh you\
+r session.</span\
+>\x0a        <span \
+class=\x22js-stale-\
+session-flash-sw\
+itched\x22 hidden>Y\
+ou switched acco\
+unts on another \
+tab or window. <\
+a class=\x22Link--i\
+nTextBlock\x22 href\
+=\x22\x22>Reload</a> t\
+o refresh your s\
+ession.</span>\x0a\x0a\
+    <button id=\x22\
+icon-button-8b59\
+04b6-78fe-41c0-9\
+45f-4259c8e158ea\
+\x22 aria-labelledb\
+y=\x22tooltip-a3925\
+6f5-a7dc-4193-bf\
+a1-777f851b67bd\x22\
+ type=\x22button\x22 d\
+ata-view-compone\
+nt=\x22true\x22 class=\
+\x22Button Button--\
+iconOnly Button-\
+-invisible Butto\
+n--medium flash-\
+close js-flash-c\
+lose\x22>  <svg ari\
+a-hidden=\x22true\x22 \
+height=\x2216\x22 view\
+Box=\x220 0 16 16\x22 \
+version=\x221.1\x22 wi\
+dth=\x2216\x22 data-vi\
+ew-component=\x22tr\
+ue\x22 class=\x22octic\
+on octicon-x But\
+ton-visual\x22>\x0a   \
+ <path d=\x22M3.72 \
+3.72a.75.75 0 0 \
+1 1.06 0L8 6.94l\
+3.22-3.22a.749.7\
+49 0 0 1 1.275.3\
+26.749.749 0 0 1\
+-.215.734L9.06 8\
+l3.22 3.22a.749.\
+749 0 0 1-.326 1\
+.275.749.749 0 0\
+ 1-.734-.215L8 9\
+.06l-3.22 3.22a.\
+751.751 0 0 1-1.\
+042-.018.751.751\
+ 0 0 1-.018-1.04\
+2L6.94 8 3.72 4.\
+78a.75.75 0 0 1 \
+0-1.06Z\x22></path>\
+\x0a</svg>\x0a</button\
+><tool-tip id=\x22t\
+ooltip-a39256f5-\
+a7dc-4193-bfa1-7\
+77f851b67bd\x22 for\
+=\x22icon-button-8b\
+5904b6-78fe-41c0\
+-945f-4259c8e158\
+ea\x22 popover=\x22man\
+ual\x22 data-direct\
+ion=\x22s\x22 data-typ\
+e=\x22label\x22 data-v\
+iew-component=\x22t\
+rue\x22 class=\x22sr-o\
+nly position-abs\
+olute\x22>Dismiss a\
+lert</tool-tip>\x0a\
+\x0a\x0a  \x0a</div>\x0a    \
+</div>\x0a\x0a  <div i\
+d=\x22start-of-cont\
+ent\x22 class=\x22show\
+-on-focus\x22></div\
+>\x0a\x0a\x0a\x0a\x0a\x0a\x0a\x0a\x0a    <d\
+iv id=\x22js-flash-\
+container\x22 class\
+=\x22flash-containe\
+r\x22 data-turbo-re\
+place>\x0a\x0a\x0a\x0a\x0a  <te\
+mplate class=\x22js\
+-flash-template\x22\
+>\x0a    \x0a<div clas\
+s=\x22flash flash-f\
+ull   {{ classNa\
+me }}\x22>\x0a  <div >\
+\x0a    <button aut\
+ofocus class=\x22fl\
+ash-close js-fla\
+sh-close\x22 type=\x22\
+button\x22 aria-lab\
+el=\x22Dismiss this\
+ message\x22>\x0a     \
+ <svg aria-hidde\
+n=\x22true\x22 height=\
+\x2216\x22 viewBox=\x220 \
+0 16 16\x22 version\
+=\x221.1\x22 width=\x2216\
+\x22 data-view-comp\
+onent=\x22true\x22 cla\
+ss=\x22octicon octi\
+con-x\x22>\x0a    <pat\
+h d=\x22M3.72 3.72a\
+.75.75 0 0 1 1.0\
+6 0L8 6.94l3.22-\
+3.22a.749.749 0 \
+0 1 1.275.326.74\
+9.749 0 0 1-.215\
+.734L9.06 8l3.22\
+ 3.22a.749.749 0\
+ 0 1-.326 1.275.\
+749.749 0 0 1-.7\
+34-.215L8 9.06l-\
+3.22 3.22a.751.7\
+51 0 0 1-1.042-.\
+018.751.751 0 0 \
+1-.018-1.042L6.9\
+4 8 3.72 4.78a.7\
+5.75 0 0 1 0-1.0\
+6Z\x22></path>\x0a</sv\
+g>\x0a    </button>\
+\x0a    <div aria-a\
+tomic=\x22true\x22 rol\
+e=\x22alert\x22 class=\
+\x22js-flash-alert\x22\
+>\x0a      \x0a      <\
+div>{{ message }\
+}</div>\x0a\x0a    </d\
+iv>\x0a  </div>\x0a</d\
+iv>\x0a  </template\
+>\x0a</div>\x0a\x0a\x0a    \x0a\
+\x0a\x0a\x0a\x0a\x0a\x0a  <div\x0a   \
+ class=\x22applicat\
+ion-main d-flex \
+flex-auto flex-c\
+olumn\x22\x0a    data-\
+commit-hovercard\
+s-enabled\x0a    da\
+ta-discussion-ho\
+vercards-enabled\
+\x0a    data-issue-\
+and-pr-hovercard\
+s-enabled\x0a    da\
+ta-project-hover\
+cards-enabled\x0a  \
+>\x0a        <main \
+class=\x22font-mktg\
+ \x22 >\x0a    \x0a\x0a\x0a  <d\
+iv class=\x22positi\
+on-relative\x22 sty\
+le=\x22z-index: 0; \
+transition: all \
+0.25s ease-in\x22>\x0a\
+    <div class=\x22\
+position-absolut\
+e overflow-hidde\
+n width-full top\
+-0 left-0\x22 style\
+=\x22height: 370px\x22\
+ data-hpc>\x0a     \
+ <img alt=\x22\x22 cla\
+ss=\x22position-abs\
+olute\x22 height=\x224\
+15\x22 width=\x22940\x22 \
+style=\x22top: -20p\
+x; left: -20px; \
+z-index: 1; widt\
+h: 110%; height:\
+ 425px\x22\x0a      sr\
+c=\x22data:image/jp\
+eg;base64,/9j/4A\
+AQSkZJRgABAgAAZA\
+BkAAD/7AARRHVja3\
+kAAQAEAAAAUAAA/+\
+4ADkFkb2JlAGTAAA\
+AAAf/bAIQAAgICAg\
+ICAgICAgMCAgIDBA\
+MCAgMEBQQEBAQEBQ\
+YFBQUFBQUGBgcHCA\
+cHBgkJCgoJCQwMDA\
+wMDAwMDAwMDAwMDA\
+EDAwMFBAUJBgYJDQ\
+sJCw0PDg4ODg8PDA\
+wMDAwPDwwMDAwMDA\
+8MDAwMDAwMDAwMDA\
+wMDAwMDAwMDAwMDA\
+wMDAwM/8AAEQgBnw\
+OsAwERAAIRAQMRAf\
+/EALYAAAMBAQEBAQ\
+AAAAAAAAAAAAECAw\
+AEBQYIAQEBAQEBAQ\
+AAAAAAAAAAAAAAAQ\
+IDBAcQAAEDAwMCAw\
+UGBAEGCwgCAwEAES\
+ExAhJBUWFxgZGhA/\
+CxwSIT0eHxMgQFQg\
+YHF1Ji0iPTFBVygp\
+LCM2ODkyQlNaKyU6\
+OzNEVVc0RUpBYRAQ\
+EAAQEDCgQEBQUBAQ\
+AAAAARAQIDUwQhMZ\
+HRkqLSBRYXQVLiBq\
+FCQwfhghRkFVESYh\
+MzcYH/2gAMAwEAAh\
+EDEQA/APmt+KL6fH\
+yMwDu9SqlUFtBRAz\
+IlMBsHdVDC1UOB24\
+QpgNFYh8UFBafaiJ\
+TACpPZVDtA0QyYWl\
+EphbMqhxaUQ4tPdU\
+pxbPdIlM3ZWJcnFs\
+0QMLFSnFvkgYW0Vi\
+CLVUpxYoUwsCqGAH\
+ZA2JQNgiUwtCsKZu\
+EhRxKIOBVDCyUDYb\
+pEo4qpTYiEBx4SBs\
+UIIsKsBwQEWoUcVY\
+g4qRRx4VTOBx4SA4\
+orYcIg4INigOKFHB\
+Fo4HZEzlsOEwZbDh\
+CjhwpVHDolPi2ARG\
++mFaNgFAcAlGwCUb\
+EbBAcRshytig2PCi\
+hiqYbBKcrYINgooY\
+BEY2K4M5DBQbBFDE\
+9UI2J2RQx4UgGIVg\
+GCgGCKB9NDnD6aI3\
+0yplcBgdlFpcFUDB\
+RWPpqLkv00ShgpFp\
+cOEUuKZMBjuEgXEK\
+ZXBcOEANvCi0pt4V\
+Cm19VFpTYUKTA6Jm\
+GMgbDs6i8xTYZ9yh\
+ghs3DIuS/TUKQ2Iu\
+QNgUCH06qLUzYUAx\
+mkJlcFNqkCY7Qi45\
+SGyunuRYQg666qBT\
+b32SKQ2tp4IAbdCo\
+pDbuHKGMlxPCikNl\
+eEqlxDcqI42qy6Oe\
+VANtSimbx2RDMTot\
+IoA3Q6oGA8ETJha6\
+0igtUKfElidVUOA5\
+gMiU2JQqmI8EDM/K\
+sTOTi07eCqU4tZWF\
+NirhFANVIUwtViUw\
+CoYWqpVBaoUwtVQ2\
+PDDdAwt3QMLAOUQz\
+cK4wGAKsQwsQOLOE\
+DYJhMmxQhhYqRsFU\
+NggYW8KLjI4hVILJ\
+DmNiqDihRxRKOHCF\
+MLDsgOHKIOCKOCIO\
+CGRwUUcFU5BxUK2K\
+pYOCQrYHZAcOEKOH\
+CnMcuRwOysK2BQ5W\
+wRGwUabBVGwQHBBs\
+FFbBVGwKithwgGHC\
+DYcJlcZD6Z2Qo/TQ\
+/3BghW+mVKB9MoVv\
+ppRsCgGPCitjwg2I\
+QDEIBgEUMAhzhgil\
+wKGAx7KQoY8IBjwg\
+GCAYFZWwMCi0uBRC\
+mxCgbFFLgPxQL9Mb\
+KKGHCBcOG6KRQNqQ\
+5iGxFLgmTBTapFIb\
+UUps4QLhwmcLjJDa\
+RopApseaItL9NQIb\
+DqopDYO6BfphTK4I\
+bOPBRU8Whu6BcZhR\
+S4t2UUpteEqxM2mr\
+90CG2CikNp2d1CFN\
+qgXE7IOECBHRdHOm\
+AbpoqhgPFUUA46Ih\
+2lXAcW7U3RDga04V\
+Q4GyBxa/xROc4DKo\
+fGVQ4tn7ERQWjZWI\
+cW/einFp1VSmFtFU\
+UFpSLTCz8VWTi1QO\
+LUDCx1UMLQFYhxbs\
+EDC1A4sVSmFgQp8U\
+OUcVUNgdkhTiwoUR\
+YdlUMLCnMc5sPwQN\
+9NEo4BCmwCcoItGy\
+Ai3hA2OyFg4pCjgi\
+ZyYWHZIUcFQcEQcA\
+iwRaESNiEUcRsgLc\
+JBmViZHEpjBnLYlF\
+bEpjBkcSpCtiVQcD\
+soD9MoN9Mqlb6Z3U\
+oP0zulG+md0yYyP0\
+yhW+nwoVsOFShh7M\
+oo4FEDFIVsUitikG\
+ZSGMgyozcKAY8INi\
+ihggGChQw5VK30wo\
+ofTG6I30+qLQw4UA\
+xbR0ANo2TlVsUSFN\
+iLygbEC4IpTaithw\
+6hC4pADZx3UUuBVC\
+/TKlUMDuoFNnZFLg\
+EqFNg2UUpsUUhtbQ\
+dUilNoKgQ2IpDYoF\
+I3qilwfqgQ2nZRSm\
+2JUi0hsU5zmIfTKV\
+SG38FFIbPFRUzYPv\
+QJdb4lRSY6MgBt6l\
+RpNjRCFI11UMEIdo\
+7IuE8fBB5rT11XbD\
+goBxAqUFAPPRA4t4\
+VFANobVVKcBEOLUQ\
+4tVIcWyhzKCxqjhX\
+nTmUFo0CsQ4tdBQW\
+tyrEzkwt/FUOLUiZ\
+yoLRsyJTi3hDGTCy\
+46KpTizdA4t2VSnH\
+plA49OjzwqhhYPvQ\
+OLOFUPhuEQwsGyFP\
+i2iY5VzyGFvCsQwt\
+4Qo4ohsUBxQhsUij\
+giGw4VhnJsNWUDYB\
+EEWhUHHhIDjwmMGR\
+xKQo4FARYqQcEQfp\
+opsApRsAqg4DZAcO\
+EMDhwgOPCFbFAcXQ\
+bE7IDiUORsUg2Psy\
+DYoNiUK2JQHE7IVs\
+TsfBCtgdlFHAolDC\
+5Fo/TKI2Ci5bBUrY\
+8IgYjZRRx/yUg2PC\
+RQxGyTIGAQbBIYDA\
+JAMBsmTAYcKRa30+\
+EKH0yi5D6dyDYJzn\
+MGA1UUMAiUD6YUqh\
+9PhAuHCKGKgBtRS4\
+8IkKbQpyqBs7pVKb\
+OCgU2HZAuHHdFDAr\
+K0p9NAhsRSmysKBT\
+6Y2Uq5wQ+nwopDZw\
+gXHcKKQ2IENqKU2h\
+RUzZwUCGw7IENmrL\
+K4IbEqpmwqLSm1SL\
+SGzx2UyqWCAG0KFT\
+No20RambWRQYfeoR\
+5YAHDLtK5UwC1GVB\
+a3xQpwFWaoLTsgpb\
+Y+iFUFh0FVTJxYUS\
+qCzdVFBY7Sqig9MC\
+tUTOTiwKooLAhVBa\
+Nu6FPbZwrlMKCxQp\
+xaOqsQ4tOyqGFiB8\
+eFYHFhVQw9NEOLAg\
+YW8KwPggbAImTC1A\
+2PDIo4KocWd0KYWI\
+hsAgIsGyqGFvCLyG\
+wKII9MoU3090oP0w\
+lDCwbIDiNlcJkcey\
+A4oDinMfERYgOCA4\
+BAcAhWwSg4cIg4cI\
+DiqNhwoo4lBsUQcE\
+GwRRwSplsFFbFWFo\
+4lAMSoDiqYbFBsVI\
+VseFRsTsoo4nZBsO\
+EAxVGwClGwCUbAJS\
+N9MIN9MIN9PZSrAw\
+4ReUMEQuCDYKNShg\
+qgG07KK2HCAYIB9N\
+QD6fKi0MEAwQDAbI\
+uMlwGyigbBsgXAKI\
+GCKU2qRS4qZXBcEo\
+U2cJVLgdkMFNh2QK\
+bFFIfTG6KXBQxkhs\
+CgU2DZFpD6YUUhtG\
+oUikNjoJmxQIbUXB\
+DY6cy86RtQIbPxWW\
+oQ291DCZsGiNchDb\
+x3UEzZ3QIbDsopDZ\
+96ilwQryRbxC74cK\
+qLQJ1QPjtCqZUFpZ\
+EzlUWpBQW66qpk4t\
+4VgcWkq4TKos3RFB\
+a9KKocWalUUFvEIK\
+CzuiKC3hIhxarEOL\
+CqHFquMGTi0lEOLC\
+qHFiJTiw6BVDD0yg\
+f6aUpxZwoUwsKqUw\
+9NDGVB6SUMLAqhha\
+NFFMLdFYyOBSFNgq\
+DiEDNsEBYpCjiVUE\
+WEoXJsEBwKQo4cJg\
+ybAoDgUqDglBwSg4\
+JQcEBw4QHBAcUBxS\
+FbBIDikKws4SGcjh\
+wkK2HAQHA7AIDgUW\
+tgd0Sjhyg2CUbBBs\
+eFOdeYcTshytidkG\
+x6IgYIrYoNhwithw\
+VEbA7FUb6ZUqxvp9\
+EA+nypVb6aUD6aUb\
+BCtgnOczY8IBjwhA\
+xUqxsUAwQDBCl+nw\
+yNcjfTKIXAqKGBRc\
+ZDAKAfT5UA+mqFPp\
+jZRaXBAMOEhS4qKU\
+2qKU2IENqkUptKBT\
+agQ2KmCGw0WctENh\
+2SHMU+mdkCmw7KZX\
+CZsUi4IfT5QpTZup\
+nDWMpmxSCZ9PhKqZ\
+s4UCG3hFIbOyKniQ\
+7qZXCZtdQTusKKmb\
+dGUVM2KKXE7IPJYe\
+K7YcOQ4tcqiwtooG\
+FvDBawyqLeyCltp7\
+bKphW21+dkFBatYw\
+zlQWFCqCzRkS4OLF\
+UqosQUFiuDKgsTCZ\
+yoLOFUOLOEKcWDZX\
+Bk4t4VjJxYgcWgaI\
+U4tGyIYWuhnBxZwq\
+hxYgYW8OgYWnZA2B\
+2VT4nHp7pUHBCmwQ\
+MLCqUR6aJTD0wgYW\
+DZUwOI2UgZikBxKs\
+BwKIbBFHBQMLeFYl\
+bDhMGcmwOyfE+A4F\
+CjghyjglBwQjYIDh\
+whBx4VBw4CDYqKOJ\
+QbBEwOKK2BQo4FCt\
+gdkKOB2QrYKFHBCh\
+9NUo/TUK30ylAwQH\
+DhBsChAxKhGxT4rO\
+RsTsg2J2QbE7INid\
+lBseEUMUGxSLQwUG\
+wCFbC1ChgEyYDDgK\
+DYoFxOyK2JQDHhAD\
+ahC4BADYiwuHCmcm\
+MBgdkaDA7ImAw4Ui\
+lPppClwSLS/TQKfT\
+UC/TGyQD6Y2UyuCH\
+0xsikNhChgptUUhs\
+4RSG1AhtRSGzhQIf\
+TKKQ2Hbuoqd1iipm\
+wqZyENiLjKZ9MKKm\
+bNlFTNvCKmbOFAhC\
+mcKndafwUVI2oSlb\
+3U0UivGFq71wqgtV\
+RYW8JgycWuzaqotb\
+aPvVRQWpgyoLVWcr\
+C1kDi3uiKC1WIoLV\
+YZypbbREqotNKq8h\
+ynFpVQ4sKqHFhKqK\
+j01KHFiBxYgcemES\
+mFoEMqhxZwqHFiBx\
+ZwkS/AwtViHFqYwo\
+i1WIbBAwsCpnBsRs\
+oQcSdFcpgwsKZMZN\
+9MoG+nygOClDYKoO\
+AQNgNkyco48IZwOK\
+EHEoo47JUg4oo48O\
+qg4cKA4oDjwgOKJy\
+tirSDiosbFSLRxCq\
+QcRshnDY8IQceEwR\
+sUi8zYoQWQjY8Ikw\
+2PBRcxsTsosHHhBs\
+TslSDigGCA4hFbEK\
+DYhEjNwgzcIc7Nwi\
+s3CAMg2KDYhQDHsi\
+wMUGwQgfTOyAYHZR\
+aGB7oNgqBhypFbAK\
+IGA2RQwGyQuWw4RS\
+mxRcFNqIDKqDbqUg\
+YhCAbOEUhsOyZMFw\
+7KKBsKBfp8sopT6f\
+sEoU2KKQ2cKBTYNk\
+MZhDZwovOQ2MikNq\
+iwhsUEzayqkNqixM\
+2cIENnCy0mbOFBM+\
+mSipmzdRUzZ+KhUj\
+Yi85DYCpVSutCKmb\
+RRlBPEPRZi14wC7u\
+CotMQtMqC0nRUq1t\
+qFVFlFcJlS2yiqK2\
+2dglRUWDXwRFbbBs\
+mTGVBYBo/C0igs4V\
+RUWJEUFqsDi1EyoL\
+FU5Ti3ZIHFiooLG0\
+SIcWHQKwOPTKYMnw\
+6KpkwsRKcWIGHpq0\
+OPTCIfEDRSgtwqQw\
+tRDCxRTCxKQwtVQc\
+UyYMLeEIItegVDYH\
+ZReQRYqlNgiURYEK\
+OI5Sg4jZAcRshBxQ\
+gi1Fg4pgzhsUBxCI\
+ItHVFHDhEoiw7JRs\
+OAlBwKVRw5RK2A3S\
+g4DlQo4jZVK2I2Uy\
+uGYbKozDZRWbhAW4\
+QZgi8rMiMyK2IVRm\
+Citj1QHHhBsFItb6\
+Z4VhWw6IVj6aFbBI\
+UMAorYBVGw4CAYnZ\
+RWYhEZlMYXIMhGYJ\
+BseEWtg+nioB9PhD\
+GQPp+OiKH0yotKbN\
+ygGCDYhQgYDZADYN\
+kAwQKbNlGiYoAyAY\
+hQLhwqFwOyjRTZwo\
+pTYdUQuCKU+msqmf\
+TVoU27qKQ2BQqZs4\
+UyuMkNqikNvCGMpG\
+1FIbXSCZsKipG3hR\
+UzapFTNhFFFSNnHZ\
+QTuseVOZedI26IuE\
+zZCLhPFSLXji3Rd3\
+nVFvZWCgt2VxhMq2\
+2qxFrbUFRYyrOcq2\
+2cIK22LTKgsVFR6a\
+CgsVRUWURKcWBEUF\
+nCqKizhA4tCEOLSV\
+UOLAgcWrUQ2CmDKg\
+9PhVLg4sQNhwimxK\
+VDD0zqhnJh6Y3RD4\
+BCmFg6olHEbOnKps\
+eEQwsVIbBAcUBxQg\
+i1DODY8FCDgdlQcE\
+BwUwZMLFStgFKDgF\
+Uoi0dUKOA2UoOHAQ\
+psVUbHlRRxQjYqo2\
+IUWDiFSNiEgzDZRR\
+x4VQceEI2J2SKOJS\
+DYpBseUBxCQy2ISG\
+BxGymeQ52x4SDMhj\
+DMixmCJBZAMQgOI2\
+RWw4UGwVGw5Uo2G5\
+SgYHdBsEo2HDqVQx\
+GyDYBRWwGgCqBgoo\
+YIBiixsShGY7IQMe\
+EGw4UAwShfplRQPp\
+oYyH0whS4BT/4v/w\
+BDAbKKGI2QDAIlKb\
+EUptUUuKBTailNgR\
+CGxFxSmwqFIbOEUh\
+sUCn09lF5EzZ3RSG\
+xRUz6amVwmbFAhsC\
+LypmxFSNoUCGwKLh\
+E2t0UaTNmqCJtZRU\
+za6iom1FJiorxrbN\
+16HnWFj6QrhFRa2i\
+CttnCIuLWpVXCZUt\
+s1VRYWqooLVUVFvC\
+ooLDslRUWHZEqgsK\
+CgsVTKgsVFBY6IcW\
+AK1FBZwgcenwlIoL\
+FUzk2KJDi1KQwsQM\
+LEDi3hEMLeEXPIYW\
+HZVDYHdAw9NM5MGw\
+5RDCwIDiFQRYgOIQ\
+NihRxRKOKGBx7oc5\
+sUGx5VIOO6g2IQML\
+eFQcTskGxOykXAiw\
+qg4EpAfpndAcOURv\
+phFHAIDgEpGFoTBk\
+ceEI2PCDYhBmCLDM\
+hGY7KUHE7IlbEpVw\
+OJSnM2CUrMEpAwGy\
+Ug4DZKNgNkpBx4Qw\
+GKitiN0I2IQbHlCN\
+ig2JTI2B0CHI2JUG\
+xRWxRAxCixsByg2A\
+QbBTIGPCZMAQgDIo\
+Yyh8AwQDFRYGJ6qo\
+zFQA2ouC4gqLnEA2\
+IYA+miUp9MqZaxkM\
+CiExUy1gMQgU2AqB\
+TYikxQKbe6BTaikN\
+nCZMENhUjRDbupBM\
+2JAl1hCipm3hTOFT\
+u9NFwmbFFTPpqCRs\
+RcZTNiLUrrFFSutG\
+qmVSus2UXCJtUypM\
+ZUHjCwru4KixtVam\
+VrbN0FhaeyuEytbY\
+NlUVttfogtbbwtMq\
+C1UVFqIqLURQWqmV\
+BZwiRS2w7KoqLG0R\
+DiwlUqlvpqlUFiJa\
+YWohxYopxYFUNiNg\
+iGAVhTC07IU4sQML\
+eEQ2PCAsiwcVUhsV\
+Qws4hQHDhXmTnNgf\
+8ACgYWHgIDgd0QcE\
+UcAkBFo0dWA4cIGF\
+nCAi1EjC3eUUcRCE\
+HHhAWQbE7KVRxOyr\
+I4lSq2KUHFKNh4pS\
+jiNlKDiNko2A2TBk\
+ceAgOJ6INioNiqNj\
+yg2KA4lMmGxKlVsS\
+lBxPARK2B4SjY8qV\
+Wx7pRsE5TkHDhUrY\
+gaKLzhiNkLBYbK1A\
+x5QbGEoGJRWxKXBy\
+sxSkDHhKRsUK2CFY\
+27KLWxQbEoA1VFDD\
+gJChjoyLGYeChnDY\
+8IkBhshAI7qLANvC\
+oU2FFwBsOykKXEpF\
+DFIRseFIFNiBT6fC\
+BD6amWsBgqlKbFlS\
+mxCkNnCjVKbGRKU2\
+hDlIbEVM2bKKQ27o\
+qd1igkbW5TK4TNqg\
+kbSFlpM2uiom1Sql\
+db4JlcYSutQwjday\
+ipXWKLUsSo1XkC3Y\
+Ouzzq22HZVF7bCei\
+GFrbGVSqizlXCZWt\
+sGiuEyrbYrUVFg2R\
+FrbBsiKi3ZXGDKgt\
+VRUWomTgKwUtsVTK\
+gtRDC1CHFqGTi3h0\
+Q4tJ0VwZwYWHZA49\
+M9OFRQWfeiGwCQo4\
+qoYWSgYWDZ0WmFiq\
+CLeFA+JVQceUIOKi\
+wWVgOJ2KEHA7K5yY\
+wbBAcQpSDjKtQcJq\
+s2LaOCtStgAd1Cmx\
+GyUHGKJRsd4UUcTu\
+iUcQqMw6oCyILcIQ\
+AOFGs4HE7ICLSqjY\
+osHHlEjC0aqLGxCE\
+HEIRmGyEZggLIMyE\
+ZoSHMzJBmQgshGaH\
+UWNiUyRsUSNig2J0\
+RYzHZCMbTsgzHZCB\
+jworAJgyzIkZkiiy\
+ZwMyTIzTRAMUAxSr\
+GxMpggYnZBseFUbB\
+ItbBC4KbPBRaGHKc\
+xztidlUDFlFbFQbE\
+dOUyYDFApsUXBTb3\
+RSkIAyiwrImcQpt4\
+UUhtRSm07IENqkUp\
+tUOYhsQJiVGiG3hU\
+IbOFKqZsIQIbeygk\
+bFGsZSNihUjZwplU\
+rrVFTut4UVE2sipX\
+WqKgbW6KVYTCapSP\
+FttXVxXFqotbarE5\
+1hburhnKttrrURa2\
+zulIrbZwqi1thRFh\
+YegVwigsVwZVFiRM\
+qD01UUFgCCgtVRQW\
+cIHFo2VjJxaUgcWU\
+RTixEh8VUFuEimFh\
+2VQwsQOLD9yFMLD9\
+6FNhylQ2AQwLBAce\
+FQRYouTC0BKkMAdE\
+pGZKCylWCycyc4i3\
+hUHEqFHFKgi3RAcf\
+JFg48qo2O5QbEKLB\
+xCEZhsgLDZAUMAgy\
+KIBRGxOyRaOJVRsS\
+oDiUGxQHFKNh7BCt\
+gpRsEW5EWoNiBLon\
+KOMIYbFFbGAh8Wbd\
+BhakKzFBmP3KNMxV\
+RsSGRWZEZlMrhmPR\
+AcYKqNiNggGARWwd\
+Qo4bK1ANh2UVmbRW\
+pGZRWYKQBkGIDoYw\
+2IVAx5UUGKqM3CEB\
+kUMe6UA2+Ci4Ljyh\
+AxO3dAGKitiiBh9z\
+qLnJTb2ShTYi/7i4\
+qLQxCIXAKKQ2KBTY\
+ikNqEKbVBM2pViZt\
+RcENqgmbNkawkbWU\
+i1M2qCN1qKkbVFRu\
+tUhUrrVFRutRUbrV\
+FqWMqNPIttouzguL\
+RsrhF7bdWWsYZysL\
+eEFrbYRMrW2q4Ra2\
+1VFRarhMqi07KkUF\
+nCCws3CvIycWnogp\
+b6ZQzlQWJhMnFrqn\
+MoLEooLBsiHxGyHK\
+It4VSHFrophb2RDi\
+3hVBFqYyZwYWhCGb\
+hAcTsqGwQoi1CiLS\
+aqUNjRKDgiUcVKDi\
+EBxGgQFkBZUxhmQj\
+NwiwUSMhBxOqK2JQ\
+HEoXA4ojYpQcfJAc\
+QhhmUoOPDoDjwg2J\
+2QHEoRhadkMtidkG\
+xKijgVYNiUMYbE7o\
+RsDHmg2BKc5zDgUG\
+wJQHA8INh0QHB0o2\
+J6pRseEowt4TBlsf\
+JCMxfVSrG6hVIzBR\
+QYbIMAEMswQZvFFD\
+EoVmKDMUVmQjNCEb\
+EbKUgYeCDYdGQDEp\
+RmQZlCs3dAMRslGw\
+j3IBilIDbqkDHZQw\
+GPCLyFxEooG1lAFY\
+gECiypTagU2+xRaQ\
+hFKRwpFKbUiENvZR\
+ambWRaQhQJdb2Ui1\
+M28KiZCgmbeEVE2q\
+NYTIUEbrUVK61SKh\
+daoJXBRULrUVNpQr\
+yrbV0c17bFaL22ur\
+zMrCwIlXtsdUysLd\
+lcM5WttpEqorbaqR\
+W21BUWsiKC11Uypb\
+YhlQW8KphQWHZEUt\
+sP3qocWIGFpKBx6Y\
+3QPgNVUp8AhgRYNn\
+QMwVQW7KKLKoYA6I\
+g4lSrjBgO6Ug4lAR\
+ahkWRDY0KEHFCNiq\
+o4qFbHhDAi1KZHFA\
+RYEwZyLAGiIKUjMg\
+ItJQHFCDhuqNiosb\
+EJARahkWQZpZAWKH\
+IzIDigzdYQrAIZFk\
+GbTbVCMyAshAb8EU\
+USM33IrN96IyK3sU\
+GkFQjN4IRmRW80IL\
+IkZtEqi3HZKjAJTI\
+Y6qLWwEoVsBuUGwC\
+Fyws2TBmhidkRm0o\
+i5w2iEZggDIMQmTA\
+MW9yi8jM2iK3ZVAb\
+VRQNvKAYnskKCIyQ\
+Zu6kUGCUgY7KhTsy\
+AN9yFBpaqKTHlArM\
+pFCEQDaNFAhtRaQj\
+yRaVlCFNqCd1qipk\
+KKQgFDmSutUVMhFT\
+ut/FDCN1sqLjKZCK\
+hdaoqVwUELgpGkbr\
+VFwjih8HnW28Loxl\
+e207Ksr22FKi9thV\
+FhZolRa2xWpla2wK\
+orbYNlUqwtA0VTn5\
+1BamEysLQAiHAVFL\
+bVUyoLeOigZlQ4t/\
+BUhxb9wRDYomMHFu\
+yKYWqoOO6BhbsiGF\
+iUEWiYZSrkcUBYOg\
+ItKqQ2I1KEEAbdFF\
+jIGbhVBFpQy2KKLI\
+kFkBwOyA4FAcAhzC\
+LRshzDj96iiyqMyU\
+FuEGZBmRYLVSIzd0\
+GYKjMkG8tlFbhAVR\
+pQZCMyDMpgyzbShB\
+ZKRm8EVmaqVOdm8E\
+GbVTmW0WGqtRm/BR\
+WbhKCx2VRmUI3dFZ\
+CChGRIzIrMpBuio3\
+VQZAKaKKyoKIEaqK\
+zBVANvLKKBBQBj9q\
+qMgCi5ZkKDVQBUZR\
+QZ9EAbZCA1XQBIAy\
+kGIHZAG1CtQpG6BS\
+Ksi4yBt7IENrfcpF\
+oIFNqgQivGiLSEfg\
+i0jKLkhtQTNqhUyF\
+Iqd1qCRFYUaSIQRu\
+tUXGUiFFRutTK4Qu\
+CyqFwSKm0rK8rgtH\
+C6Yw55WtCqZXtCuE\
+XtthDOF7bYWmXTZ6\
+Hq3B7fTuuB/iALLO\
+dppxz5w1jZ6s82Mu\
+n0/wBH+pvfD9P6t7\
+VAsJ+CzniNnp59WO\
+nDWNhtNXNpz0ZdNn\
+7d+uuLW/o/XuJoB6\
+dz+5Yzxmxxi/79PT\
+hccJts5n+zV0ZdNv\
+7T+5a/t36n/ur/AL\
+Fj/IcNvNHax1t/0P\
+EbvV2c9TpH7H+8Q3\
+7R+sO3+g9T/NWf8r\
+wm+0drT1tf4zi91r\
+7Oep0Wfy9++3h7P2\
+X9fcN7f03qn/mrGf\
+OeB08+32eP59PW1j\
+yjjdXLjYbTsaup0W\
+fy1+/kgf7j/Xh9T+\
+n9QDxNqmfPOAx+vs\
++3p61x5Nx+eT/o2n\
+Y1dS4/lb+YtP2T9b\
+1+jf8AYs/5/wAv3+\
+z7WGseRcfuNfZyvZ\
+/KP8yXBx+y/qu/pl\
+/Bc8/cXl2P19HS6Y\
++3/MM/o6+hf0/5O/\
+mW8sP2b9QCzzaLX8\
+SFnV9zeW4/X09K6f\
+tzzHP6OpUfyX/M/w\
+D+n9aObf8AOWfVHl\
+m+0/j1NemfMtzq/D\
+rX/wD+F/mqv+6L+/\
+qel/nrHq3yvfY6NX\
+U3j7V8y3OenT1q2f\
+yF/Nl/5f2g/wDG9b\
+0R4P6gWdX3h5Vp/W\
+7uvwtaftPzPP6Pe0\
+9a39v/AObf/wBT1/\
+0/6f8A1iz6y8p33d\
+1+FfSPmm572jxK/w\
+Bu/wCbGH/l1k6fW9\
+L/ADlz9a+VbzPZ1d\
+Tp6O8z3eO1p6z2/w\
+BOv5pN2J/Q+nbvcf\
+W9Nh4XEqZ+9vK8Y5\
+Npns6uox9m+Z5/Jj\
+taetb+2/8ANAj/AG\
+b0B/21qx638sz+bV\
+2cunozzL5dPawpZ/\
+TX+Z73f0/01h0B9Y\
+H3ArOr758sx8dWf5\
+WtP2V5jn4acfzHH9\
+Mv5nYHH9Kx/wCtp/\
+7Kz688t/59n+K+iP\
+MP+PT/AAXH9Lv5ih\
+/V/RAmtp9W5x4WFY\
+z9/wDl2PhtOzjxN+\
+huPz8dHTnqNb/S/w\
+DmEkf6b9CJbI+rf8\
+PTdTP7geXY/LtOjH\
+iXH2Lx+fjs+nPhUH\
+9LP5gf/wC8/bwJn6\
+nqtH/ZLn7heX/Jte\
+jT43T0Hx3z7Pp1eF\
+S3+lf74Tdn+u/QWg\
+NS71bnf/swpq/cPg\
+fhs9p0afFldP2Fxv\
+x17Pp1eFT+1X7yB/\
+6h+iPQ+p/mLPuHwe\
+72nd62s/YPGbzR3u\
+ow/pX+7v8AN+4/o7\
+RoR9Qv/wCwFM/uJw\
+nw2Wvu9a4+weL+O0\
+0d7qV/tT+5mn7n+m\
+ivy3+9mWPcTht1r6\
+cNe3/E73R0ZEf0p/\
+ciQ/7p+mAJqLbyZU\
+z+4nDbrX04XH2BxG\
+909GVh/Sj9XT/fHo\
+/91d/nLHuLsdzq7W\
+Opv2/22+09Geth/S\
+n9Wf8A8t6L7fSu+1\
+PcXY7nV046j2+22+\
+09Geta3+lHrn/81Y\
+Nx9Ax/8xc/cbRuM9\
+r6XT2+17/HZ+pj/S\
+n1nA/31YQYf6Br/w\
+B4nuNo3Ge19J7fa9\
+/js/UsP6TXMH/fQC\
+aj/ZoH/wA0LGf3Hx\
+eTh+/9DeP29zOXiO\
+59Tf2mJLf7+1n/AM\
+Lp/wB8p7j/ANv3/o\
+Pb3+47n1ns/pPY5+\
+p+/XNo36YW+/1Ss6\
+v3Hz8OH7/0taf29x\
+8dv3PqP/aj0XP/AJ\
+3fVv8AoB/rFn3G17\
+jHaz4Wvb7Rv89n6h\
+H9J/Rdj+9+pGv+zj\
+/WJ7ja9xjtfSvt9o\
+3+ez9TD+k/oBif3u\
+8iMh9ADzzKZ/cbaf\
+DYY7Weo9vtnv8APZ\
+/ip/aj9G//AKt61P\
+8A4Vv2rHuLttzp6c\
+9Tft/sd9q6MdYj+l\
+H6N2P7v64f/q7ftT\
+3G22509Oeo9v8AY7\
+7V0Y6wP9Kv0QLH94\
+9cR/8ACtf3p7jbbc\
+6enPUe3+x32rox1r\
+f2q/bP/wBn+qdtrP\
+cy5+4vE7rR05b9Ac\
+PvdXRhj/Sr9rH/AO\
+T/AFVWfGz7FPcTid\
+1o6cr6A4be6+jDf2\
+p/a2/9U/UvwLNOye\
+4nE7rR+PWegOH3ur\
+owpb/Sz9mxe79w/W\
+3Xat9MeWBWM/uHxl\
+5Nns+91t4+weEnLt\
+Nfd6h/tZ+yn/8Av/\
+rXff092/wKe4fGbv\
+Z97xL6C4Tea+71B/\
+az9llv3D9aSKT6f+\
+Yr7h8Zu9n3vEnoLh\
+N5r7vUJ/pZ+ymn7h\
++teIf09f8AiJ7h8Z\
+u9n3vEegeE3mvu9Q\
+f2t/ZiW/2/9a+k+n\
+3/AIE9w+N3ez73We\
+geE3mvu9Qn+lv7Lb\
+X9w/WePp9/4FPcPj\
+d3s+94j0Dwm8193q\
+E/0s/ZRP8AvD9aQe\
+fT1/4ie4fGbvZ97x\
+L6B4Tea+71B/a/9l\
+kH9f8ArQ38T+m3Bm\
+xX3D43d7PveJPQPC\
+bzX3epX+137BAP6z\
+9eCQ7/AFPS930viu\
+ef3C4/5Nn0avG36C\
+4H59p06fC39r/5fd\
+j+s/cAYLfU9L/Uqe\
+4XmHybLo1eNfQXA/\
+PtOnT4W/tf/LzT+s\
+/cGP8A1npcf9SnuD\
+x/ybLo1eM9BcD8+0\
+6dPhEf0t/YCx/2v9\
+wD0+f0v9UnuFx/yb\
+Lo1eM9BcD8+06dPh\
+b+1/8AL7Fv1f7if+\
+09L/VJ7hcf8my6NX\
+jPQXA/PtOnT4S/2u\
+/YWP8A4z9f0Pqel/\
+qk9weP+TZ9GrxnoP\
+gfn2nTp8Jv7X/y+x\
+P+1/uMf9Z6X+qT3B\
+4/5Nl0avGvoPgfn2\
+nTp8Lf2v8A5f8A/w\
+DL/cHnH/Selp/2Se\
+4PH/JsujV4z0HwPz\
+7Tp0+El39Lv2Nhj+\
+u/XWlpe/0i9Kf6ML\
+Wn9wuO+Oz2fRq8TO\
+r7C4L4a9p06fCH9r\
+P2b/8AYfreC/p+7B\
+X3D4zd7PveJn0Fwm\
+8193qA/wBLv2bT9f\
+8ArCWkP6df+Qr7h8\
+Zu9n3vEeguE3mvu9\
+Tf2u/Zm/8Av/1zyC\
+x9P/MT3C4zd7PveI\
+9BcJvNfd6m/td+zM\
+T/ALf+tOon0/8AM1\
+T3D4zd7PveI9BcJv\
+Nfd6m/td+ys/8At/\
+63kP6f+ZKe4fGbvZ\
+97xJ6C4Tea+71N/a\
+79lj/x/wCt8fTo3/\
+AT3D4zd7PveJfQXC\
+bzX3eoP7Xfs8f+P/\
+Wks7g+m3nYnuFxm7\
+2fe6z0Fwm8193qKf\
+6WftbuP3P9WLZYY2\
+E+5bx+4nFfHZaPx6\
+2M/YPDfDa6/wAOov\
+8Aa39rr/vT9SxDgG\
+30x8FfcTid1o6cp6\
+B4be6ujAD+ln7aW/\
+8ANP1Lk/4bNn2T3E\
+4ndaOnJ6B4fe6ujA\
+Xf0r/QP8v7t+oAOh\
+9Own3hbx+4u3nLsd\
+PTlnP2BsLybbV0YJ\
+/av9EI/wB7+u//AP\
+Fa3vV9xdtudPTnqT\
+0Bsd9q6MdYj+lX6K\
+P/ADb1wTp9O2I6p7\
+i7bc6enPUegNjvtX\
+RjrJf/AEp/Tv8AJ+\
+8+raG/i9G0z/ywta\
+f3F2k5dhjtZ6mNX7\
+f7O8m2z2cdaY/pV6\
+JD/wC+7+f9AC3/AM\
+xX3F17jHaz4U9v9G\
+/z2fqN/aj0CP8A1y\
+/p9Af6xPcXXuMdr6\
+T2/wBG/wA9n6k7v6\
+U2FhZ++EA6n9OC/T\
+/SBax+42r48P3/AK\
+cs5/b7Hw2/c+op/p\
+QQP/Xf/wDV+z1lr3\
+H/ALfv/Qz7ff3Hc+\
+sp/pUZb9+n+EH9Ka\
+7f9Krj9xv7fv8A0H\
+t9/cdz6if2q9aP/O\
+rOf9Af9Yt+4ujcZ7\
+X0se3+vf47P1E/tX\
+6pp+9enR/+hLf++r\
+7i6NxntfSnt/r3+O\
+z9SX9q/wBZP/m/ou\
+P+ru+1b9xNjudXTj\
+qY9AbXfaejPW39qv\
+1pdv3f0ILH/R3af8\
+ZPcTY7nV046j0Btt\
+9p6M9aJ/pb+5v/AO\
+pfpuuN/wBi6e4fDb\
+rX+DHoHiN7p/EP7X\
+fuLOf3P9MOcb/eye\
+4XDbrX04PQPE73R0\
+ZS/td+8EOP1/6PHS\
+fU/wAxb9wuD3e07v\
+Wx6C4veaO91B/a39\
+5dh+v/AEQ0r6n+Yn\
+uFwe72nd6z0Hxe80\
+d7qSu/ph+/B2/Wfo\
+CB/l+qD/8AS5W8fu\
+DwHx0bTo0+Jzz9ic\
+bjm17Pp1eED/S/9/\
+FpP+0/t5Oto9T1X/\
+8ApK4/cHy/P5Np0a\
+fEmfsTjvn2fTq8KX\
+9sf5hL/wCl/RQf/i\
+3/AOrXT195d/ptOj\
+HiZ9Dcf/ro6c9SV/\
+8ATX+Y7aH9JeBU2+\
+qY8bQtafvzy7Pz4/\
+l/ixq+yPMMfJn/AP\
+f4FP8ATf8AmQQ36a\
+rf9Lv/AMVX115b/w\
+A+z/FPRXmH/Dp/gg\
+f6efzMH/8AD+jczu\
+R6tq6et/Lfm1dnLG\
+fszzH5dPawW7+nf8\
+zin6X0rz/hHrWfEh\
+ax97+WZ/Pns5Zz9m\
++ZY/JjtYSP9Pv5pg\
+H9BZx/pvT/AM5b9a\
++V7zPZ1dTPo/zPd4\
+7WnrSu/kH+agWH7a\
+L4qPX9Bp63hax95e\
+VZx/6z+XX4Wc/aPm\
+eM/wDl3tPiSu/kL+\
+awD/5SYq3regfL6i\
+1j7w8qzyf93d1+FM\
+/afmeOX/q72jxIn+\
+SP5pH/AOIvH/ael/\
+nrfqzyvfY6NXUx6W\
+8y3OenT1o3fyb/AD\
+MCRd+0eq9uxsPmLl\
+rH3R5Znl/7tP49TG\
+ftrzHGf/HV+HWlf/\
+KH8yWs/wCz+uXowB\
+9xW9P3N5bq/X0/j1\
+M5+3PMdP6Or8Otzn\
++VP5jf/wBH/Vf8ha\
+9R+Xb/AEdKen/MNz\
+q6ET/LP8wiv7L+s/\
+7m/wCxb/z3l+/0dr\
+DH+D4/ca+zlG/+XP\
+3604n9k/XE7D9P6h\
+91q1jzvgM/r7Pt6e\
+tnPk3HY/Q2nZ1dTn\
+v/AGD98tD3fs3660\
+bn9P6o/wCatY844L\
+PJjb7Pt6etnPlPG4\
+59jtOxq6nOf2b93Y\
+k/tX6wAVP0PU/zVr\
+/KcJnm22jtaetn/G\
+8Vj9LX2c9Tmu/av3\
+Gf/L/1P/dX/Yt/1/\
+DbzT2sdbP9DxG71d\
+nPU5j+h/WAn/wnrB\
+oI+ndHkt44vY55te\
+npwxnhdt8dGroy57\
+/0vr2lr/Q9S07G0j\
+4LWNvs845NWOnDOd\
+jtMZ5dOehy+p6V9j\
+Z2XWvuGW9OrGrmzh\
+M6c458Oe4IiFwRUb\
+gsrhFpSK/SPp/tH7\
+Vbc9v7Z+lt0j0fTH\
+/NXwPV5jxWccu115\
+/mz1vuWny/htPNs9\
+HZx1O30v2z9vtuBt\
+/Q/p7TMj07A3ksZ4\
+7iM4mdpq6c9beOD2\
+GM3GjT0Ydtn6H9IG\
+P+yei4m35A76aLnn\
+itrn8+rpy3jhtlj8\
+uOjDut/T+jH+isfX\
+5RHkuf/br/ANc9Le\
+Nlp/0x0Ou21mB2gr\
+m6Omy0gB42UHRbbp\
+XbQqKrbadSWfyQVt\
+tPytXQH7kqui214Z\
+vb7VBYW6CA+ygsLT\
+DGKMgYSSB2ZWBxaQ\
+Q0g+9KKgMRX7FA4t\
+Jfhw7oHtFO6mQzOH\
+Eg1KKYWsQGg16ohs\
+XINxIZ/PkIKMBAkn\
+T2CgAtYf4hAYQw1V\
+ocAgM07jnwUUWNwI\
+3iVBmIgHx07KkGSC\
+Rrx56ICAbtGGgMop\
+mcA8QSgGFzCkSOqA\
+uxd6jWPaqAsQNRQc\
+zqgOJO7Q4MfegbFq\
+Bxx4oARpIB1ozfgg\
+YW8kmeiDOTIpqZFa\
+UQbgCBTzQY3UALyB\
+4pEEk6s4lhv8EUCQ\
+HYsdHogIoA8x28UA\
+Dg8bxO6DPdsedNe/\
+vQGjvoICAA3kBhWp\
+koMBQ1cxttVA0nEQ\
+fDkIMQZevfRKMbIN\
+DOp328UoAADh9A+m\
+n2JQRazAkPoY3pVK\
+NjMWhtendKA35dXN\
+Q/togaJLkBnGygNA\
+80l+UAAtf8oJBgdE\
+G0m12MaoMQILVYEb\
+ahAbbQBAjU0QbEP3\
+mUoXEC1z8zePeqUa\
+Hi0Bi7oMwAyL2isQ\
+e6oN1ujPPIUowZ3i\
+TXmnKDYgNuddtdEA\
+Yw4l5I0VGa38p3gP\
+yg2JgOZp4apRmmpB\
+1J2HglCsXEyKE7Md\
+OyAkB8X5Z0GwJ145\
+SjMxilS0sgwclwxE\
+jJuiAmRIBfRAIN0V\
+1YoMCADL8nVAoJDB\
+3PjFVUa3EUe2rind\
+A5Lcb91FATIGMwgW\
+4APJcAttsqjANIgO\
+fl61eqijiDJtrz9q\
+BTaGDgwXMA7nRAJ1\
+qLXJQC4OTEatJQag\
+Gw0O7oNiBIDk6oEx\
+hrav8Al9/uVGa4ED\
+F4kjR/wUAZ2Jky+y\
+AAXUJjLSea8IjAEh\
+209oQhQcrS4x/wzP\
+iUQXFwJA2cuyKUi6\
+Q+7OiAbaWkYkCNQe\
+FQpdizEMVFTxmrTr\
+v1VQOCKVCKTGPlBE\
+flZKiZBZhOw0fqqE\
+xLky0gWoJ3DYcyVQ\
+pfsNS2kFIJ3WBwDM\
+1UCXWk00h0HNjW7W\
+W9gtCVwcGDu6COHV\
+vtRIh6loc7tIfdMI\
+hdbUU28FRy+pZZda\
+1wF1p0uDhaxnOM3C\
+ZxjPO5L/03oXZA+j\
+Zc/wCYYgv5Lpjba8\
+c2rPSxnZaM8+MdDj\
+v/AEP6Mv8A+F9FjX\
+/R208FvHFbbH59XT\
+lz/ptln8mnow5P92\
+ftzt/sH6fr9Kxvcu\
+n9dxG81drPWx/RbD\
+d6ezjqVstee1F5c5\
+ep1WW613Uo67Rw7e\
+9QXtBgv3Sq6bLa66\
+KVXRYKU4FVEXtmIc\
+e3xRVhbE0eUqr2W1\
+JgNVSiotegaD9ilF\
+7QSQxjQ+9SigBNIk\
+sFQ4kMJJpt1Sigte\
+CGIkqUNawtcSGjsq\
+KW6zN1AdnUoZhaAT\
+SHI4UFMWc0qSZjzS\
+qbWKgOiGxBcEy8NV\
+KCA5h25Hm7KUOwLE\
+iSlUJImLSW0+KAgN\
+0FRbHVWqNo02060S\
+jYAC4fwu5tShmHyn\
+kl9j5JUNUGBSX4bh\
+KoWviARj1iEBxl3c\
+6h2ShjaCMSZoSfaU\
+oLl6SNQ2qDEU1tKU\
+YmhILExbqgwLfK8B\
+g4GvVABJD/AJnLdI\
+SguzyAR+Y7Ogwyea\
+HTtwlB0MMRUHyUoz\
+aAUZwfsVoIH5pYXF\
+x5KUCkMeWlKM1ptm\
+XLt0ShrRaRu4iJlM\
+5BLyB4k91KAMiBUR\
+VWjPIDA7jT3KAvkd\
+Ri1DugzSDA6VSgMT\
+jq1W2SjCRbLA156p\
+QHALSDbDzsqNaC1X\
+cNIShqGbmfnyUoQC\
+LixLn82ytBLYv+Lo\
+CAxcggtDUCUYkChd\
+5JPsEGccAw4d9WSj\
+QD8oZpuaOyUYQA5g\
+MBuxQYNpERv26JQT\
+Dh6a0/FQYUAEPV69\
+koWpDaByRXwroqDL\
+46s8CFKN8rgsxAgf\
+YqM+ogbmlfvQC55A\
+Li4bVqYKAvqDWQTp\
+uUBElxBox08FKM+u\
+TQQ6ASJE8EiuyoIk\
+EDSAezuoA+pt6A79\
+SqM1Q8vHs6UKBbaA\
+Dt5pRrgDLuBr1TGR\
+iNQzDXoEo0gbmAJh\
+9VaAwektN2qUbKt1\
+LeYFUBtJOMPAc+KB\
+HDs5BuZ2p49kQwoH\
+LPMdQlUHYgAyXOO5\
+fdAQ5ca6HTghKNUN\
+qP4Z/FKAwc5SeRHu\
+5SjG01tNS5Jn3JQJ\
+0c++fsQAE0IPU6DR\
+ApYl688JQMaMSADI\
+56pQsux3n3pRmFMv\
+y1l6pRhvLajUcMog\
+HkO+n4pQDDh59veU\
+oFJYnbl1aFOJhmLo\
+EuZpNDBQIbSH2ShC\
+xyFr7E+ZVqEbcM/w\
+CY/ilErrQ53eo8Va\
+EIDgksZcO/ZKJs/w\
+ApFPblMhSBIIZ6dO\
+ylEbrXmRqzVVojeH\
+dnfeioheCXDdExkR\
+LPdxp+CI57rZIZpV\
+o5vUAEsz6FXGUc9/\
+sVaOe8aHsERz4F+1\
+VaOex4KK67Aw82Kg\
+6bNnrTdB0Wmmxqor\
+osBgVI1UHTaTu70A\
+UVa0U0ajTQqmF7ci\
+WnZ1FdFuTbuoLWvT\
+26qCgkvU6D26Kikw\
+B3HVQPaDAmJ28UFA\
+NKW2wyBgGDUPnKgp\
+bV2cE+cophubWIL2\
+vxuiKyR8v2dUUXYO\
+TAE7+SgYZPBdBhbu\
+cqwfBAQQbQCWDSH2\
+6oM0s1NHoGQEEW3Q\
+Ib83EKwO5NfAxPVR\
+WJJ3J0cKjEQ4hxBL\
+AdUQw/MJ+aUUSSSw\
+JGhcbIA5dyYkAe8e\
+SIx/iuckioPDoC5M\
+hiN+RsisLi7Cm3TR\
+IDboxJDCPbopkAC5\
+q0/M+iAuDqaS1JkI\
+H3aTx1UANACWGp9o\
+AQY6yx3b7NVQXk5U\
+DMXUGdxdNabIFBJA\
+AIeZYeKoZwZy2kbf\
+ioBkXxBLvt4lIMKk\
+iMQ2SAgloLvr9iAF\
+y/zAG6oIdigLkknR\
+3fp+CAA2g7PvWEGy\
+uIAaoI4SAlgWZzJZ\
+kGkNoGJxrKEYm4iC\
++gLfYg3FpFp1j4IQ\
+ACzEB2Da06oQH1Br\
+Liv2qwa00LO4fWui\
+BiXi5QZyGDjRwKoA\
+MgWgszdPuQNxt2Hb\
+xQKb2IBJEVaO1Ugx\
+JJjUV0QZ3I0JLkIN\
+kQ4DckoCXNZhwW8Y\
+QYXEmrsHhIN+V2rq\
+gxLOxq2qAZQQflBj\
+p2QY3H+EZZflEU7p\
+AXNDz3D0QZySMg5I\
+2QAEhxHTb3IC+ReQ\
+f8TfagFxJa0Frmf3\
+JgYGkmWDkbdeqDXF\
+iCbqAEDp4Kgu1C32\
+qDElhLA1Jj7EAuy/\
+htkMARoqGq8cNwVA\
+uumRFNYVCkMDcCYe\
+IjVCMZOgNLSPFAJA\
+i4sZB6qg69II+CAF\
+yHf/gzrp5oQDeRDl\
+9+UgFQwDAwdC6JDF\
+rt9noig4LAMWmZQA\
+B/4g9WGqELdkMgQw\
+oSOURnIg1ltiilal\
+TNAW+zVEbR7aCCCV\
+Bi5fUmgNEAY8uRL0\
+8kANQCJPHtuoFi4S\
+a0J52VIRyAWPSde0\
+qoS4Egs769+iKQw0\
+tTb4DhEBwQQa0O6K\
+mQRDz7oq6qJ3ONXP\
+CCVRMEe2qoUiKnku\
+gkQWpN2yggcgTLg6\
+KiFxL7AVQQud9ix9\
+qLSZS9QPWD7bJgc1\
++1DVEct4Jnw6LQhc\
+/2BEc/8XxbyVHN6e\
+mr6qjrsH2rNHSKAV\
+lm1UV020fQU04RXT\
+YJah0PmpR0WOGed3\
+03UFrYq4BZM5VawT\
+qTKDotA1hqaUWVWt\
+DGvVEVenSDKBgC2x\
+fqlVQCgthpLmfilR\
+XEGlWYtzVSqe0N7v\
+wQUtcNDUgTCBgx7U\
+55QEAkn5uQ9VAbXc\
+3M+gZBU8QdB8FBvz\
+aEgluyo3yhiNfBiq\
+ofnmoaI8pTmGrp+a\
+pMa6IKEGCAHMMdei\
+BndqFt2ooMT2Z3uZ\
+AKEmpFG0j7koLatQ\
+6JQoOVXmhNOiob5i\
+dH12PClwCGYRo4NY\
+NfJKMwNrkPPu1OyU\
+OTTR9CoA8FrXfT7e\
+roAzkS9rwCPsVozl\
+sgPlqdyoDL7zThAC\
+XJdmZiNUBo0uCacI\
+B8pFpuYjf23QBid3\
+3H2QrQzggEOW08/c\
+oMKFtKfcgAJIqSSR\
+NOUBbIu0DWPBKByB\
+J0aoJ8EoNWf5hBZA\
+AZxdrWZuqAw1p376\
+IFa4swLGhEM6oYPD\
+uIkS8qAhzIalUGxa\
+MfCPxSjC2AxZvYJR\
+gCCAA3PRBiKPDGmh\
+KBmcOxb+DRAMQWBO\
+XB+xKMRaQwdneiDG\
+0OwBoGP3hBiLQIMh\
+gH99EAuBctRnch6V\
+QA2s4mTo3TqlGa4V\
+1hvvQEg7FpLadkAk\
+EOGYQxHdBsfzABy0\
+9dnSjH5nkwZHxhAO\
+CDHVKC9uggUIFEAu\
+IBDgktGtHQEmSPEG\
+nPvQA4ki54q+ytBj\
+JjXaWZQYsHf3+b1Q\
+CRaACMjAuPjqlBq7\
+GGg1fpKDCTALPzVt\
+XQEnj5TU+9AA/ykG\
+lSWjhAIqSSLqkUCA\
+sAJPyiCK9EoP8A70\
+sD1QAkiNNSfgyAEv\
+BGsbvVAGDMbQCzEh\
+nr8VaMbRoNmq+/sy\
+UJUQYGk91aGOgqSX\
+r3UAdyAXltlRouMO\
+AX0jugNNKCilABJB\
+YEAeMKjM7w5EzA1d\
+QJcGd36VDdOUAmkG\
+wCdUoxh3NBDaDx3Q\
+KDRydAwOtUQD8xL9\
+RUcIA0QYP5Y2+9Ap\
+EQAGp9miDXBtCzGR\
+VAjPoREUZlRIgfmM\
+EOlCOdfPQRVBO6h0\
+I0KokS4PEOyIWazB\
+gFBK7+ICoNd0Erg0\
+V96K577flIh1qohc\
+WZg2k/YmBG6szylR\
+zXAEw5ZUc94F3LHT\
+lUc90DdqhERYZNqq\
+jlsDfFB12gPSdCoq\
+9tWLyfYIOq3rH3qZ\
+V02wHo6mR0WwQ4qo\
+uFrAH5feqDottLDV\
+9NgoL21O+0qKoBDU\
+I9tVUPaBk2nuUVQO\
+xkzA68KiweXkmFkO\
+Jl3YzwgcEB7rZGyC\
+gD9D7bIHgEu4eUGD\
+MS72iBvogaMnILUO\
+ohQG2jOABokUwMgb\
+nwZAtoJIkyI5HZUU\
+0khzDb+3RAXrod7f\
+FQbUGZGmsfcqCXDM\
+ztUqBQHMgPL86UVG\
+JcCoLwgYWOJAiG2f\
+rwpRhbDj5S0BolA7\
+a1BUAFxLaBpf21QA\
+O7sSDLO8+3CBgweG\
+AFUUDW6f8AhFkRsQ\
+zQYHL/AHIMXDSQKU\
+f7UDSAA7e0IpIIpS\
+BRj7wqg7gyK/YoMT\
+JxECkxuEBoSD/F7M\
+ijiYmpd43RDYwZoa\
+BFDEdDv08kQwE0Ib\
+eX2RQcQQH47FEBjA\
+AZgIDfegYuWFvV9D\
+qgDal321YoCa0+Vn\
+7lBnkbEsdkVrKCY7\
+SdUyhSQQ4qQwarqg\
+0eGA0ZQEEyJB8WQA\
+BxPzS87oMJDgkho5\
+PigJ1JctIAQKwgHX\
+Snl3QNi8/mLu2j8Q\
+gDhxIh3D6lBhVzPh\
+xRBocMC5AoGeio1p\
+YMXpOvCgIth63fwv\
+o2iAQJLx+Y1CAwYA\
+YCG5QAuTIoe+6A2t\
+zMgdaoEYwzDGs7dF\
+QSQS0ZM9PeoCLQDo\
+G+KKUCGIxJYNKqMQ\
+5AN2MSA0MoDiRJlp\
+L6dEAFpBkyHcNy8F\
+ACaauWA3b8EBigEe\
+CKRwSQWyGldWVQTk\
+adYLlQbU1q2yA1rN\
+pjYorOTIGviiAWqL\
+gzgluyAsIIjYjXqg\
+GU4MDSOdhTZAflhx\
+72bp3QBzDwSwf4yE\
+GAyEwZBIjVAuNNIb\
+2ZWgOPzEkRy3ZUZw\
+Xat3SfeoBIHXcuFQ\
+eCCxl6oASRp0avDi\
+EGNo0GsjSZlQTJYg\
+VLUdjKoxr/AJTS/s\
+HQY1LGuoUQpdgLXh\
+jcKIMQKkA9dECEV/\
+w6g/cqFuAlnAuKBC\
+Nolqa7oJ3HXxLIEI\
+JehcVfRUTuDEnU6+\
+3RBHUuenKBQDLl2T\
+KYSYVE90VC4TOvwV\
+RzGCwoXcDwVESNi0\
+PCIjfR68K4HLcHBj\
+ofYq4HNdUhvFBJjk\
+3mjLk9PFnA5DarWR\
+12e+izlV7dxXQorr\
+tHGyg6LSJu3+CmRa\
+1hyNKfBFdFgh3AO+\
+ig6AGB1YexRV7awY\
+UDhpA7omDi0wwqav\
+ulVcAGGpT4KUMHe4\
+0GsoLWgXON6jogaT\
+8rhxXwQM9Tw7MUDM\
+8mem6UPSgDYsQYpu\
+oG63AOJ2dFYHWHP8\
+PCDDQVOgoPuQUh3l\
+7aj7HQAOQAQ2xgwq\
+CXOrA/l4Oig1ammv\
+J0IQAObi8XA0G7CV\
+QwAGUtj+YKUOzPc0\
+0A6qVQ1JuDbbyiMK\
+sGcB2afFAoOpDlnc\
+asfigf80GWqNEAFG\
+DEEdkVopN4PxRGIg\
+MBDG0bIMbS4LdtAl\
+GYF99BXxFEoNhuu0\
+YDSqZDAER0HPVAuJ\
+LxIEPuKHVAwAAEEk\
+18PBBiQXFDbPt2QE\
+gkCARUgz1ZnQF2Ic\
+hh7UQBg7iprd06pR\
+hi1tQ8OYMboGaGnX\
+3opXGINDi+6I1rUL\
+Pby+pCZCuwh4OnxB\
+VDgsw/CaKAQWMbgA\
+PPvQakEBh+ZtgNOi\
+A6uQeAemiKX8xIfS\
+WRDEPSCAGQByCz5C\
+6QHHRAHDPSZujXdk\
+BqB7E90CtBtNz8+8\
+qhpnUjTR+ygIZncA\
+eUINkzirksXQKN9n\
+dudYQZquGyYBxpRk\
+BEMf4jXR26INEOWN\
+CaOg38MkAET33QAw\
+4H5WILN3QYlySN8R\
+zx5oD/AJOpd7ttig\
+xMkuwDDhBmMtA014\
+QDU/wnetX5QNBho8\
+kUrsXxtyIjfuiGFX\
+BfYaMgAcmRy0oMQC\
+XZo2/BBsXkH4opWu\
+fcEsQ4hEKbTLmQGf\
+hKC4Ji75RM/egzOx\
+l4f4yOiDcFtvZ0UA\
+LaPsAdR9iI0vc4BI\
+imiBmFaEvKKUkWsH\
+PM7wiMAxyDMZJ3Sg\
+ORDEkOANa1hAxxeW\
+M7oJkEDUQ90K0Coa\
+3+GIfgcqjQHYEN4A\
+qAkvrIgdwgxIobnr\
+wgBtBuLu/j96BADa\
+QN9Pjugwc3F9OrFB\
+pBjSs9UCzLiTQyoi\
+cWuxLWj8u3VaG6Fi\
+RQoEuabSW2HHggQu\
+Ydte6CVwAM0JogQg\
+0JPmrRMiCasgjo2o\
+MgFVMkuDhzWjlRUL\
+iGubUP9quEc9wYFo\
+1AKCBDOSXaSqIXBo\
+ZtvBEc14DyQTwtDl\
+vFvmdFRJi7+bKMuO\
+w9CrnCumy6BqVIOq\
+wjYy0+aK6LC8iPPR\
+SDqsu1aCFmC1pBPc\
+PqFYro9My0O9OikF\
+7btAK1CmcKvZcK0D\
+MkDO5iHoPYIKWkEk\
+VYedEHQDiCanQKQN\
+aTV4adfZ1IKi5stB\
+QH3pA9pLGjs79eiQ\
+YyGxIep+xUUEPFa6\
+Dus5Gc1knW0H4SrA\
+2WptbKoPCRRehI7D\
+coHBttABbYBIGyFB\
+JP2JApuyYYtpt2hI\
+NkHcmsWnrskBNziQ\
+ZhhykBB1LhtAG+Gq\
+gd2LggAbqKUXUa1m\
+/MA3h4qxByAcsW2f\
+nqykVn1IA2c0VRsm\
+Nxm5qJBsgHto5jfw\
+SASa1MbHdBsqAWgE\
+Hz1SA5Ro7QXiSkGy\
+B2YT8UimlhkSKexK\
+RDAtLGfthSDG4O5t\
+IectfcrBnucmS4YS\
+g2TD5jJgDk7KQDID\
+5WbQgzGzqwHNsizB\
+ngxqfNIBk1rCjSa+\
+3ikB53kndBjcZNtu\
+QO32pAchbS2dBryp\
+FC4hw4BeATGvKuEC\
+64mgo/y1NExgA3Ct\
+dZaOUgd5MAtQ691F\
+K8uzvroQ1fNVGBJu\
+JxgD2hAciATozgEp\
+AMyDEghwY8UgwZzB\
+3tnQoNmMQKEVmQkB\
+yYgsJhzHZikGeeed\
+gUVheSBcYBl/blIA\
+CA/UFhCINtzn8rOK\
+PDdEgxugl4MBp+1I\
+GMijFRSky5EGC6Ix\
+u4L6nRWDZCfmkiNQ\
+kGBgDEZEDybqkGNx\
+FAza7e5IC4cHwL1U\
+igbg9GYxMUorEDLU\
+QQKc90gd3YHvyopX\
+eAG6e9EYXR+VgHfX\
+srAcgCHDloevtKkV\
+jcWdg+lvwSIAukHR\
+mDUqrBiSaTbqDq/K\
+AwDSbtIZxKig4ufG\
+G7F1UA0LQ1C/eiQK\
+chDeE7cIFBGNoLXC\
+08F/FAQaSxtj4IMS\
+wh3ckDkx8UBfRg++\
+2zqRQyIeDdrb76qw\
+HL+KgAn2ZIFBDXR2\
+BJRAclvlcDUP8AFI\
+GeCGZ7iwFUBF+pEN\
+8s18VIpCCGLcMaNq\
+qhcgDq8lzR2CsBzN\
+o0FeiQC69jsAapAQ\
+SR4ueaIFdySCCQwr\
+KQJkA8Npd4DZIAbs\
+iwraXSAW3OLiIdpJ\
++5TOEY3AswYkv5JA\
+j6WgETQtRagW4yzF\
+m1NVIEuIAHytowSC\
+Zul3gwCkCXEsHHUd\
+VcCNxuIIg7EQrBN8\
+niC0KCd9zAG7VmKs\
+Errg70cJjA5yTD1a\
+VRzXGWbjaPBWIjdd\
+Xc0DpEc110tWrqwc\
+txMnX4KwQmnd+VUc\
+dkiRGlw+CI6rXbfd\
+1Kros3Z6HZkquqw6\
+aCGUo6LZAZrtIUHT\
+a3yk7pWl7DAeN67a\
+KC9sVnUn4KUXD/AD\
+tVSghjcHB3f3K0Wt\
+pIlqdVKKiAxZgYPT\
+lSioIAFHNAgIZgBI\
+1G7q0VqwIDv8qlDP\
+roTTdA7sHaOfHlQM\
+DPaTzsigBi8PNPN1\
+aCxeS+pqPilFaBnI\
+lShXJnFwDO6oImBc\
+7yfJKMaNaWgy+yUC\
+4GB3BnR9ExkOdAAw\
+ZmFXUo2RBORjTf3o\
+DbJNNvCvvUoAcEB6\
+VAaOXhWhqADs6isH\
+e6K0PsyULSloBkl5\
+7q1B+YtMN3UozvNv\
+Vt6MqN8sG3t8WShr\
+RLXB6kOpVNuwerAF\
+h0CUCagggRa32lWo\
+LNq4IZm0GiVQGI+Y\
+yGcFkqC/Zy/wBxUU\
+Q7k0c/dKUAPUOZo+\
+6UEPBoGp8AlABJAO\
+hFXnogIAIa1gKgij\
+pRgauG0bx1QZhUAT\
+8UoUHZ3PBffVVGBh\
+x+YhA1oLEXTvt5qZ\
+ypSXucbflJbXZVBa\
+G/KJmg8EoBD3B5LO\
+B1Sgt/EBJLufBSjP\
+bLyJcvsgwg1NzOXj\
+TwVqjlGTAv7BQLa2\
+zBmII06q1GD94y8E\
+o2jEE3SACz8TRKMS\
+AYDBw+jaOgIEFqbB\
+mPailBBdyY0KKTQg\
+GZPsVahizAEuTQxK\
+gAuORJoNacjRUEcT\
+TVi6g0s9ZesJRtiT\
+iDLK0As5BAYtRKMA\
+KyxkkJQwOhgtThRQ\
+BD3giT+b8VUY3AHn\
+bqoBAgwKDrV9laC7\
+gEgTQ0dRQLNAdgId\
+44VqMTqYZ5E0QEwW\
+JcHQ6/BBpb5o3I81\
+KC8gjZjxsigQ7iAl\
+CAh22Jcu0+KBdgAf\
+l7N0VqG7Et7V7qKA\
+aX/KeyVGId7iC4p2\
+0VoIbsKMN1KpS4NG\
+D4g90RnpqNOsz5Kh\
+nJIgiHdRQfUy7P0Q\
+AAGYJE+TVVqEGRL+\
+fG0OrQQzgTEh5ShQ\
+YuB1j7uyB60e3inK\
+ilDsQ4jQTXRVEwaM\
+1JhASWBhqygQOGLP\
+EnkyVM5RmeSQXode\
+yUIdS7irHlWhbmLA\
+yQZPZKFLdC8mvZ0o\
+lcAQW1Na+KUTuFIk\
+e1VcZE7ibiRvp96C\
+Uww7IEPBHBSiFxdm\
+dgS4VwOe8h3BmaKo\
+hcXIimqojcSTBYio\
+4RHNdBow1KUcl9DC\
+1RJ5rG76ojjt1mqq\
+Oq2exhRXTY0Grsyi\
+umw6Me6g6LXaQ5aC\
+mR0WzzKjS9mpmC7+\
+Sgvbpc2rPRMi9tSA\
+SXOvKge2WL13p2QV\
+tedf8AEEFQQ2x0P3\
+KBwSRNrA1lBS2LcT\
+MR+CCo3kCg196DOB\
+/EwB6oKOCx0mNpqs\
+jWs4NsbRvKq4B3FG\
+MEPMPXdUMHA3LU2+\
+CB5YgU0MuoCRk0s0\
+n8CgwpBe0/mh5QEU\
+rxkR2ZBsgGeuw0Ps\
+UimBoCamC/2qAl2Z\
+23Blh1QaaFmuAGOj\
+1KAvFpAjc6BBjc2r\
+HmiQBgCB3M+CBQ5L\
+CLCxDBEYBqxEcIHJ\
+htRXSqKV5IyYtA0R\
+BEEUEmUU4kWuTNbg\
+d0QXbXJ3IbYooGkF\
+7aElEFyDbkdPxQa6\
+AYIeSaoo99Y+CBWD\
+mHgOKdSiDaQIGmhO\
+5RQDy4dpB1k0QZnY\
+lydRXZEY1t2BcHzl\
+AZoQQ5rsigxLEVg1\
+imqINI8/vRSs4tdi\
+BQDy8EQTbI/wAWpZ\
+AQwc9wNepPKKDuQW\
+ckM9sxr5ojNrUGBE\
+AIrGKzOj+LIgxR8W\
+/KH19iit8zagiGJn\
+rygzh2AJZp0qgAYg\
+ir66n2qiMazSeBR0\
+GnEkCojp2RWA+aTB\
+p70BJcZAtFBqgBNo\
+oSC7tUojESW02Aro\
+EBDucQwENCKAkwCA\
+eGY+wRGclsXo4gIp\
+pGnB16IAGNWNpmJf\
+vwiAA71BoxneqDC7\
+oQPzDd+EgIHzQwAD\
+AIoSLon/Jdy3L8oG\
+MD8ooxeA3mgABtZy\
+4cNDMiFcM4l6mQOd\
+EDGdBawh9OiKBgtW\
+YI328ERmIYPQSNB4\
+oC+hd9xCKxMNTT4I\
+IngviHI9t0Q0h2L2\
+iD0RWYAhywOjs2yD\
+OIAkD2jsgLiTUGuq\
+AamMWEalAQWABk/e\
+gECsRJhEZnFu7ObT\
+ygwq4tYmt3R4RQII\
+AmgmpRCQaBjPloFQ\
+pYPDwHD7aMyoYTWd\
+6UZQHSJeCSJ+CKBa\
+20gHrNH3REyKSdRk\
+PNAflZ3dy/XRAvzC\
+IbiiIBMcCR0lAheA\
+AHNQ234qhbg0tLV+\
+9BO6A1XLkdEC3Ylh\
+vLBQRNGrrvRUIQ1R\
+lz38VRETs5od0CEl\
+wfLzQQuIZ2nurhEb\
+yH2JPxRXNdvzELSI\
+38AGKKYRzXs8zs/m\
+qOX1BWrw7KiGuPl8\
+VUcfpmntJTKOq00A\
+LNVRXRaWHaOyVXXb\
+qA3DbrI6bZaHISi1\
+ruQ1Gb7Uqui2eG0U\
+qugF6g/epkVDggkl\
+zolFQSxY6QVBQEOG\
+4YCk6pRUGvB7h0FA\
+JLV0Cge0uBb47exS\
+igLmjw4ShiCMpLmU\
+oayDWA5dTOQxeLd4\
+bblKGJMPHdGgYAbk\
+yT96tQRcKTMA7Toy\
+BmoGDO59xYJQwZn/\
+i1r7lKoOBiwYbqo1\
+WY6wRvqlGt+W5nYE\
+lgmchxcAMhIGg9pW\
+VMXMAt8EoVyCII0A\
+r47KozU0bT3bbKUb\
+QMOdCA1KJVEOBEht\
+ISjB9wSGFfbdKFpa\
+zjLQsQCPYq1Bcu7U\
+Pl71FYxG4qA9G2Sh\
+nMGS9SPBKMLnxcO1\
+XrwlDZPP5WDgFAdn\
+qanVKNQAAsfYpQMo\
+NQ0c+0oMGGuRDEqo\
+Mk0gROqlVuTXUapQ\
+RzJJpVkoW65raaaS\
+yqMaTB6OW1UUfyi6\
+XILj70ozi16TQ7tu\
+gznQ6M9UG1LeDJRi\
+RBaYr1+9KA4IBOoy\
+J8zylQGYC1mapNCr\
+QQRWQxE7+KiieWIM\
+HdKA5tBeWmRSOFQQ\
+QHD4tPRQAEh7ZJ3+\
+9ASIIfYUHuSgFnkE\
+b7dUo35QR+YAszPX\
+RKMznmpHTv0SgioN\
+QBB3fqlBZmcvSvgl\
+Aau5Md4dKAHA+Zne\
+o9/mrQQ8AjcnhSjU\
+DiO1T5pRodzEta2q\
+UEVpIgFKAAem46pQ\
+CwrcfmBlKMCcm0P5\
+njuFQcplwXZlACCX\
+INQwIKUEVZ/wDhBK\
+NwQxIlAAzC7FgHbu\
+lQX3iZPGiKUnEOBI\
+5j7EoXWTQiKpQdiX\
+AdAGIA4EsPclBkxB\
+Z6zwlCsQboGLTNd/\
+crUE4gfNIAYk6gKV\
+Sn8xuya3UfFlahiS\
+Sw6j2bhRRIDiu4CU\
+YbmlQUoXIiSGA3hU\
+Kxcu9zUSjAGAKDn2\
+0ShQw/yd2+PirUM2\
+MBgKkqVQFwe4vFFQ\
+LiHfmVKJkwbmJ4BK\
+qDMF2h7koX8txiKm\
+56AqVAuIBbFuEwFm\
+CHJIrwrQpIPQ+EpR\
+O6Tszz70oS4muo9m\
+QSJDgbv8wnzCoiTo\
+PbxShXBgCdQgjc06\
+gQ4VoncWNOjJjI5b\
+iQ5FGrVURuJftTWV\
+ajnvDF9NvxSo5r2L\
+sRqFRzXnjhWiL/AD\
+M/tVKjhsNA79FR1W\
+Fh4qDpti6hPtyorq\
+tJ3bRQdFpAmZ3QdF\
+pFBzKirWNoeoKmVd\
+Nmhc9T7lMi1h0Yhp\
+PPgoKaM1FQ9rsADI\
+FUFrCbgDXcJkOGa3\
+FneNUFQRFSeeFkMC\
+7Cj0I3CooCCHqABT\
+dQM50JJofeimcEZu\
+wURoteal3KKIfToa\
+ke9UE5MCJimqKd7u\
+hqx+5AQwBbQhj7FB\
+gRoIJem5QYEjVwD7\
+hKAvQs7weOEGtg1k\
+gFMgPaWNA8katx2S\
+IpR3l6AU8lFByCZc\
+OSRqgzN+YOHqUBdy\
+xgs8H3KAAkC6pYwT\
+qXVBMl3AHXxogDQQ\
+CKFw7Ud/MoA9Cx0Z\
+q9KohjSDpDMorBjL\
+M1UAAa4kQ5o6obIk\
+By5qbT7cIMCTyDRB\
+hdWIp22QOLrXggad\
+h+Kg0FnIkBh8FQJ+\
+ZyBsdkG+UuCKnmS2\
+6DNBe0R+XaEBipI6\
+kKDFjBqacPrKoHLf\
+LcX4QF6/K2ooFANC\
+GAJ09zqgi4OXOxHf\
+hSAG6TXjTTdUH+HR\
+w2LoMGoDUT8GQBoL\
+EBjXw1QaHDmszHtV\
+AfmDbDfRAIuILmDS\
+mqDSSAZLSWQYXWuW\
+EhmfwSAtJIAJFa8I\
+AxLzLSAIpTZAS7OS\
+xGvTiUBIJY0q5hx7\
+1AtsCJGg253VGMSz\
+A7V5EINBMdepr8EG\
+BunIEtIAZAdXq5fS\
+IqgFRczToKnugxJk\
+21Z3aD0QZzLCKkbl\
+kCk6RPyx7FEOKHQ3\
+b+2iig4IeNiQ/uQA\
+XwAC5aRuqNlVwAH8\
+UCm64AkeI51hAXnl\
+n691AopBDav4P0VG\
+JkSHGj+KDbwK1G/Q\
+oA5cVj8zeVEB/4rg\
+U435QEuQGNWJP2KA\
+C1tzjIfToqM5I0IM\
+cIDHNaNOygVw5DgB\
+4bgKhQWdgS0t14VG\
+/i3u4KAXAgEhwAPz\
+atqiG4aA0nhFAFw8\
+ULHbugDAOAcXnKiI\
+VySRQEsZk8eSARtU\
+OX7orNIeRsiBJ1lm\
+1ooFyAcFqO4norAt\
+Xkh0QLiAwcDaECEi\
+CwaiBHYOJf2KCReX\
+kifF1oTuu7mjn7kE\
+bmoeHOiDGmj1ZQc5\
+gUymiolcDxx8VRz3\
+GrS/vVHPdcJBoKOi\
+I33OC8AVZVHLfQid\
+h7FUc190ttVIIsc3\
+iqtRwWXAblyqOqy4\
+EuzyoR023NJpRRXT\
+Zf7exRXTZfD8QoR0\
+W3CnkoL23hxqQVFX\
+9O8Oz6KCwuAkOYgI\
+Ki7tVm3Qh83Y7mm4\
+QWtvJ0+U9FFh7S48\
+sfwVpD23M4pvH4qZ\
+FQRWbhRQh82Lu/FP\
+ehFMrfGvhqgEO2L7\
+IQwIuIban3qcxDZO\
+WbWPNBnypG5aHnQq\
+1RyHIPRkGF4YRBbY\
+Q33IRTN2+bE7cn3o\
+MbiCYnp4IMbqQzAE\
+CD2CAOGYFjQgVhCN\
+vptoZbzQhnbICuhQ\
+jZkwzBoIFFIDkLhU\
+h9NYlCGe2SZ69VCM\
+4qA1DCEA32u5Yc/B\
+UF6PaW2jzUGcngnV\
+CMSAxekv0qhAdgDi\
+21ux+9UjM0hz5JSC\
+4lxyTFVCMTQgF3nw\
+8kIBapJGpPbRUjAg\
+5Pb+bwLhCDkxerVp\
+DfaoBmQIMES9CqQx\
+vAEhgDTdlAMiSajU\
+t08FSDmLWf+I7oQw\
+vEj5mhoUWBnboCxk\
+8uiRsxpUy34KkY3g\
+k1BFWgygY3D5hbqK\
+HwooQcg58kWFytnX\
+XLqiQcrWd2EsSWQg\
+A23M+8FCCLnE2kBt\
+d0AoQwkRa4jyVIxu\
+YF3IME7uoNkJe2ak\
+DhUYgAUadD5hSkZ7\
+Rabdaxo6pANwaHcb\
+oQ2Vtsy7UjT8VFjZ\
+WnsQ/tKJC5T0cA1r\
+3lUjZ2AsHBPvQgZn\
+UQZJY+EVQEepbL2u\
+5g1cBQDIEYm01BYt\
+DyqRswdC5p7VUIxv\
+tBNrByI8+ioN18Ai\
+j+9QhcwavEbchCFe\
+0uzHQH4KkEXPuHJZ\
+0BBJaOhPwUILw5lt\
+ojxRYR7SRD6Y92VQ\
+zhy/BFuqhABADFiH\
+pSB96pBcQcd2ajKB\
+XcUIc1HTVUgkgRBD\
+wDoyEC675XB6jQR0\
+Qa0/KSATB08qoQ7h\
+5Mj2oosIDaxO4D6+\
+eyqRs3JZ+tKJApIl\
+ixMyemyoBJYfxHUc\
+aoQwumQRRggUEgTN\
+adZQhiavR5UIRxaa\
+8sA/dWkY3AhnIxiq\
+EKbnZgQXkgfagDvN\
+sA1CUAXGIfihUQMm\
++YTHzShALGWJerKk\
+C68WuS8SgmSD80yJ\
+aAhE3rcQ4EjRUhMn\
+OrAxVAuYEUArsgib\
+w1HbTmsOhEyQGn2K\
+qRO4gaOzbOhEiX+a\
+Q+nkhELrwC5glm9y\
+ohddoCRzqqIm4T1R\
+EL7gHL1og5byJ6y3\
+itEcpugzKqIv8AM+\
+r1blB59umj1VR1WR\
+41UV1WXMA7qDotu1\
+BpJUV0WkRNNd0HVa\
+fx5UVUEkB4fyUF7b\
+pA32eEVcFzWDpRlB\
+a0yKHbuoKhhI1KAu\
+7ih2QVtLSIfX2KCo\
+ZjU6EIGBpMaHZA9v\
+ys5qXlRThwxYRLBA\
+4IJEi3UPtsgM2zUV\
+PRA7ijDrxopAQdOI\
+BKgIBEGhNK6K0Yy0\
+ToVVGrmf8AJ+3zUB\
+F1CXIuLqhgXJYMRT\
+SDRQABgwDu86eSoL\
+MxrzvsgYCej+agUw\
+XJ0Ymk8qgACA4JMG\
+dp+KBssSNH8t1IGy\
+LQH60SDChoxp00DI\
+CTowMT8FAAKzq8RX\
+og0QRqdPYIMAD8wc\
+ZPBG9UB2LPsDugLG\
+LqHUIMGA+URuKboF\
+/Mzh3h990BtB5Y9i\
+mRiAWB/hn7EAJalI\
+fqN2QEkEggiH1QAm\
+TUkUd+3FUBnQVPQd\
+0A1BJDk09mQGdiTS\
+fegABIo13s+nwQYO\
+zsa0130QYORc/zA0\
+OjICwJ+ZwQ7z8UGL\
+6FoqgBud+KDy5QAH\
+IhjAeW16qh5tGzmB\
+TsoMSwDjkBApu/MS\
+TDEtp0KA/M5aAK8e\
+9AA7sXHPU8boCCdQ\
+SaA6x9qAECT/CYbR\
+AHB+UyYZ9e6o1vzO\
+D8suBrKBi4LGXoGq\
+ygBctMgtaXZz2QEk\
+sCNNYQbJxFAWYhIM\
+BNpLkjX3oAasZP8Q\
+08UBIDyeQCHhBuMX\
+tO0oBN0AgjxQF67S\
+zFkG5kP9roAZbfSN\
+W5EICSAa11hAAHj5\
+WeNw2/RBtw4/ym2l\
+AXucEMAIPXyQapIY\
+hxIqgF2xq2zpgYEE\
+yBIhtlRhcDT/ja9l\
+IFFw0Alzl3furBmM\
+PJq7IM/Dvp0NEAeh\
+/NsX1VG5brb0QDn+\
+E19mQG4OQ12LFMDE\
+0AJPM12dQKXuh2Hm\
+qFAdhOOr790AItrU\
+dkGBJFrOdz+KmUrE\
+vaXDlnIQKS3zCZEo\
+AA5BedBsFQjiJFdD\
+7kALuGoHcoJm6QAW\
+GvLIEJihAGnsVRMu\
+LiHrTdEKSBHiTsdH\
+RUSQ9QQIA6IhSW6D\
+bhBI3czugiSGMxLa\
+KiF1zmAY3VErjo5e\
+RoiZc9xZ20lUc9xB\
+MU4VwOe403VRzXkS\
+3cboiLz5qjgtOnRB\
+ey4kbEVGio67Lmju\
+sjotILEDpsouHRbd\
+XnyQdNtwiXGiiuiw\
+9Nn2UFQ3jBSqvaQw\
+O2/vUFgQ0CnhCC1h\
+atApVO4/hlyA9UQz\
+j8paKOgsLnG3tsop\
+w06lq6cK0PkzNMcq\
+BhUlhNT8EofNi7vQ\
+cqBxdQOztKDBrqyT\
+UKh8mYCmrqDAiS8v\
+ACBy9AIOte6lC7sx\
+FR15VoYXUbzEAaor\
+bkTDIAHBLOAJ9grQ\
+4uAEuJ+bZ1AXB/ir\
+IND5oNjDlnma9Eoa\
+SJcRXYoMSAdBugEA\
+xJqT+J1SjOxJuLho\
+B4QAQ2lAwQb/JctE\
+jcVZA70YAAaqAPbV\
+hBY7hUZyHALvDtVA\
+wYuA8u51hQFyG68j\
+7kAECHcvG0IMbrp1\
+aS2z/cnICwEUl6JQ\
+pBcc0EjqlBaTAcwD\
+7cJQddJG+/uQCks+\
+MjfmUoYuDVqv0QD/\
+J0L4ilPNBh/khnl4\
+TOQANCPy0SjfKA1Y\
+Db8IM/zOxcCj86IN\
+QMSIgPwlDO7fLMA6\
+1QLV2i4Q4/BKDSAw\
+03hKAXajzA47pRt7\
+WYuXPHggDEAziSfH\
+RKGcQ1QW8UGMsdz8\
+PNKAxktk+h4Sgh+D\
+Hy9W0QaZLtsN9n6o\
+BNSWLgM7INRwT35C\
+DEEyBNCD1dKDjaH0\
+IDk8eSUaQGMAsPHo\
+lG5obqv7kAAIJEEH\
+syUFgzM5YkxD0SgA\
+2nr11QE0BEdeUoAN\
+pbj8ohkDEnRp1qEA\
+i126jZxCUAk1cWtR\
+BoBJJ1lnQDIO/jog\
+UkzkKGCH3qyoLgmX\
+gwgx3dpd/wSgGCHa\
+4Ma8V0QaoYEF5380\
+GFTrFdX3SgO7hoeV\
+QYmpqBPKgPUhxTol\
+CG7cAvQ/BADc5k0L\
+R0QKXrAA3PgVaM4q\
+LhrPvjspRnYAgHE1\
+ZKjABiASC7P1UoV8\
+S4D6eSoBLFycQgWA\
+TRz+X8FQLrgYIcB/\
+mqgmSDFtAYQKZq23\
+hslCEm41HcUVQDWr\
+k1KVUriKUqyUSykh\
+2brPREK7SPw+KCd1\
+2oAoWCCdxZ9ZGSYV\
+C64Se7qoidz+CtEL\
+riTBB3LojnuuE7Es\
+6ohfdBIh5VHMSQ/l\
+sqy57yJ02TAg/z/B\
+UcNh4QXtNPJB02Ew\
+enZQdNhgPHfVQdNp\
+APWqir2HbSohTKui\
+0sXNG9iguC7RFXUF\
+RcXd2H8I5SKtaW7S\
+VBedNJoiqAg67OVB\
+TKHZuapgEXWkS816\
++wViK5As8ifJRTvD\
+l28wgclg/LhBnYhx\
+NGFOB5qIrlvw5UU7\
+66GppCAi6m4gbFUE\
+kia/BATBNG9nUDC4\
+EVJ/whICCSS4BGyD\
+DQu4BnryoCKlux3G\
+vvVWi5c+KDCWJAHP\
+dAPmYsfmFDCB8mlh\
+Su+yA5W3DsenZAWa\
+P4Wk/Ygwc1YNBG+6\
+BWMAt9jbKghv4gwF\
+CW8FBqtQcEVVBcy1\
+JDqDO4JB/5MlBqsY\
+PtzsgwNaOwBCAuYc\
+ToDKAGgdy7x2QHMu\
+Ad/l37skGdyYYj+J\
+/i7oC4drY0cqAgyR\
+LM59ggwLi4sw0PxQ\
+HQPazSihZwYDUkdk\
+yg6HEhz4P96BTaCH\
+fkNHSSgJcCAKdHZA\
+dQ5rQIAzuDShLoMZ\
+fia88ICSWYaQR+KA\
+M2nzXVQGCKV1E0/B\
+BmioI25q6AAzwK8N\
+PxQYxWBd0qKIGJLg\
+inigSLWMV6tvKc40\
+kMLWDGWmiAhi5BYm\
+h0ICAA7watIdAzQQ\
+wmpaEAtta0jLWXHw\
+TIxFzk1eDOiAF9Ds\
+O9JQM5DA6+3KBXBc\
+bQG37INkCCR0fvyy\
+QGCGagQKSwdvm1uH\
+2qwLmCzEguGHwSA5\
+FtXrMT7BIAROQLj7\
+WQaQXGsHsgYkiGfk\
+xRApALyXaG6oC8Eg\
+5TH2IMBUnQu40QEi\
+WMx0QBjLAQ7asgDS\
+S7hm31QA3h3Fr7nn\
+ZAQTo8jXRAlHEAmS\
+d0BcSNRtOiBXBMl2\
+luqDSzg8nuiDIdug\
+8tlAlpA/yQGg/eg1\
+zmdqGkqgVZ33YoFl\
+3baWVAy+UkPq+mpQ\
+KbiJu1o0lQLk413Q\
+TdiS+R2/FUK8TdAi\
+OyoU3EDikwgmSaab\
+0QJk+sVJVgQzSYUo\
+W+6vRMYErjEliaqj\
+nuuYVZoICIhdcDr3\
+VxgJdczyx1CIhcW4\
+4VHNddroKhUQuIej\
+IiF9w67lVHLfSQqO\
+dy+XkqOGy7nWQqOq\
+09hqsi9lzBnGqDpt\
+LN1ooOq0vrPCirem\
+SdZ+1FXtuIDbwoL2\
+3O/wAUFxd96iqAmR\
+QsJQWtu7cxpEqCwM\
+AE10KCttzan/g/co\
+KQaAkEymFF8WDx2V\
+50OLgXbeg51hRTi4\
+QKDUGeUFDcd2EUTA\
+YOOpllARoCWek7IH\
+zDZaa86ICLtTpTiu\
+iB7TMgvvv2UBFDMm\
+oM/YqCQQPzNsXZAc\
+j0ippKkBYUYc9HQF\
+jcB8VAQWmm6AOxfQ\
+7096oIL6sGYN70Wt\
+qCzNLinO6AmASKms\
+FAQTONwJZ2QYXXUP\
+EcdkBJNJf/ABBARd\
+TnWnigwFdrvE+KAm\
+WmN6U8EGmpoJG6Bc\
+mIJDMKhWBgxf5Z6V\
+dQZ2Zq+27IA/YwCO\
+2iAQZIm6gd/DRA0s\
+38JEEa1QaXjWjzSq\
+DF2JqW3p3QF2uEs/\
+mUAFwdn/KYFa0QYP\
+pe4aorXogzu5obY6\
+IA5tJYO+nXlA2RYv\
+tDlICDA/ijyUCuQ7\
+AuAdKkqggtQNaPyo\
+NnQs7aUZIGyYCIAb\
+hlIBkXJYEavVWBYg\
+EBiaCA6A6HU06dEG\
+ygQCGkT7kgGQkU3J\
+25lICDq8W/m29mQB\
+63A0BHtCBgbntfaB\
+9qDZGtWgJAlxOhZz\
+r4pgFyHq/+IINqLi\
+AxqemqDAF9CdfZ0G\
+/LOjyNuUGJo7R+ZA\
+GMOAYo6DFhOm8ICQ\
+MpMtDoMSADO7nUco\
+Do0hhEIAAYP5uD7F\
+AAImnMOgJLMWa7Rz\
+XugV/zEtAmKsgJuD\
+FwRHaECEmhck1ID8\
+6qjEs9zna4iNIUGJ\
+oLQ5GsIMIfkMbvxQ\
+LUEAIggsdRsis4rV\
+qs9QogktJLCSgmbh\
+3Z3VgGR4Dltm2Vg0\
+ZEEmjv8HQK7HrDje\
+qAEuPloWIMoASCZ1\
+qgQ3RBx3+MoFJFS5\
+Ya9UCk3Pta1FQpuG\
+gcvTT2lAhu/wAp7h\
+7UQTuI+wcDRETeTu\
+SCD1p5qgEtDNlp7B\
+QIbpIJ+5BI3ANMqi\
+V1zxq0oI3XSdeFRE\
+lpEaP9qIjddJJPbo\
+qOe66QHfb4KiFxhn\
+7fFBK65hp9iI5b7h\
+74VRzX3HuahURnby\
+VR59t7NzRI06bLxG\
+nVSDotuGrd1EdFl/\
+CK6bLmbXdTJF7b9d\
+4P2KRV7b5SC9t4D9\
+a7qRV7bmf5oOsBBY\
+XuJBo4UFLb7RDzsk\
+VWy5g21PemcEXtuB\
+Eud3lQhhfQ09tkgq\
+Lgwdjo+6hDO8g9Oq\
+pDAl3Ad6O6kByAh3\
+2mXQPbcHcflPsIQV\
+zBIccuYogJuxpTVI\
+GBAl2LUUhD5M8Ehv\
+JRWzq0nY6KwG28Av\
+btI5RD/U1aD2lIrW\
+sRBLmpLVZEhnDSHA\
+NSgIuLgMQ3RSKwvG\
+1NjMcJBhcDqzy9Ei\
+GBd/mnz3UWBk9B2b\
+8KqjR8xqx/LQezIG\
+yBkSwE6R1QYlyXjf\
+3IoltWcCT9yEbKHA\
+LkJBjc51tpISDC+c\
+ZpBPs6DG9nOm41kK\
+kNmHYCQIHtRQgi4E\
+SOI6INkALmD9tX2S\
+DChfn5RwhGMEyeAH\
+hCNGoJLF0IPygDxH\
+CEY6jQUHnCED5XAY\
+8ARyhGdq0pT3oC4c\
+DWnavdIBENUCDqhB\
+BDs0NRCCC80fVCFF\
+wf8xLQwSAAmflYGA\
+qGoNyNT03UIAud4+\
+V2hIjAuNbnAn7kVh\
+c4ly+ujeaQEmBE+J\
+QbJtDokGcOxPLdSg\
+xkHV6gBCMCzljMka\
+lBnli5b+JAHckaVY\
+8oRhNrh2IjVvN0IJ\
+ajG48oRjcGpFSyQC\
+QXD6hzX2dCNlABM7\
+8gKwHUSWM+7ooRtu\
+B0QjC4Fn1MDzlIBk\
+AxduIQgZSQAS8EaO\
+yEb6jmJFEgGRIuYM\
+X1/FAM+X2SDPoWIE\
+Y7JAuTOSzEQPuSBw\
+bQBqbY5QKb3FC/tu\
+yRGFxiCJcqAZS0gb\
+aN3QbIUDlmYinkkA\
+zAmrnqKwkCm8G4NU\
+vLOrEYXGhHAqEgV2\
+H5Q+sdlRs7JGrUSD\
+G+ZaRpuopcixhhWF\
+UhcwSGpo0aIFyG7W\
+s/ZFhcsWkxUUSIV6\
+gTEj2KpGybncosTN\
+wALU2O6JCZaswJfQ\
+IFJJd4YwgU3B3Ylj\
++bZUTN476+NVAl1x\
+AqQ8kmVYJ33EAtJ1\
+O/ZCI3XhpqzEhWCZ\
+uES5r1QSJFrsHOvt\
+3TnRG6+WfpburEQu\
+vmndIIX3kRxX7lRC\
+64STroiOe+8SGfVl\
+cYEL75bhiqOa64OT\
+rwqiP1A9fbqkV5wu\
+1Wh0WXGNlB02l9ZU\
+yL2Hsg6Bc7CnKiui\
+256+/yQXsNQzgyoL\
+W3Gru8htUVe26XJn\
+QdFBYXkUkioQWFzg\
+OK6cKB3AYaiQiq23\
+1aSD7kirW3vr82kK\
+CoNNCDRQMCTpTQQC\
+gplMQBLe9QPkYL1Z\
+uVUM566GFCjO7inK\
+KIuMB22ZUOC1QwoF\
+BRx0c6oMbjyWYR5p\
+AwMvMmVBstTt14QP\
+kBx5dUBBY8En26IG\
+yMw1PM7IDlE1EPKB\
+oPJoUAAMfws1D5IG\
+m2hjWEABLiGAMIGy\
+rDEDnVSDFmcSaBAa\
+MIHDIM/LOw6+9FZv\
+4dH2SjVuLiHmfglG\
+cB3cQSwPc+9UM4dh\
+EO52CisxIEkaoBpc\
+woxAVRtKEDQdeiDE\
+kEgXSzse6A51AMce\
+KQEEkBrpbiiKUGIa\
+DXkohjcZDs0ugxIF\
+s1qgZ3JDHvIRQu0I\
+jQlpCIOQY86fFRS/\
+LD6u6qGLMxID69UA\
+cMJYaFBnA5iEGyx2\
+IP5qoA4BM0JnZBgb\
+dbgWfI09qoGe0AaA\
+aj4qKDgUkEgv3VGc\
+Cskl/GiIzWkB9Ndu\
+iUAF4JqGeJZAcrY2\
+erNKDXEAcGAPuQLk\
++jy2qDEksYtGp19n\
+QbNg5LAFgPhqgxNz\
+SXLV2+5FaRJOTkDb\
+tCIFxltRr3QYD/AB\
+Gnt5oGYQ/YaBRStR\
+tD5aKgXADgGo0RBc\
+XM55kT0UG9iDRKA+\
+rIVuAe5qgBZnYfNq\
+IoURhAcl3rKDOBqY\
+NaIA4IOqoXK4sKxL\
+O/gkDBiHBijoFJEv\
+ABFeUCvbTQRX23QA\
+3nbGQ2tKpACZLnhh\
+5IFyYEi2jtPigAJa\
+HHXpogVw+pd3OyBc\
+tXFpqOSrBriQxqaO\
+UCPt8uqonkxAFRTX\
+hAMiYq1TshQdmDtx\
++KIE0gkMAgmbmhpa\
+nARSEh9zLoEytNCX\
+JdBI3FoiVRM36gnU\
+/ckREkihd6KhDeN+\
+6QRJaIGwVRC66SMp\
+2QQJFXHLKiRJBYn2\
+CI577ndq0KDnvuMj\
+fdVELrt3O4Co57yw\
+aGdMCOerndUedbfp\
+DaKo6QW+Kiumy6k+\
+wUyrosugAaKIsLqD\
+yQdFt3kiui24001U\
+F7bn9veoKi/uUVYX\
+mN9HhQXF/n+KiqW3\
+OwBYRDaIigJqO3wC\
+VVLbiGO9RoEyKW+p\
+Tmh67KKrnE0QPbcd\
+z7eKgpbeXYjrrKB8\
+jBlm9tVKGBES54Vq\
+Qzxs87IMLjActTai\
+Bxcep3G0qKbIlmLv\
+7QrQRe8QHkeKgYEM\
+SHtag2KAuXAFDI+5\
+A+Wm0FQEXl4MfxeC\
+A5EAwQalvggNpoA9\
+tZ0QEXEfxOedUBN8\
+vi5Ghqg2Rt8YbmVQ\
+RXYuXea0UoYEl2DA\
+BtkGybtQ7+wQYEgk\
+iQTIQHJhMaugNpB3\
+7saqA5CR4kR7URRc\
+1cFzHKAOwiSIAp2l\
+BiXdixO2roDqGZz0\
+olAJd5d+NkpRBl7p\
+aQSlGJYkm13En4US\
+gk7n7Iq5ZKBlIhiX\
++5CjAIfR2SgFhqZY\
+MFaoBiXEm4yaQlQw\
+uDOKeXdRWJbbLQdV\
+RgdtaH3lkBd8gILU\
+KgWj0PEDxZWo1WAc\
+tr4QiszByPmYT7Ol\
+RiXL6N+aiDGK6b76\
+JQXOhrpy/VFZ5gvE\
+AIAZEN0OgHdEYwba\
+TAAQGOpGilVnDBi/\
+T7kQCRMzq9aJRiSH\
+Or6fGqUAtUtwXbor\
+QS+kkGaa8lSjOzDE\
+jbfxSjF++9H+1KAC\
+Tr2bfdKCSWqHA1+x\
+KMXJZnfV0oGVS4cH\
+8UQpOjGPt4VGyaWZ\
+hHRAci8kP7UUUoNa\
+vpCqMbiHYSfgg0Wu\
+wYsKJQNPzZe1O6UL\
+kDo0wxZUbMuxECH1\
+hQYksJd9UC5NAZ2l\
+j4ooZXP10KIU3mZi\
+r8DZUKbwKv4mEGJe\
+AQAa90ANwtkzPUyg\
+U3EMwc0ShM7gaSdu\
+qoBuJI21MhQJcZp8\
+CqgSHlhoNNUCuzGm\
+zsGSkKb5/5yKQ3kP\
+tJLoEJJ1qgQ3GN/N\
+UTN/zAUQSN5Ys71K\
+ombxqXendEqd1zzo\
+K8IIm6mpGqqIG4sS\
+5BnoqJXXmdjvCGco\
+3XO50CIhdfuKKjnu\
+vZ2M0VETdq8oiF91\
+Zog577mHwVVzZl1U\
+cNt1PeqjosuLB4UF\
+7Lmg90V02391FdFt\
+9C7cqRF7bmZvFBW2\
+/QIrosv1Md1M4Fxc\
+1TGg1UFRcxPvRVBd\
+s1Z7IL23uPe8LIqL\
+tjOpf3oKi4GlRuHR\
+Tg3NvuFFUF5YacOk\
+FBc1SeqCgvejka+9\
+A4vp3b7FAwvIoxGy\
+QOLoLD7UDgxo9Syi\
+QRdkN5f2dAXJBqR/\
+CVQz/KwHUcKKYXiK\
+Dp7kByblwYQNk9Dw\
+SgIuc3B3F3tsgMDo\
+KDZAzzR32UBdxV9b\
+XQEXCSZeTtRARfWg\
++5AXAB5YR8aoGtuN\
+RqabdXRRFxq/G6Ag\
+u3iCEGBaWLbD2CIO\
+VtXqYZBoJO3mgwII\
+YNHKAs5Id/bhAXcm\
+h2CkVg9styeyIO8T\
+Q3IpQflNz1d2+9WI\
+Z2ABruSpFZw4J0cM\
+kABA4AaJ17IGcAua\
+vCAAjzejH4IDkJYu\
+AHZ596DOJJYtJQb5\
+Q4dn35QYEVgywKg0\
+EE/wAOrVVRiC5gEA\
+flFUUwbjnrRQLqC7\
+AVJ8VQXnWKjfzUGx\
+27iqABxW2ZoqM7nY\
+0OiBXDEO1KndEMLg\
+zu7OT3lIrMMefeUA\
+NwtJklqpEGHqG8T7\
+kUruxduAYRBcaS1B\
+8EAyNdNQdkgwMzaz\
+lwNeqRWfWjVOzBkA\
+F0Yt3ZEAE3Nx2qKq\
+jAM0voW2HRASBXYx\
+2RQcFi/IO4RABAMP\
+u1EC5FzdV9NPjogL\
+k1YXFn9yAEuJrps6\
+AZB3fTYvCBcgNNoH\
+CDZXBoeafggGQAIO\
+jBAj2mGZjvvoqDka\
+AMalSDEl5nYKhCed\
+K8HlACREQUCm9+jv\
+HHVAuQLhmCBXNNQZ\
+KAVoRNURiRALMNCg\
+U3NrUSPwQhDeJBDa\
+TCRSXXuSJcKwIbh8\
+xiNECm+R8zcIJm8i\
+kA1/FBI3EhquqEyc\
+gPoURM3ASOjcqid1\
+3LkoiRuDtTjzVETe\
+ewQRNz18RyqiRvh9\
+BoEETerBz33ly32J\
+gQuO7cqolfcR96Dm\
+vuaWVwrmuuBJoqhM\
+kSvMtvb4KjpsuoPF\
+QdAucNqlF7b2ijKK\
+6bb+/RRV7b36iqiL\
+W3M0pRYXe3KKtbfQ\
+bKC1vqD7W+9BYXCJ\
+p+YKKoLqcGQyUVtv\
+pyJ+KC4udgeqzVUF\
+7kzT8UDi53cNPigp\
+lL+W6VTj1HPtRQP9\
+QPa/YGsoHF8hy7nr\
+5oKG+Az8tKA5kNUn\
+b2CCgunpyoHyoNpU\
+oIu0h+NuVaQzvFOq\
+DWx93xRDZF9izsot\
+EXs1PdPRUEXOHkTQ\
+6qUHKAXBG9FaDkLW\
+eY8+EocXB93NW1Cl\
+Gegd+ffCBsyBPn+C\
+DZVggoMbg9oiGhA2\
+bsMnNQ6gxLg5DHXs\
+lDO2s+2qVRDMdCas\
+lAcSx0EaylQ4uD1B\
+mT1SqF1xE7OwNUQz\
+kS3sUqg4HQCLhwlQ\
+2Q3c6Hr0RQfafwSo\
+I4oN57JVAXWgEwwq\
+yqDDkwWrp59FKrC0\
+5Eg7+KVGbEAVHilG\
+kfMxJb5bde6Kzi13\
+11EVTnBeXcAUBPHV\
+BiagFruCgBdgHcmn\
+xSoMtB4aiVRd9Sgz\
+k1IHd0CgmvDjSOUQ\
+SSS9WEjUJRgfeKlF\
+Bmks9UqMYl6UFEqi\
+8UYtrM9EAiBtLMlQ\
+dnPwSgEiguYvR39m\
+SjEiBDUKVQBiCeW9\
+ilRnBDCXqyUAk/4X\
+4PXdKDlMxu1JSqDl\
+30FD1SgZyHdAHDOT\
+Ry/KVAJHyiIiUqgC\
+KNXRKjOTbSu+qVQN\
+7C0P3fREDIXFw5ai\
+KGY6MqgF3G1uh12Q\
+Bzuzz8KFADcKAdiF\
+aBkG0nXRKBddo7Ub\
+VSgC5gBL7JQuREnS\
+s7pQt1JltD9quMjO\
+0mI9pUKXggdVakbK\
+u+6VYTKmwepUoU+p\
+rR6EKiZLyI4JQKbm\
+BPEP5q0Ib2FTw6UT\
+NwJMj7igmb3LAPOv\
+kqFuJkulCXXgMw7I\
+hDfI/DyQSN7ZHwKo\
+jdewarbKold6g3+x\
+BM3Rv5oI3XM4Bd5C\
+tRzm7o6tEjfI02QR\
+uvd211RELrhQFtm4\
+Vohdd3VVz33DfslR\
+C64B5nZWolnz7Og8\
+4EKovZeISK6bTTyW\
+Re24EQaoq1twfdQX\
+tvcxpCRV7b94Oqgu\
+Lq0PKIsLnIUVS2/k\
+NuguLxBBHI0UgsLo\
+o/UoKC6hZ9lFUtvo\
+xdggsLxEztXRRVAd\
+jOh0QUF7NEbBBQHw\
+CgLyGr7e9FUFwA21\
+I4QOLgDz8KoKfUoQ\
+HOpCkDA03ZkDggiY\
+QEXA8bHokD5NUu9A\
+d1BQXblzoygwugVe\
+jmoVDOwklgKoC4M0\
+Iq+iILh58N0WtwS5\
+ZwgzwBQGSUDEvUxs\
+fNA4voAWhwFFEXFq\
+to9aKozvd49UURcD\
+LtxuiMGcMXbQcIGe\
+5o13UUQTVi7R7Qgx\
+uFBroffCQaCK5ceS\
+IPMA7OimdyZnVtYU\
+AfUBVBdjOsvqFFFx\
+X8zxvEoNlqWGz6eS\
+AuJ2KBXHzGm569VQ\
+Q4YO5IjhAXEfM0nV\
+QZ3cC4M71VDEmQ46\
+eagWKtFSXVBBpM08\
+FBpoS77oNJYv0JLI\
+BOTO7aKg8SNj5KDa\
+SWgh/egGRaC++kDd\
+VBd2IuIGiijlO7eK\
+AGWYuAOEAg6iBLbo\
+NkKguIbSUAd7iduX\
+QHK0BmYeXdAou3G/\
+i6DZ1faQ2qqNbdRq\
+CQTUplRFwLb8e2qg\
+QXtrTWOisRi0AGpn\
+fZFbIS9NUgAIuBaJ\
+nWU5gAajrHgkAe6r\
+xLN96oBIgRaZd0QM\
+pI2FWQMbtPBlFI7V\
+6Ame6qFJBapb4dEA\
+JDyHNtEGclhTcBAj\
+hoZzt7BAQe4iUKWA\
+QPGK6IgEgww6fdCA\
+Eh+u3j5osBwARI20\
+QIbpc3TodECm4EEs\
+43okC5B23oVQl14d\
+iWqgBuDIIm/aN9a9\
+FYFJBcmW3QI9D4kl\
+EKbwJJZ0hUzeC3NF\
+YIm7XfTp4IiZuIG5\
+KonddLAsYJRU7i4L\
++3iiJXXAQINRvsqi\
+Jv0PbZII3XipLbBU\
+SNwL7IIG4gEP3V50\
+SuLcsioXXb9FRz3X\
+B2HsERG64NWlVRz3\
+XUYzurhEckHm23k6\
+0WmV7biWe7RRV7bz\
+vRIrot9Q7tupB0W3\
+neAoK23kaoL2+oYm\
+tCKKRpa31DXLSgUF\
+hfuURcXdSVFUzP3o\
+K2+oQWeKBBYeoZnu\
+FBUXnUxogoLzvEso\
+tVFxiS5qUFB6hIIB\
+nR9eykU31DLFyzwi\
+K53dZkoqn1CaHhSB\
+86dUDC7Is8EIGzJi\
+vaPNFpheXckSfdwg\
+e31C7gxSNtFBQepc\
+7kuKMUDC44mWIQE3\
+khn+KBxdcB+ZpUB+\
+oaAjmHSBhcNTOoQH\
+K5vzA7goQwIIlh23\
+SkM9WuqdN0B+Z+EA\
+ycNyzQgwvLTDiZ0Q\
+HIvV0BzuZnbogP1K\
+tAQHMt+YF6nRA2ZA\
+kyJMIALmdoZygY3N\
+AJfQoMLi5uccoMC1\
+CH1HxQEXFqlpLkoC\
+LjNr9R70ByuLtBNS\
+FFDK4O5cH4oNlcAz\
+DV0QRfcwDzsitk5m\
+KP0QNlDEtFVAMiJL\
+knTRVC5kEBteNEgb\
+OTEakwkUAWMFnDx7\
+kByrIfaI2Ugz1kF3\
+6qg5E9FBsneQW8fB\
+AuRLE1NFRjcz13NK\
+INlrVvggIvJL8VSA\
+C81Hc6cpAc7gWhmh\
+IFF2LkCTqiBmXY66\
+MPPxVgIvuIqQdWHX\
+qpBhdcwZwHdigDmJ\
+I4Z9FRnIjIOKOg2R\
+qJmGZRQyJdpDCPgq\
+hcySSaVH3INncHLk\
+PNH7IBmRJvHKKGRd\
+zDs6IXMw4g1DaaIM\
+L7gILgGjIA9zBzWo\
+LeaDAlm2qyDZEjad\
+PwQAlxWkM6DfUgYl\
+0C5l5IcCRCBc2Z7h\
+ugXO4vID18EAN5g5\
+bwkC5EPKBDeZaHOo\
+VCi81yjRkyE+pcSS\
+8GhQTNzlgXdUA3k1\
+JbnVApJH8TDZKhD6\
+jNvq26QqZ9S5g5bZ\
+mdWBTfcAPbwQTPqe\
+fmiJn1CJy3Vgmb7m\
+m7vRBM+oXI9yFSN5\
+0LblVE7rz03+9BG7\
+1bvaisErry4kxqgl\
+dfqNIQRuv8VURu9Q\
+jWEVE33KohdfV0Eb\
+rzR4VRz3XnfyVELr\
+yXD9FRHIv8dUR59t\
+y1lF7bt67KKvbf24\
+UFrbj1RV7b+WhQdF\
+t/lopBa2/Yu+ikVa\
+26jd0Frb534UVYXy\
+BXWqQWF+5fhQVyhw\
+QOUFLb4r30QUtvYz\
+FOiCtt53DPBUFh6l\
+J0dlIHFw1ZtUWqAk\
+SKIGF+h9nRVcwdZ0\
+dQOL6seUD5Unuge3\
+1JclgpBQE8e5QMLg\
+XGo0VBfo2oRTZFo9\
+vFA4vJ1aVIGz53Y8\
+oCLyw23QO7iZ2ZAR\
+cTUhzHdIDk8abaJA\
+4uY9VATeQ8MBsimF\
++LCUQcrqjXyQHIGo\
+f4IMLgHdyftQMQDM\
+B4dBgHcvHgg2g0Zh\
+ugaXh6qKXLSrCaEq\
+oJIo4ZobzQFzQEG7\
+dAHd/lrt7bINlq2r\
+oHzcP3qorZmRoBTh\
+UFy4nqiNMHx0KAi9\
+4AgeSg2RdneXNfbR\
+VQNx1IaqIOWniNUA\
+G7DhKGF00oaqKBur\
+ruOiqMSWgCPYIC+4\
+oXQK5G25QF6FjB1Q\
+Z/yiAUAButHxHvQF\
++5NAUUDexFN26og5\
+NDdkUCTDOQ/sUQM3\
+JlyPJFDIjffr4IgO\
+WY0CDZGDQiHqgDnQ\
+Q2nkgzkyPfCAOWaS\
+T2QEw5csdlAHDw44\
+pwqBUMIf7GZAfyuW\
+2p1RQyOzNQIgZVj7\
+ZQDJgC3RpQA3mNW9\
+qKKXIlnAYvJlVAN0\
+cawgQ3R8xfqqAbrn\
+BFPZ0gV2IamroFN7\
+u1N0AzrudTr7kCZV\
+jsKIFyNRuwPVUI5l\
+vlq7ogG7l6QKoUmc\
+c1lIFuvAGgGzpAhu\
+MsfFUIboApWiBLrm\
+ER04QSuv0VQmTjcI\
+Jm+pBdEpDfNegQSu\
+vAeqoldcX25+CCV1\
+6ondcxDmUEieyCN1\
+8wa7KwRuv+1BI3M5\
+02VRG68pEc917l1o\
+Qvv8lRG66r+KIjdc\
+yCOU1lVHCC9DKtVU\
+XtXdEdFt/4KKvbe/\
+ZQVtu1B7IL23wfMK\
+KtbdMIL237dlkWF6\
+iqW3KiwvLg8qKuLx\
+uygpbe48KIKZCATX\
+RA9t9PBBUXmJEQSo\
+Ki+al2hBQXnbzUFc\
+x32RTC6YrUoHyL8U\
+Z0Di+stOzMop8g8x\
+ow2ogYepNWejhEUF\
+zM8j4qKf6mrkhqpA\
+/1BUwaBARdGoNIQN\
+lV9aNFNEoLkayBKK\
+YXXUqDVAx9QBuKby\
+pAc31L7jZA4v1p1Q\
+Nnt1aiA5vUO3vQEX\
+Aw4fUH2CA5xXuNFA\
+2YFYBpogIvodUBzY\
+E7Ul0BF7gEeNaoGy\
+3Pf8FFbNydkQR6gk\
+x4hUAlpM+dEByDwE\
+BBFXbsoMDk4neY9m\
+VGe0EOWfdBnDSYKA\
+ns4KgM0oSae9BnLs\
+51CowOx4IUGfTTRA\
+AS0nnsqGc7vqe6ig\
+5aoLOgORk02BhEDK\
+PtH2qjZHQnpqoM8t\
+l2HiyAFyK1q6o2Rp\
+Ry9ZGiAvMzIUGLy0\
+ooOCdy6IxL7dEArQ\
+gDaqoJNoc8zCgBIl\
+j2Z0o2Qq8VlVWyFs\
+mC6iBbcIoH0TIGZr\
+4KjH1GMmqgUXVkH8\
+KxuqpTeHgjlyiNk3\
+V3dAM7mu9zV3QKby\
+CJbg68oBnq4A38lQ\
+DdzAQDKhpEqBchGW\
+gqFQn1DUxLT5IBdc\
+Bqw4p0QLkYYdRxoq\
+A9xl24U5ApuYkmay\
++yqUuZrR6bRygX6n\
+dygX6jO6BDcakoEy\
+2LkVVCZPwzONECG+\
+h1ogS664irKoQ3aH\
+s23ZAh9SfeURM+oW\
+5VEjeAKwPwQTuvLx\
+u5LoJG+u5VCG6ZPm\
+gmb/NBG6/bsNFRG7\
+1D2nugkb0ETc3DhV\
+Ebrw/IVRG655Mkaq\
+8wjf6nkmBC66JVRG\
+69kgjdeqJZoOK25E\
+WFwKiqW3FUWtuCgv\
+bfypBa24aFBW29vc\
+oq9t4+5Ba29meikF\
+rbtB3UVUXCJdCqi6\
+NkVW2+kzsoKi/Sr6\
+aIKi+mu6gcXMILIK\
+C7qx2QUF7wCgoLwQ\
+ON1BQeoNIoSkDi9w\
+zOygpkH6/BFNbc+r\
+EmUDZkPXcsgceoQz\
+9winF4NWflQPlSfs\
+CAi6rVOn3FA4vAGg\
+26KQPlViYCBxcDp+\
+KgOQHQGSgL1Y61Vq\
+mN/Nd1CiLoZ+u6Bh\
+dXyCA5liGqgYX8t0\
+QNnIrwSigLhL1FSE\
+Q2TwY2lAchR2N0FA\
+Re7Tq6gOYoQJ0KQF\
+yQzQZqimF79tUgGe\
+1ddUgJ9Rm2SDZgzr\
+PTukQRedex9nRRyA\
+L6DpyoCbyRNCzQgw\
+9RueIqg2T6SDRVBz\
+IcuGMeCigLwXL9w9\
+FUH6jksYCK2etEGy\
+3rp+CIJvFY4UUBfA\
+dnpsqjZM+rBBjcWY\
+nuoNmKQPhyqoG9oo\
+77+KI31KAGtaIoi4\
+/NJIOigGWmpmNUC5\
+B4pUuqC9p43DqBc5\
+dwW3oqNmd+ERjfqO\
+5bZIoZcEvUMiBlEk\
+RL1SAPJLhyWPVADc\
+HkyOFQLi5fbRMDZA\
+PNHl0UDfQ7KBfqfN\
+EDUKoB9SheqKXMVB\
+096IBviuvdAjxNWY\
+91RjcwEPSQgBu4rC\
+gXNme5viqhTc9Ke/\
+hAv1GhzyUgQ36CvG\
+/dIFN2gL9S6oXIAo\
+EN8NSY6KwIbxpXhA\
+h9R/lp18EiUhut1O\
+qFKb2l35QJd6lZkH\
+oiJ3XhhLvAVxgTu9\
+RtezoJm4CQWVCZa7\
+1LIJm4O7uQyCd14V\
+gkb6zzKCV1/bR3QS\
+uuqdd1RI3BETu9QT\
+qRokELr6tqqiN16o\
+jdc7z0QRN2/ZVEbr\
++7qwRuvEpBC65UI4\
+4TlRxW3BUWtIUFhc\
+GQOC3IQXtuG6iq23\
+aoLW3DrwoKi7wRVr\
+b1Be24Rwoqovb3ui\
+Ki+AHUgrbdFUVQXs\
+2hSKoLm8FBUXu24Q\
+VF1PIKCgu0egr0QO\
+57IGF7auge2/dmr7\
+FMiovBgyNlA+fMGi\
+QOPUkiVA4u5cU8EU\
+2UuNoKFM51A9tEU+\
+RjU7oGF40LMaBA2T\
+auRpRA4uEB2ah+xQ\
+ML5JeNvBAwvL8DX3\
+qQMbhV5QML9a6pA2\
+RZQEXwK88oGyFXpV\
+AH1rNSfbZVaJu3JZ\
+/ghTi7WpUAF24beX\
+VgbJ9e6gObOO+yBs\
+g5Lvx0RRFzBhBaWR\
+Aygh2eJ1CBhczDwf\
+RFE3hoIfxIRGFwgx\
+ygOoYMwZvvQDJ206\
+IGe06t4hQAkFhWZZ\
+UE3aExMKAu01I1Ko\
+AukS+8oM+r9dnQYE\
+Akg8M6KwgEOW1RGd\
+y4LAc1QYFnAMjlBi\
+f8rSbnAQYkbtLHlB\
+gQ8E+xRQdq3ayiM4\
+AaGaiDPEB+soA8HQ\
+By46IBkGoxoEBztr\
+DS/LoAboDkBtkUMg\
+KO5UQHakHY0VAyEm\
+p0CDG7YsZQTN1Knz\
+VByllAM9AaUNdFYU\
+MjSv3IA7ULV/FEAl\
+zv9miAG7VjGigXLV\
+hq7TVUDPUd+6BTed\
+QPgkC5GtTuUCm/lm\
+gTurAmQLAnRApv8p\
+CoU3tSen3IFN8gIE\
+c11bVEKS1NWhApuA\
+eWJ1QIfUL/ABREzc\
+KEto6sCG4Eb8oJm9\
+jwdVRM3OOqBTcZ0m\
+OiBMx3CCZvMh+jqw\
+Suvl9kwJm+uvKQSN\
+wI3V5ghu+8IlSuuh\
+iUEbvU+5WIjdfXzV\
+gjde78IJG51SpXXS\
+iI3XOghdfKsEiSa0\
+VRO66uqCb/ADIrhB\
+5VRUXcoLW3U96gtb\
+coqgO0qiguRFrbwo\
+q1t/ioKi4HWlUFbb\
+29zKLVbb0FRd5ILW\
+3w1VBYX0HmopxcPB\
+BQXS+pRVLb5rRQUF\
++lSB7kFReDL0UD56\
++CBxc+wdKKZH70DC\
+7V2ZQPbfTVUPmN/b\
+soHF4dhEdUD57kcE\
+KBxfV44RTZCJogYE\
+VoaIUz0cTygYX9js\
+opheANxv8AiqCLw4\
+Y0dA+YkcQFICLrqk\
+16oGF43GjIGyepf/\
+CoDmw7oGyB6/agOe\
+s1+1Aw9QTqdQpBsg\
+zEPqUDZPL9OqAgwH\
+NUABNSRyEBcTQdKp\
+VbJn1hUog0lwEAF2\
+wLmoQpgXr2JUGzBn\
+QUdATczac+aDZFif\
+Afg6A5MBABKAZaTR\
+ggYXggMYbXZIBnz0\
+BQEX0makfFBhe4Yg\
+EbIBmCZLvQMyA5g6\
+sDogU3MQxjZvigIv\
+ihHCQbJoBZAuZFDr\
+qXVGNzsCRyPxUGyl\
+vBBsncjug2XLNsgG\
+XgKsgAuO7lkKGTaw\
+NSFSs4hqEqDZQJ7B\
+ELkIPmqAS4OjFo2U\
+GPqNwEgxuLN7SgQ3\
+kjY6KgZh9xoUCm5n\
+2KBTfUvUCFQMoIfg\
+lApvEkHwQKSB4wgX\
+PsQqBmTXp2UCv+Cq\
+ENwcuS40QpTcJNSU\
+Cm+rVRC5aP0KBDfX\
+rKoTMUJdBP6jvzUq\
+hTdXVBPKo0p4oEN5\
+DZHugU3sHeuqCZvY\
+TTUoJm/wC5USN7jZ\
+BM3Pr1KoQ31colTu\
+vG/RBG71HoqiRvVg\
+ldeBTsgjkS6BDcBy\
+iI3XOqI3XqiF13dV\
+EyWQTuueiCN1xZ0V\
+N9XVRxi5/tRFAUVU\
+XKKsL4QVF50UFRc/\
+CBxcR0RFbbqaoqwv\
+Kgrbfo7qCoukNCCg\
+vLToirW3qB7b9EFh\
+fDarKqW38oKC9BQX\
+S7qKcXvXRBQXvrAT\
+mFMwJKCgv13UgcXt\
+96BxdDu2qBhdVA4u\
+NOyBh6nNKlQOL+Wm\
+UD5pA2T0L7uophe0\
+v0QOLq6bnXZAwveD\
+0ZAXAMSgYFyOJQo5\
+EEBxPiiiLyDWEDm/\
+V+FAfqQ79GVBzqBr\
+HRQMLzDmXkhINmT2\
+qBukD5HQvOygObfa\
+gOZpM0YoAb36BUPm\
+LQS9BXooNk9D1KBs\
+ywkg6GqDfU2kjR0g\
+Ob3CWGiDZ6aNRAc3\
++IKDH1GqWmqQbLvK\
+QNkDXwUgwIaZ1ZIA\
+biHYqjfU3LJCsbng\
+dEGytI9wdBnkbBpQ\
+HINAPQqQDIt7grAM\
+ndmFDyyQA3tQuduE\
+gbL3uoBm7iK6KwA+\
+oxDpAPqNDhjqgGfN\
+dUAzFCxBpVBvqEVK\
+BcyXPYFAMjMvcgzj\
+wpWEAyIFYAZAubaz\
+1VgGQPxSBTe8wYd9\
+kgBvakE6oFzI44QD\
+LzqqFN2phlACeYVQ\
+Mg9eGQoG8DXzQIfU\
+oN+yBDe+uqBTcaaI\
+hTewLTurAhv/BApv\
+PdFTyM1mIVQhI1KB\
+chPzQ9ECm/SiCZvc\
+mqQIfUZ/egmbup1V\
+CG8s57oJm7sFRM3+\
+KJUjfyqJm9666IJ3\
+Xz0SCV1+misRK65U\
+TNyIldfygkbueFRE\
+38pBI3EmqoS65kEr\
+rkEbr1RG650QjyqO\
+IXeK0KW30UyLW3pk\
+VF1FlVBcVRQXwoqt\
+tyCou8VEiguQUF1P\
+IoVUXfeiq23+epUF\
+Re4HKkFBfxKCguoy\
+LVLb9VMqpb6m+mqQ\
+UF+tFBQXnpNEgoL9\
+SzoHy5bZRTi5m8UF\
+BefBA49SdkDi8791\
+BQX8dEBFw02olDC5\
+9eyB8jLS2igIvZth\
+qVQ4vMVhRT/U7bIg\
+j1Nan7UgcX1UgbI6\
+mlEU2Z9t0BF5nUGq\
+Bs2D6lAchImEDZQ/\
+KgOQ+KFEXFhQgqqw\
+JfuoDmfJUNm3bhQb\
+Om4D9EDD1G6hAc9k\
+BPqeSQbNj3bVIDmB\
+3080gAvfbnlIGzPQ\
+JAXgCdqqDG4kHTsr\
+Bhfseyg2Uma6fag2\
+f+UOUgOTbxQ/akAy\
+uq8ahBvqamldEhWz\
+bVgKQkBF0BkAzq0b\
+8INnMk/Y6sGNxLSR\
+ukAzhyTKQA3MY2o6\
+A5PqVAuerUoOqsGF\
+7aUglIBmQweldEAP\
+qDdtHSAfUOzjVAM/\
+DQAIBkdCzIFF1NBV\
+1RsjrqoUhuapNvO6\
+qVsmBINd3QrG4MdF\
+Ap9SO0qhTfQ6oFN5\
+ADEg+KIU3B0UuYoN\
+KqwL9TVIFN4EVHX7\
+0QmfLcfagU3wZgvR\
+ULdcZ5TAXKJPcIFz\
+AoXRSm9n9qohTeJ9\
+6Kmb3REzfu/BqqEN\
+0l/FAmb8oEN+yIkb\
+37KiZ9SKsgnddXfd\
+UIbuSgmbvLRVKmb6\
+gIJXX+CRErr9lRI3\
++SombtaIiZuQSN3E\
+oJm9VUjegkbifsVR\
+M3BBK69ETzmqo5AV\
+RUXIHF1PeoKi8JBY\
+XKQOCiqW3IKC77lB\
+YXqKoLtXRFBdygcX\
+IK237aqZVS2/70FR\
+f+Kgpbed/FBQXjwR\
+acXa+aBxf06KKoPV\
+ivVIKW3xVlBQX+Xv\
+SBxfvRQOLtaIHyoQ\
+YJRTfUP2pBT6jtNV\
+AReOQ1UFBdzUSimF\
+6IYXg9tEDi5qHpso\
+o5btyqgi5mksCgYX\
+w71UDC9zuQgb6lfI\
+oG+pzOiRRzcdNkgY\
+XAto0hEMLiorC96R\
+zQqob6laB9H1UUc3\
+6IDnQ/BAcw1Q2qAi\
+8MHkoDluZ0QbIMz9\
+kKwLOH6IUciRVrkB\
+BYMCGQHI7wotE3ye\
+KoBkYadEByIAMcng\
+INlLQgwvu4CDZnXx\
+QbMuAD1lAMrqvzCo\
+ORp5qAZND1QF4+CA\
+ZVDV2hBsgYq1AqBl\
+cX7Qd0ShkdT1QrZ6\
+dki1stT4olbJQoZC\
+Yd6iFQMxv1QA3hnE\
+6oB9Rojp9qAZuw8A\
+Qg31GMmSgXMBtTqg\
+Q+rWWCsRvqaeSQKb\
+2LkDqigfUEbV6IFz\
+k68IhMzwNmQDOunR\
+ULk/fRRSuxOiqAbx\
+v3UC56eaqlN+tAiE\
+N25HOqBTeKbopDez\
+z5qoQ36pAmTPPUoF\
+N3fmEEzeDGuqqFN/\
+LtRSCRvfnzVCG/lB\
+M38qwIb9URM3tqql\
+TN9UE7r5rTRMYErr\
+9aKid1/KCZv7KwTN\
+34oiZubVBM37VVVM\
+3pBE3OqhCVBM3Kok\
+bpQSNyoTJUcwLohn\
+QVFyiqC5BQXqCtty\
+CguBUVQXMgoL0VQX\
+IKC9QUF2yiQ4uVoo\
+LlKp7b2AbTRBS2/f\
+wQUF1N1BQXs2qUUt\
+vdn1UVQX8vuED5nZ\
+FOL+XUDi/zQUFw35\
+KBxfO/CgcX7w+qBx\
+fALdQgYXE6simFzI\
+GzYbclA4vrKBhfQK\
+BhdPWnZA9t8QwGuz\
+KKbPempKIOTopspd\
++yVByAFXZFNkZNEq\
+ALw0E9O6obJi7zqo\
+phe0xwgJv69UQTfH\
+vSqb6gG8BQH6hPXV\
+OQN9QbRugOYavJQD\
+KXLHl5QEXjQk6bog\
+m8hgJhFHIPVygw9S\
+jeOqBs4r0UC5VMDc\
+hUEepSS40dAc3l/b\
+upQR6h4YoALywb2Z\
+KDmdISjZlya7IMby\
+APigGcTU0lBs67jl\
+AM6sQSqNmYHLBAD6\
+mhLmpPRBsz20Cg2Z\
+VAN4DOZ0HCAZgkz1\
+lAueSIOaKXN9eycg\
+GaBR6gI381QPqN8U\
+QBfFZRSm/USCgXIQ\
+26qAbieqlAJDMS6t\
+GNwOp56KUKbxFQ2q\
+oGZOrTKilN4KIX6m\
+jsqpDeAPgiEN408V\
+QpvL1pooFyJ1V5Ah\
+uBk12QA3gMiEN5nV\
+AhvndAhv4VEz6joJ\
+m/togQ3nRUIb90Sk\
+N6tRM3oJm8boJm9U\
+TN78oEN3KCZu28Uq\
+ENypEzfyipG5UTN6\
+CZLoiZuRE7r1RI3c\
+oJm77gqJm5UI/Kg5\
+wVUUFygZA+UJFUF1\
+FA4u/FUVtuUzgVFy\
+iqAoGFxCCgvBUVQX\
+coKC4b9lBQXcpA4u\
+oiHF33oHFyiqC+ku\
+d0Di+sugoLqSoKC8\
+tVA4vetUU4v581Cn\
+Fze90U4u+8IG+pRI\
+KD1KbCrpA2YCgoL2\
+FUDC+RrypA2T0qED\
+C7lkU2XvhA2fKAi6\
+vmgcXs/KimF6IOcm\
+aIGF4qPBkDD1BR6Q\
+UimzUGzp5lVBFwp4\
+Iovs8ICDz4INlsQd\
+kDC4tuyg2bbxoiNn\
+Anx4RRyNXZ6jlAcu\
+eiDZRWiA5w7g8FAR\
+e+qAZy2T7h0Bzn3y\
+gw9TR2O3CA/UJbVI\
+jZ7l3oisb/AMAg2Z\
+FUBy5YIFzfUazsg3\
+1K68IDnz5oB9R4eQ\
+gxvO7IEzViDmVIrG\
+47sgGfikAz7uYViB\
+lR/JRWyZgGA0KAZW\
+jWNFQDcTqeQg2dW7\
+FAM66bpAuew6JAue\
+/vQKb9awg2Y3ZAhu\
+HHKqFPqAcdEgU36S\
+WCQLn2QDPlkKQ3D7\
+VShmygTPdVCm9izo\
+Fzr5ugnmOh3VCm/u\
+gQ3+VEEzd7tVUKbn\
+cOhSG9pQTN/wBqIQ\
+3oJm8VVCG/aEEyeV\
+Qhu5QIbiiJkosIb9\
+kgmbpq6omb0EyXZV\
+CZAIJm9ESN0KiZPZ\
+UIboUEyXVwEJRMly\
+47oOcOqHBKZDgnlQ\
+UdAwKKcE8oKAnYqC\
+lpKCgJmCyCgJ2Kin\
+HgUDgnZFPaTsgqCd\
+AoHBOxUFASdEDgnY\
+qIcEzBCoZzsop3u2\
+PKCgN2xQODcNDygo\
+DdsfgoHBuGjhA4uN\
+GoopgTVigZzs6BgT\
+EFFUBu2fZAwuu/wl\
+A2R2QODdDA8qBgbt\
+igYG4aE7oHBu0HVQ\
+EkxCKYE7VQF7pgoC\
+CeaoC91GKBwb5a3u\
+ii9wqCdnQFzEFEF+\
+PJA73agqKz3ag8Ij\
+El5DnR1Q73MYUUAb\
+5g90Q2V2x6IrPdsU\
+QSSzEP7dUVnumJ7o\
+jPxCAudB02RWc62l\
+BnZ6xxwgznQRqOEQ\
+XLMxRWc7FQB3o46b\
+Kozn70UX2B6hQBzt\
++CqA5aiDORpVBgbt\
+ujIASa3AtsUVnuFA\
+eEGyuMAFtUAJueiA\
+E3bEnRAHucBkAe7Y\
+oA921yBXuYwiA5Gh\
+8FRsrqsZUikN10Qf\
+B1QCTsW1qiFOT0lA\
+DlFUCvc8glAHOgKB\
+Sbho6IV7tBHCoBN2\
+yBCbnoe6Bcrpg+CB\
+CbnoVQhN2oIKBCbm\
+oUCudvJEKSdkCG4i\
+GJ7KhCTsiFJOxRU3\
+uahbogQm/YqokSdp\
+TAVzsqEJOxKIUk6C\
+OFBNzsqpCTMFBMk7\
+FUTJOgKqEJOqKQlE\
+ISZgoJEnZVEyTsUC\
+EnbuipknY9VUIXQI\
+TwiEJPLoFnlUf/2Q\
+==\x22>\x0a    </div>\x0a\
+    <div class=\x22\
+position-relativ\
+e d-block my-0 m\
+x-auto overflow-\
+hidden\x22 style=\x22w\
+idth: 940px; hei\
+ght: 370px; clea\
+r: both\x22>\x0a      \
+<img alt=\x22404 &l\
+dquo;This is not\
+ the web page yo\
+u are looking fo\
+r&rdquo;\x22 class=\
+\x22position-absolu\
+te\x22 height=\x22249\x22\
+ width=\x22271\x22 sty\
+le=\x22z-index: 10;\
+ left: 72px; top\
+: 72px\x22\x0a      sr\
+c=\x22data:image/pn\
+g;base64,iVBORw0\
+KGgoAAAANSUhEUgA\
+AAQ8AAAD5CAMAAAA\
+OTUC8AAAAA3NCSVQ\
+ICAjb4U/gAAABDlB\
+MVEX////MzMzFxcU\
+AAAC2traTk5MAAAD\
+W1tbMzMy7u7uvr69\
+mZmZUVFROTk4AAAD\
+W1tbMzMyZmZlCQkL\
+W1tZra2tmZmbW1tb\
+FxcWvr6+FhYXe3t7\
+W1ta2traZmZne3t7\
+W1tbFxcWlpaXe3t6\
+2travr6/m5ube3t7\
+MzMzFxcW7u7vm5ub\
+e3t7MzMzv7+/m5ub\
+e3t7W1tbv7+/m5ub\
+e3t739/fx9Pbv8vT\
+v7+/m5ub////39/f\
+x9Pbv8vTv7+/j6e3\
+i6Ozf5ejV3+TU3uH\
+R2+DH1NvG09nF0de\
+6ydK6ydG3xs+svce\
+dtL6RqLWEna10lKV\
+pipxmiZxbgJNafpR\
+QdYxKc4tCa4M9aoM\
+2YnsyYXowXXjFq0N\
+/AAAAWnRSTlMAERE\
+RIiIiMzMzMzMzMzN\
+EREREVVVVZmZmZnd\
+3d3eIiIiImZmZqqq\
+qqqq7u7vMzMzM3d3\
+d7u7u7u7////////\
+////////////////\
+////////////////\
+///9H2B9VAAAACXB\
+IWXMAAAsSAAALEgH\
+S3X78AAAAHHRFWHR\
+Tb2Z0d2FyZQBBZG9\
+iZSBGaXJld29ya3M\
+gQ1M0BrLToAAAIAB\
+JREFUeJztXY1jE7e\
+STx53vNwX3OGWuxc\
+O7siDd7xcoYQXrpV\
+CaQNrB+w4MSHx7v7\
+//8hp9DkzGq29tgm\
+0RS3Yu5Y0Mz/NjEb\
+S7LK19dnKYLAXy2D\
+w+fj4AsrOg6cvtdb\
+KFv/x8tmDnc/NV6/\
+ymLDvv64gws7eIe8\
+olP/bW6G/xypjbCW\
+++pZD7WhqnWgf9O5\
+l8Cy21hIkT3tbzmG\
+CQ4cu+/PVuwwi99r\
+9gY9Ht2716mTnWRx\
+IjoUO9571G9tBrh2\
+6N18rlH1JgDu3bvb\
+p48EhapwpR0BEP1i\
+BL03+9ORrlRLNxf8\
+H5fmtWzeW72H7wLO\
+eGYpm3w+2e/CF2gf\
+N7cfXSmXXEyQD+7C\
+PWt4+wLohuA507+B\
+2L75Md9ir9eNrtfJ\
+U4PuHWz3U8vahb4j\
+VQ2d9+nL0r0t2+0z\
+ooBdfq5VtBoel/l0\
+Ptdw51JnYNABhv/3\
+j0nzx9roPXyuWByo\
+rWn27vFpuH3TrAwn\
+OrAL9+Pd9+CLd9eB\
+r1cLFsRz3UMunSer\
+glMmNBEWMcb5fni+\
+K8jWYyw4dBvfRY5L\
+fFbQrVxJ2/efl+Mr\
+c0TUEH3uSHMtP8tt\
+oUoxWzidZ9MVNY/q\
+fe/CFsLym4MMTjXR\
+7TPIhlkNTi9bcTML\
+kEyvq5wv7T/FdWgN\
+cQ/BxOxLz2gn8Lz/\
+J31aCfZBARituLPb\
+qTws7FsKYawg+9tM\
+wRDF6eK3o9DS1Eio\
+8vvS68mIBhX2hm2v\
+wpkktEeHlJ/kd2pI\
+G13QhE+3Jf3zTTeI\
+wjz16BUUrlrsqmr6\
+OIvxpabVko5hkf/H\
+k/v1v79y//9fvj5S\
+SVEc/7xzquxKUy/O\
+1cnlKCLq/lw8+tg8\
+Rz0gFnpuwKZQ7T45\
+yZQGI7nT1/AzVDA3\
+7BEUrlm3NldqUvy6\
+tlruspXcOfwIcbt6\
+8YXq5cePGzW9+jMq\
+Hqz/qEG471kLr7uX\
+5WrlkwRSQX36Sf0Y\
+bIjhID//0o9MIOul\
+836H8u7jX/nytXA7\
+oxGgvvl96GLbFSAz\
+gYB38wxHHHMqdMpk\
+Daly21fJ8rVx2sjF\
+QfSb5XWlR+10OB6z\
+NUIwWLKdsMHjaiuU\
+ago89skTw6r6819r\
+H2hGizzviMB4KA/6\
+8KN8erhYwvIbg46W\
+gxj0m+bD9jZwybFB\
+IbD+gAvrwqkToJdH\
+b3nytWm4nU4kTol5\
++kidaHYaxsEGxjSE\
+Pa51vCwN+m651bMM\
+efK1c9oli9A0+8tn\
+WfBSbH8RqSdRHBQl\
+JlHd9wQeO1eMKtMc\
+k/1jl5bvSKD5gJqC\
+tbS3kK5ZrCD5YTOz\
+Kt8sPwwFu6dvfLzU\
+fUELWEF7IIt5VPBI\
+z37759OrxFOPgl+V\
+9JvlDtC4Jq/pyzMT\
+0w17KlZ9FxFLNawg\
++tnMGe23ISfvfP5T\
+Z9tu0eC5SdyQ82H6\
+/w/waNgp306SARmx\
+5tRyEYQxe0vz/tzL\
+bz/gSxjS4L9WW1hD\
+XEXxk++qq3ynlXcq\
+x/XhSxmOP66LB8aF\
+U+wAPku7P14plBwk\
+TS59Jfg839d+elIc\
+xTjDI/z4RpNzJuDL\
+AXUPw8YDRBbXvtSG\
+3F6RDrBenF2NeKPg\
+IUZaExwOMmQ8Tr2W\
+jUDPuVM9JnqxBfWd\
+deKis6L8J1V+yRZH\
+uy9dq5XYkGuNFmOR\
+vUd7TmOY9HPCFsQJ\
+7K/K9w4wA/hLwuE3\
+sxP0fFwGDbD4U+Fq\
+t4OAyrMHjJE/H0oI\
+m4IH4DqVrHJXiu4a\
+SfjxmCEPJ+ELT/Ib\
+g2DrERho2JILXQng\
+EDckdGoNMu1plPIR\
+cCCEgO4xVUqgi8aU\
+ixY3AcTdKkfy9jsH\
+lAJPUfuRlPOhIdnH\
+H68JVhsdd9HPc5UZ\
+8kSAGMNsQHvtUFEs\
+kTfJ4HLyCCHjkxty\
+JR4w1u+qnpW3yp4w\
+vehiwGTy2GV+27/u\
+xbz4X2N2pDI/4K/Y\
+fZZq5O83rbwcY8BE\
+w5YsGahvCYzeQRXi\
+jSX6QhdYL/IcvP3Z\
+xdxDDWF3EYzfhq8M\
+6APNFIx4t6u0qhe9\
+fw7z2JDnDAVFJZ+k\
+SHpragFnAd+KRaIW\
+vvP6BUnwgFOGLMC3\
+r7Qplhw2T/fJN6nq\
+QD5OEBw/n1IuuMPJ\
+AcKis1xCjJMg0SZF\
+ieMjjtEKhsbqj/gL\
+FxIPkzTwoXfaSpFy\
+EB5JD1Dq865wwRny\
+F4CChtRE8UF54HGC\
+8wzAIaCT+crrITsK\
+fJfEo9nqIfsqCD8S\
+XKvawUrnNaZLgYyv\
+oh14Wj8jkMnh09Ho\
+bj4L23onwRdRWbwq\
+PvwimT3YYwlZP5zg\
+wTOHrj0vph0ry0F7\
+/grANcxHnizv6TeA\
+h5Zrcxx3zdUJXPBa\
+mRStAFx5p0Esoo0c\
+CgtvK+SJmupH59i4\
+TFgjTHYZBik0Cd0v\
+EH1qIvzM8FJlwSa9\
+3SWdZULSVxYkbml/\
+2M5D5aeAAjbuv1jH\
+fpjHvjAZyWZg0hC9\
+fcr5Q683gsU1lcFf\
+fkH6xveiSXrLAeaE\
+1a9Kp+4br5/v9mud\
+nD3BzvSE8dvkYqOw\
+0cMC4EukeaLLMWLj\
+6FpLISDy7i+npIl9\
+0kbEBPKTnutjxxgA\
+NoirRTcdzqfKfytz\
+R028nDzmeeEb6c98\
+4Xzmka+PBc02ySX5\
+L3Oss4IGy9k1kLx+\
+okD5TTKzofmHiCxm\
+iwBfL21wbD5qJ4Qo\
+/3qDzWoHuHhlJV+6\
+X98cGvK7S5HjiAV8\
+cSnxprtnrr+cOkrV\
+EqHkqEo7X/ZGygAd\
+HVckHKkFeVE3H6gm\
+PA7Ss8bSzvHG27t5\
+EPHZbZUNv+HryP3u\
+44AQMHaq4n9ITo7s\
+ItFD3uzIeeyo6mqg\
+pjxIeaF89kZX5wgQ\
+FvvqVxyhGxyevufe\
+PzKPZTan0TPEgyRW\
+bdCxgntKZWbmgOFZ\
+/zOQURs2xzG4HLV7\
+1LQE4Vs+fDsXiyZ/\
+/ESXYZr9bh1rGgz3\
+uZNvdSep0qPo+ERB\
+/ArqIr36lRCbjQHy\
+oR2OPKT2BXEoJ84R\
+1+qOtM7xBfu6EIov\
+VCPkOT96NR/JI2De\
+x4BFTQxv/mswgByR\
+0cpXEE3soA+LE3QU\
+Ox7CIJOBiSBAcksH\
+qlfEQhkBCvqQ+iO5\
+jUl37GbJA9zGerHx\
+f31E8JLLSY4q5B1G\
+dM303HpqQovMbBqO\
+gPYjubmAvaY8xgQJ\
+bB7xPpfD0EswpfxC\
+C8sPQ2QAepMuC9hG\
+uKXuILsvUcJ0+lB0\
+ImU6js8F4RJn5TkO\
+GTF70mniQrsQpJiX\
+CJoPI/FZ8Lhs5+xe\
+ywezHnpNMJNmsJC+\
+f5Qrsr+0/8HQlkxI\
+5I3T3cQcBv/sSX2K\
+C/nMcW3aQlCc6P1L\
+h1GRt/SDemdFCzOC\
+6nO5daTx/+BeB6gG\
+vB0QfUjxyAw2M4Ai\
+SMRfPQzZlL1Qiaaa\
+hoGG6Ysam+j5nbJ+\
+43NAjWbxm5HDNsrW\
+4v9fxH3xGyGaTyIU\
+wIzC6T8UZ4fu/y+C\
+QZgSaYour9NNYd72\
+efmRictiliSenezf\
+73aq03sUU75LEzqT\
+5dPFK+SqrBIUllY3\
+YC+IxV2iRATYOh3i\
+IUIvD/QeDwfbWYLC\
+7/1Lx4nuiW4ES3cC\
+SsDGZlU3gQUe+AAS\
+uojkee7yFSj5Psz+\
+sPKF7PWm2EHhYQpX\
+Xi8dSeCFNZoqohEJ\
+8cj+O3+5Q4liYWgC\
+zO3QnR+Ah3llm1DY\
+0vyxSCcUHiNHdU1o\
+ENcvzYvQg2+RmB18\
+l/orrmVXx2Nq6tbj\
+cz/lKPxK62yFGzbU\
+tgSHJeSfb6FueLxy\
+MFfj6hHg4cUp0HyS\
+N6rHagIxjvtBZki/\
+W5/p4LFEGSTcT3UL\
+dbN8rAtGBzotbK+0\
+D53nCm8o/XUBXUyN\
+VHefoOymiYGGT8Fo\
+Y36f+drXhHJBNiu5\
+x2mQZUMGU6jrnIMf\
+yGMTyfvXDFZ9X4Oc\
+N14gHV/YOuv+V0CP\
+BWXHL79Fq1sLOyfT\
+CE+ONlQGm6ETrovu\
+/UWbBZeSm93xl5zd\
+IbIU+rxMPLFcn3f9\
+m2RMZIlhnHq0+Fwx\
+oZ9doL9nuYTfd/8w\
+DrvgdeyFldz1Wftg\
+pzyO/RjyohAvo/ts\
+LUTu8eieTefHtOpE\
+C9qcL/fwGywAT1Uu\
+Nw40//1CwGHT1w6P\
+1AqeIRwLkuvSDvVh\
+oCbo3H/3QfQrs0Fj\
+nwcAsv/CLnG9DuXH\
+r4XO+RE4fzx+uH1U\
+PyNPd1+k/6BAvS/e\
+GWWI8eZGv8F88ub+\
+RNcYgG6brwWN78O/\
+3WVmS7o2bRuo79x8\
++ieXh/Tt+wXVz7RX\
+X6nytW27ki8ulm96\
+8mTe+uT4Y6/K1JuG\
+s9Gx+M5aeTT8pX1/\
+L1/K1fC1fy9fytXw\
+t11/u7h+EJWZajZR\
+KcZuLXPE9L755JHc\
+tnKzRRV86ZMrIkZo\
+FKqHawf7dMho74vE\
+I2tdAtzALPfb/GO9\
+sWSt2QrkgP5f21fI\
+uRHZd84M/FuB4UMp\
+gpL0K28DZjcK5I/6\
+qhbucSJI722LJ+46\
+Vkf4sl2gv/7tMfyH\
+NlstD4AIgHc6rdHU\
+gQ5X3zX9PnHICTE3\
+ERLvA12MBjnuBFB6\
+UkuJ2fco0A+eETfI\
+4rkCHCbFOCj+ryij\
+ey+D4w0tcFzfAnQj\
+jLOi9rA1s1GXZSk9\
+oxN/Jbzq/6W8kvaI\
+2LollymH2D3ftyiM\
+keYLoZviwSpRElyP\
+7l47EXsQOGi+EVEa\
+G8Jbjz692OR77GY/\
+chRWsv+SxsipFb7h\
+ikkwar+WjAqXEqVy\
+rfY4HMZfrUNGoYh1\
+yMAX8hLP8S45Hltv\
+1K1H0jJXCD5R9nd3\
+heBDYaKOc8yzBFZ1\
+lFxhkPWX6RQwg45k\
+2XyYlO1YkfXKWkhg\
+ZHli2JVI4kfT9cvz\
+zWyzHv6CAC/rtIim\
+BgdPK4LOEh8hNroc\
+IDUW/dqg0j5RVAkF\
+JQsuCUl1PFpANuxg\
+Dsz7juEt4cMxiDwI\
+pFZU1t3bsORYNnsw\
+nJUgG4ROtB4v2klD\
+xF7+PIFXWDzqiRSe\
+EnQv+kQ0AYiy2/VI\
+9b44HNwrxIt39jbn\
+d8ny7sK/PbeqUclm\
+TWLVuhRTwwJ2jYRV\
+6SSQkNog1/FpskK9\
+wEWOfxmFRnohEosI\
+lwyckZZ0rUEHM5ZU\
+oxvpejseXsLAqNtG\
+kHTElolNYu4j1Un3\
+Uitin+bjH8PjNrtU\
+E/jAXsd97XD/kMct\
+MWEeOCSeUjQIYxAP\
+kP6TLAv9YlEzY5NC\
+EEL3AK0b3XoaHQFg\
+Ld9M17/ST7vtSuoI\
+KZJIriX2hlsoA6bM\
+WROJk9WVijLTES5w\
+lllB1vlgpoYkIBtF\
+K+NtayGQiYaKGv7s\
+9s3sIDzw2RJm5AL9\
+lyO5h/cgnIcoWMZG\
+yGRLOugXnFlq01WR\
+FuR+k7K0Zrt3D8Xp\
+Zx5j3UGrWtm09yWv\
+JiirJJoOZydvhog0\
+PTTPZrIv2JpOxSBf\
+mIH3TNPbvumnPHR7\
+tBHepG3SDx7mTpm0\
+ECJaKc4eGIhsKR+e\
+8qeErtwlyRbGKJDv\
+i3HtkPSfpkKFsgGg\
+tHjX8NdPqdG7wmZC\
+KpsqkoJmAR73qYVN\
+lOk4/aGDGgXB6BUO\
+A1U0Ssqy1qTJRwXt\
+hvU+sk7jRmYUDVAM\
+AaWZWfMsW8jkNwwP\
+b2KQBmVbzOUOjBlh\
+zz5NSAMnN+5x76R+\
+QyOvaMmvad6NqalC\
+pqmFbz+BHozJUPya\
+TyUgU2NyozI9F/5T\
+rJrHukUEeV58lu4w\
+myrRS/poE47tDrMK\
+Azreppv9bGzzMHaP\
+0wFgT8KgnCb+yPhZ\
+MUOAbDyDaPZkwPJC\
+fMpozIf5gIwuMgz9\
+0PKpvv74dVQqUHhR\
+XvR2+gXvJn37izTK\
+Kh7Z+ystnrHciU1t\
+js8zAUX6lhq9kRTG\
+MNUkg61/N/2fWSMD\
+FBD7HH1rrf9vQ68g\
+6Y3vx03TufmtC3zB\
+TXb4/Mz3N3vvexxe\
+2ysXYNKl8X62nO/O\
+O3Y6Fc/NNc1Z5PqF\
+l3c6nR1jsfgs9gGM\
+rq8a+244mbe1FhP8\
+tGDDjtGO4nrV2sCx\
+sVt7a2pjtorIzNXT\
+y07yGORuECP2f214\
+sts3YEgM9tLXAGKr\
+W/+4ZOfd0bdzhfDx\
+051tCPABN56+SAP0\
+CvoNttH4RXL9OnVr\
+FjVUMYSdEPf/ZXJ5\
++bJyDfQ1Q2CFsgwm\
+/OYeZCfCYthao2mA\
+XuDi9bBMir6GD0LP\
+581q9mV36zlz901n\
+Aw1w49YC6V9DyZ69\
+65s4UjSOTqHPtaLU\
+DvdAafQYYIngTHAi\
+A/5hW1QiGxPkRN55\
+gVfVkWI18ZUfcmpo\
+pxlg+jEZVFVyC9j0\
+1Z6PhqQtg1MTAOam\
+GI1BHe206fouYA2m\
+P3JWBdWp6mzS+pdG\
+Oibm+MPgka0B2Qdx\
+/Zi9KBThKrxihtUH\
+0dFVHG/ZhhwtIbK0\
+ja0BNah6gNLKcwqf\
+R+rSqNA0gotG1i65\
+ADXUEGPBxyhGKF14\
+j2t6fBNRP29Si1+Z\
+TgGOL20pEEHfn55c\
+wqj78sp8wvbQuOHp\
+v9ON88oaOi4vHlLo\
+wn9OTnyg/MGtqJH9\
+QHm+A/joZqh8IHXh\
+QCQ9D5ecxxEkXHAQ\
+V/SrDBd2NcEgvgOe\
+eV6dAwONRW58GWm2\
+b+3FTH60v/DitUOs\
+wcmMb77ezyU+xW6W\
+9xVlcVFBDHTUwqqU\
+fpMYu4lTEwaumtvb\
+SXNbWf4xd/WAlmgy\
+PHyTsN3TyHcRekmH\
+RTzu/NGkKNVIEXQ3\
++I0yCx3M77TTNaWp\
+umwLNqfOG9eXbhHb\
+jpeL6EfxJdKYOEDc\
+QkSS6NbF9J3daMAy\
+dwMUFwSH9gzXcgII\
+hYynsnBfiMq/eSr8\
++vbQRA0yCHrxJXfv\
+ZZnxmJ472Mno4HVY\
+hAY8QbMCKQON4zA0\
+MWih4jxuRg8mmaec\
+hHMlGlhWyUMBwLPd\
+q4OAE7B0dzCPoh44\
+Bq6kdjdjrOJmqhxO\
+DV3sSqQXL8yvm5D8\
+a2GHRAZ8w30WCyUS\
+bOrY8mxyn8cylCB/\
+E2cJfByTncqnmdBM\
+jxETenyY/17R2fXP\
+axhjUL32sAHZt/Kp\
+NPtF5IOtHnAVG/ai\
+9P609Wc+9VRvPQ+1\
+stqnt3tTY1KxUr0Q\
+p5Xsm2kHOo1AlhIy\
+1l9YH3Voh8aP6hsV\
+E214NhyYIaJt5HAT\
+TtHYuYl6Z3ybBEdr\
+fWzRzm3snxq9OTaW\
+pofAOpDQUpqPhq8D\
+Ypen4pDq2pPzU63k\
+4umrrD++qkSHxS1L\
+2aJfINzJAmHbwV86\
+KqI7PIfK7PHV3bFT\
+ZnB+ffrTzhb1htHd\
+2bJXYRfLg1Sx6x3Z\
+30TRV4Ze2rl/7nk9\
+t/Dl7C06nraGDyxj\
+6Wifz6speVH6QIF5\
+rG0cS4vqZ48Eq3sS\
+vZ0JIVBpZemH+otp\
+B4g9dyAmaOB85cz/\
+NWrvGqM7d6sqGX/D\
+70BqQ20m7fOXZGbW\
+29sxOoa3behwrHzW\
+7+LupZi7Irwx8Vz5\
+cnx9bfsY2CB8GRl5\
+BEAN8zBy01czNZ8D\
+Y1G1qOjx6HLFv5Xh\
+wzeCQTJwkM+XxgIV\
+kM5q5u3bLyDJn7Qb\
+E94tM6GZkWYRtE7e\
+YM0H7iQrK7Ncjw5l\
+diFixf5nOTa359LU\
+nPTxzPXurPgJ/PPM\
+81C3wAE2trCdnjo9\
+JbhNIrmzAOR6SQij\
+1m0sDUtKKHz4zPAp\
+8JihIP8z1yuT5z1q\
+pzqVlzj/V1qwG8o8\
+q9q0Kux2pliaN3Z8\
+iHuUmcsH4eYHFKl0\
+dELELs6I4LmoTTwN\
+ZDrrw6NIrnaTG/WZ\
+CaMQtZVmTFp9047X\
+cc5bZUfAfn8d4vwC\
+QBTwIBh1DQ6xDRUZ\
+F604VMi0V+15Oji7\
+mwt2eE4FoLzr7G0m\
+V9pSQ0Wr0PyYSx6v\
+LqPF46nQn44L4CC7\
+XhvIJCv6Dm9XvJmE\
+qt5cv1rQFabDyruY\
+/+UB32IvQ1W8/Jiv\
+NL7xDZmaa6iInPHS\
+xO1PQJZZTAteiTek\
+4HpIu5ffELgRyUvy\
+xASbcudPSTEQNSG5\
+Fk37jaIRhYJ4M81I\
+cwwVXSrQX7BwCOfa\
+1s0t3t2rdWhcJy1o\
+HfSX0xD41lb1oolJ\
+XUncZ7qQs0I98xZ+\
+bXOI5DqF6NQ2bYsi\
+bkDbUvUZamvdHe1a\
+RN2aLtFeF1LlYg4n\
+qruX5dn3vD3t9RPS\
+NeP8I4Seb5iU8Ev/\
+UikvySOtPvOXMDXm\
+d9WeHmNjfSEzKzBO\
+uC3gIrdhQLIyB8F5\
+4cSCxAiG1cASwUpO\
+hSfT8XcGENWnr6yM\
+Fy7gI5ArzLWIo9gJ\
+f3LlGq3xygbJphk4\
+Txhf2yMNnXPhNRXM\
+d9grdpFPDjtnlqat\
+k89Da5uK9pzm+CPk\
+O7cx3aTq/8l0qtxF\
+m/h/aLcW6GWq7hQb\
+bYFfTn5XbqzR9xi1\
+HDF2GEAWxhAdHmha\
+7N2jkd3uTLRw9wZa\
+v9ruIcHt+5PSjdru\
+nzUWQpvI3AMgP9qb\
+bGAybvvrUnWFaRM5\
+9lzYD5OqVl8PJW8N\
+mLfRj5D2aN35nen7\
+kck8sXo6VKgw8c0l\
+MNHyZz7eisQTXfz6\
+HMZ+p2VVb1/OZNp9\
+NMz+HXI3W7RW39RR\
+IQo6CFbX2m+vKba7\
+bHdV0QFP7VjC4r60\
+Qtg/YvTdd+j3yJiR\
+xKLv1Dpv5div+/Fh\
+BHokfG6h0+hHUw26\
+0w1b9MVOOJeLlkj/\
+FbgEb2lHrjogn/nN\
+sPo+UPbJrJqNhPGw\
+B/zEcjdLhCzSHU4B\
+RNXx/aUwGro24NnE\
+kHU9CusfUn4bC0fe\
+kgiSOeH6jlK/rj7i\
+1umrbi2oUDnl0yC0\
+Ag6ZJ09KsKNhOIf5\
+QWYMw6Zy17Zn5BpZ\
+uPtWZ+4hni6c+LnW\
+5Gy6VKKpsONyHTBm\
+4VTc4YTNMSf4YX4d\
+UkdNwTKc8Hg6XZoL\
+xCSlt4VCsaUOuHS2\
+L5oXcXhiWBENtjwK\
+NQry2VnukjmqnJo6\
+f1ynjwgujg3AKg4b\
+yJfQv42nAo3VH/xE\
+1wAe6bFESB0v0CEe\
+c8QiVJudwIDSPdjO\
+kcv3A07j7Rmb+V/a\
+43ma6NWNtzUU7Idp\
+LZ/5j5fXC4ZESCDE\
+e7mY1vXTW747vm4b\
+Vaj/G/ICAh8VO21Q\
+RraOexLPehuDBhFi\
+iZPqxcJI+A8/1wc6\
+3Z8pZj3LCNNY/Tv1\
+1TUUPF8GY4BoO0ez\
+8RI7z/VBbe3Guchp\
+7cHjYs2F6aDyp3bl\
+wSFaK/oNFInhBtQw\
+eFADJ5YxhajPsnBt\
+hXrdNGxIcW5dxMXT\
+1g/EbXGqMh5fYasL\
+YTjfzs9amM8SsRYe\
+aTQUAJbyKSRzeBWO\
+/4XDRLoNOpfsxKaV\
+vdCf6DyUvhVw5Ak9\
+qBPnFkJ5ZJxLkP5u\
+8waLbXKcJdoZeWYK\
+nND75avw26HhUef9\
+pU83OJscKjzFPMcP\
++1DaufU5I0BudYkl\
+SdPgt+BV/vxyP8da\
+x1ZnVYrCVxn7aMrb\
+hUaIb+DORYnKGYbK\
+ZwYF9TOvQPnljbMb\
++TWoK13CoTZnwub4\
+jrB/OBN2zD5DjqSH\
+288koXbogRfoyHtJ\
+kHa+smrfv1IkNJJ2\
+56FcmMPtwYgKBqvo\
+5+Hvz/Qw/G2RH3sQ\
+kACRkS1w17eVJNRq\
+FpA2Iw06qaupn459\
+MIH7x3nQygiQOz4d\
+pczGsxvMwj0Dc8a6\
+q3s39JDS3fYznDXr\
+oQpSjsErriD/40IR\
+yBHPt3NKO5uK024a\
+KwMdbn4EAl/OUVDl\
+pQ677FTQ7a5qwXGk\
+g1jz12Q2wAPBzRuP\
+SAJJoUx+dN86v+sG\
+xf8Ywz01dvA/52y4\
++VUlBcgCCh01Fnm8\
+xFNT8/AzTgMuHyOB\
+MhS6nXhhgflS7rBC\
+YMd+k3iAPz96/spw\
+ez13OCPxdD0030wB\
+I64W34X0Q3XZzNPc\
+we3uxTPiYHiq8+uA\
+BgdujyFwORGGTMsO\
+DzC5K3AMGwzZLUsi\
+wR5GBOjlzkgEerZf\
+sYnIUW7uMZeMA4s3\
+jM48I2JHt2SePhOy\
+0d2dOoSaxC/UaUkI\
+uU3K4Hn8AdbgYe/6\
+OpmaN83Fi10+VSsM\
+b4wg03pnWCPaC97E\
+oNnknmvWo0zlNPiA\
+qOdniXG5vhew0TC9\
+jxK1T4h0edvowSie\
+2ctPg/sD+VfSnpLb\
+YFH1Q/5stCsJ3kmy\
+pRd60j04ErEjtJnv\
+IVRoCOfKSReuYX3R\
+WX55wuNzCaOOvmgQ\
+j4Qfu5/VF45Z54Xf\
+SoSf03qccpl7QQDG\
+l5cOH72dwSfHYupv\
+r1NTQrxEP4sgSrbd\
+mbh2eNXUzztsGmV7\
+BnD6eQ5AswZ8MWdI\
+wYsrcgor2IiG6AUV\
+x+0EfTwuWAE8r+kn\
+6IjTC/HvYR34DzZl\
+LFkSsqyiy/yCCrAt\
+5+D50ws6or8QA+gz\
+DiyMkCPfZI/sgWO2\
+n14wVfiGwnBRY8Nl\
+L4+Eu1zkpqFwsNst\
+lCFzNIG3yQo4rAyH\
+7GB0sG4l06Yr5LCb\
+xQte/AA9FtUILPgU\
+zW/rkl8j3cC0OGw6\
+SLmYjIBw4ynR17Dp\
+Q0ZpXtRQ78MBKm81\
+LgusQGCn8JDshWlu\
+vkFxRDYdHUqWcD4l\
+rSyzHQ/SFnHjGfa4\
+JrvLILk/kSRPddLa\
+0ni+cQCg/5D9zRaM\
+WlY1MKR5bWsEy+pG\
+M/Wtol15CFcpRZQ8\
+niIdr08q4QAUxp9y\
+zg/EIKlbrq99C/CH\
+IrfOmQodCLfXmoo7\
+Lsw79evuhSdVcrQa\
+9wmKhfrlHbk0JS5Y\
+V9MuWQvxB+8jYJ3x\
+lP6RLuGZBKTe/cB0\
+2XFWYvNhrZzKwNf0\
+b1gInEYSVD4IFPKR\
+hZu3pcGV3kdvX6Sl\
+JHatJffOHSeGtGRU\
+y2UVBc3jYMNxEUjA\
+ckJ0RSe39hfMt7aC\
+IksBicHNYUDSbMlx\
+itS4SHb9Z2MU1Ylp\
+0Y9WgaqIDc0U8ZGd\
+BuVtqTpz4R/QDxaI\
+8yKyo8SMWPh2eHpH\
+S/FJwP1q5fa/mg3s\
+q0q4mJtN56x8TdEk\
+PNkMhOgZ4YxA0/Xl\
+qd3+upnY3FDZ2XEL\
+Ea18N5he/Pwb70LV\
+7hBSi/Hoy+di2l+G\
+5ItfSnYv7+aRyCRB\
+uyh5/sJtMF3avCtY\
+AH0/gTAMOJKRRJvc\
+W6kdoFIC3Hbs9Te1\
+ecWQ4D+mEE/daoba\
+5OoojFQzb7vTZI3t\
+4B4U+mvs9tNrupcJ\
+eYg14+Ey886Z1Jyt\
+21eM3TS9sLskv85A\
+n0TQRj9ZvEyrYT6r\
+9vizgOfPf2bQfhKM\
+2s+D5lxwWpVu/Aex\
+eSXHsyTV2j+91G1m\
+Zxkg8nKxO6/ierqn\
+2G8NOLtiL9Qe9Z3Z\
+79Nw+IujkeeNzOSx\
+Ju4ibtqmcv3F6/nZ\
+26Z/f07/UfmfbKNA\
+v7ilF99wanubSKDM\
+ZC3gwv4RaQMrCcDS\
+J5whwUHhxUs3hON+\
++bmJUVR9ckoPXDz/\
+fwonAEDIiXPrCvK1\
+tosIHe+kTAeym9Id\
+dFYEYAAAHAklEQVR\
+Xtm0bnkSFXfn5uDq\
+59HkPc5viMBr6IwX\
+v7UEr3lpgbdrEqIo\
+sAuhno2qO39GRiRk\
+mPikeo2AwH+gXqAk\
+PGxTqc4gewsu0IFS\
+MAW14uN2fRAfHFw5\
+aXaKCdgeORmkav9q\
+P8an2FILh6Sa89cC\
+/T0IR2FNmYxvxgAc\
+Y7Ws3iFvOnKusH11\
+nlb6RS0IIeLjX4QR\
+s3I/NBfIfDcXDMd7\
+4BA50attOjc6f+Te\
+chJM47U97zad/9B+\
+NOwrYwG0HdXLrpdY\
+dbeqa1FNRo7Kzyi7\
+/kQMYghebo9AkPOK\
+z624EL52pj0P1+Ma\
+P1j9d7gEg8EC12p7\
+0p6P8FmtgRM7/AB2\
+Fp9sdoZjgGTfx+RG\
+vvRnYCpCkwdedeLC\
+2qUxb96qeBmlz+A1\
+kq+3P00QpZDw06SS\
++QVxC4p37tOkS6cC\
+2QfZSJ0G1e0uIwcE\
+f9QezjPZi8dbOAWm\
+VFkIlncc+tRyf6gQ\
+JfpwFEmCaen4Wz4s\
+dHzpMJVDmKEMhpbl\
+4AMLhfoP9h297FZ/\
+EtsPbIItEwIahiK/\
+1sn/g4XXLq31DQKq\
+nlcOPzCQKK4XCU0a\
+XfqRWqZ8Lw/L4ODF\
+FEl5AJpehgDqx/g3\
+U2528B/FiIosPT0D\
+fxzHGSPih1BqvATF\
+lKrxPwvKH/akz4JA\
+qUtfiux4jHGTQRTw\
+4lqiXJr5IgVk3FDh\
+crrheBnEoAFEq+Dn\
+CBLoU3hXiK2iNNQg\
++L/2pMTrn1tRe6gS\
+oToSTYGF8MzlL//5\
+LACDfgJ7XJvqthpV\
+/xY+NBltfx2UonJi\
+5f1S9jpbt39qhISh\
+5P6xOrky8opyinQy\
+r9yFRwflDiNK8S00\
+UUv4lOAYFr+M6NSy\
+0bH7x/vS9cUPTyr4\
+lo7FHVuHo2wgzm52\
+fZiIRRGR7KefSn7m\
+40DqK2THEpzVkz8Y\
+Jt4F1BxoRd+gC6bX\
+jJqYm2MTVeFmPlY7\
+VzPqnvjoNb804fws\
+UGsjwPvZv2dAmXo8\
+B/CRw+iaSsfrj41F\
+4S4Z7y9v5OKgMOvq\
+LPgQZUUk/kGWR82D\
+3jqTWBe0VrBtgrjk\
+Pvbukh5DMpv1b9lw\
+MN3XnDbVXgGnI9YD\
+LoVuSnKufPjqezx1\
+YlXvloUFmmE4rjq/\
+CkiT6Bf8yPyvs2yu\
+/EJjDC3PgLYBNetO\
+Te00HdiH0CEWKx2i\
+MErF0DY7PrmIGSmX\
+3PQno7yAjqKnjaya\
+qICioxAUsLS5CigR\
+k77fthzH0O3LJ3ec\
+uKWSm3Ytn4V0fkBl\
+lBnsGn+bLDMbo5+l\
+lE/MgdMTDvr9Yh5W\
+zXTi7lPfwdiHtWCX\
+aQURcKn9Mr7L1v1T\
+J/RnpQNrmiNU0i0/\
+zTjpIan4n0FmwP5b\
+vJJPodhmxuXqWuF7\
+s+jn7LU8R28TR2YL\
+4Q7YbgUhyMclLaSJ\
+EBCa4p5LkJERgcKK\
+r9y2ctohKLzJO2S+\
+NMMdj3UGTGVhz0Fi\
+1o2oEKYb2LUsMdGJ\
+qOaE4U2B+SBH0o9s\
+BF8zkOp92gwet7Hx\
+6EoQq981/T5xyAu5\
+7If7Iuenh6MplDUf\
+nf4XPyk017Vhsvd7\
+LAxbNLwz6HNuC3mQ\
+DrIXbkfF+x0dDmED\
+n0+OcHu458afTnYw\
+LIpAWzys/u7zht08\
+hLyZFvI9vIeqHZCm\
+MjaAtOquTlTiZkIN\
+X3BDZQxHjDLi8WvY\
+zuyE5Pq7/OR5fhIs\
+Iv3JwNuEiMoXEZVE\
+8htGXRggNtcoglET\
+HVZiCZ0qT6iYSCbp\
+lpBRYToYlaHcxPs1\
+PagTquMoXNytn6pX\
+pGu4k/F6IP6QecWM\
+yaKK7iT8Sm5DGJBc\
+Jo5A6kRUiViBaqvh\
+lgVL2k4hHHLovfDI\
+oSsVvSJjI7cv6kQ+\
+gQEro9HOsZaQrdKM\
+IHUdGPm9AHP7a/3X\
+O3lZU8KefS10F0jq\
+/qzGe8VPHaoucBL5\
+O6lrwH0x1dWiUg5F\
+qdoKzmUBJ818+TeB\
+c8h9Uf3stEXOjIPU\
+QSOVxFP2VBKusDAS\
+Ogo1Qywq3OuMx3+A\
+L2/7AXza9/VF8P8z\
+v1FwWvB+XMZWzTW0\
+n1MSV+YDkN/2NBDq\
+Fn2sAud9tcWyoaIg\
+qKXrpfUq/s0kWFcF\
+eeCcaS5sjJJqpbCU\
+6DmqXF+ICsi4Echs\
+MADkeh78r75nT5Xi\
+8DDUk3Spa6+eNoQT\
+cc2ZURCfqCVEo9+c\
+lx2Nfkd+TIkrKKsu\
+ATSpJKqy3xdCAC0a\
+1tTzAyzkJikGuL/s\
+cj13cyW/SIiKs0jJ\
+tl+Pxhx8okUL/zH5\
++Kz73cJvjsXUPk8G\
+KII6QxAbZ4hDYVVF\
+iyjxqRgXN1+X4go9\
+dh1Fr4WfPsrt9L4N\
+ja+uxKCRhtUjhV75\
+r+FiAY2tr71em5Em\
+xELAZGW7HjCBc7Yl\
+wbG398eBT7ujLGuf\
+HXkKQd51Y0fSGQtC\
+E+5k+oJqUysFOAQ5\
+wIvsHvhFCpItJTDL\
+jQBAxOI/SaHJgCtq\
+Dfl9vpjt4JrmOra3\
+/B72L99CCrFH3AAA\
+AAElFTkSuQmCC\x22>\x0a\
+\x0a      <img alt=\
+\x22\x22 class=\x22positi\
+on-absolute\x22 hei\
+ght=\x22230\x22 width=\
+\x22188\x22 style=\x22top\
+: 94px; left: 35\
+6px; z-index: 9;\
+\x22\x0a      src=\x22dat\
+a:image/png;base\
+64,iVBORw0KGgoAA\
+AANSUhEUgAAALwAA\
+ADmCAMAAABYgh8IA\
+AAAA3NCSVQICAjb4\
+U/gAAABgFBMVEX//\
+/9SOCxSOjH/wp8AA\
+AD+wJ4ICAhWPjL/7\
+tDMQjj////66834v\
+ZuZmZmVcl+bdmN7K\
+CIxIRr39/dUQjpRS\
+0nFQjhKMihptaVQR\
+UEzJyAyIx46KSF8L\
+SdAKyJSOCxUQjqci\
+ncQEBBSOjFSOjHzp\
+4tSOCz/xqZSOjFkT\
+EBUQjpSOjG7qJP/+\
+PQpHhpSOjFSOjH87\
++jz4cRqUURDMSlTS\
+URQRUFUQjr/1r//0\
+bAaEg9UQjqHZFL/5\
+9nOTENTSURSOCyNf\
+GojGhddV0wpKSnGl\
+3yWlJKUh3d4YlM5O\
+TkQEBDez7fLvKWdj\
+4hzW0xIQj/05+bbp\
+4nWZlZTSURTSURSO\
+jFSOjHo17yMgn5+b\
+FwZLSlWPjL358v/4\
+sL5w6XWxKyJcmF3V\
+kYhFxIzMzP86Mynn\
+Ii1jHRXmYwhISEYG\
+BhSOCwICAj50rveh\
+n+SblqRMClWPjIIC\
+AgAAACLZWJAa2I2X\
+VRRS0kQEBBUQjpLO\
+C/xt5blqqWvhnBNh\
+3spRD4ICAhWPjKmN\
+NozAAAAgHRSTlMA/\
+////////////////\
+///////RBH///8i/\
+//////uZv//d4j/3\
+f+q/1WZ////Zrv//\
+///IjN3////M////\
+zPM//8RM/////8Ri\
+P////8R////EUTM7\
+v////+7/////////\
+yL/////RGa73f///\
+/+q7u7///8id5mq/\
+/////+q7kFCNkwAA\
+AAJcEhZcwAACxIAA\
+AsSAdLdfvwAAAAcd\
+EVYdFNvZnR3YXJlA\
+EFkb2JlIEZpcmV3b\
+3JrcyBDUzQGstOgA\
+AAgAElEQVR4nMVdh\
+0PUyBo32U2C7gLC0\
+vvCozcBQREbFlTUs\
+/feFfXOe/q84on/+\
+pv2lZkkm6x3nCNuS\
+zL5zTe/r8zMl2TXr\
+sTSNrny2/z8+PBgZ\
+X/yDv9e6Tp6rXKon\
+gMGPV0i+TI+eXWng\
+GWUrsmpGxrGt2u5D\
+xrxfIPel3++d2ywb\
+QcxJpa2ym8DHit5h\
+V9B6JGvP/q+P145s\
+aNgrdJWmcKeV/Lzv\
+Bs5xXfds4togUDvf\
+Rv5l/hf+c3Xvc763\
+/NWch3b5bFjtOhNB\
+3jjR3cY965dhzTN7\
+aJ0L5fo57CxrPHw4\
+Vh+zfke5ILnvoNZ/\
++BH3mSeGqboCHV8R\
+E2R/69Xdgj58oilo\
+T7DLYXoX89TyXXeb\
+MZ7UJ0dkX7X8CjKy\
+PfQTkAzVEvy8GYAm\
++zro6EZRKJjdXmNb\
+ORzowytz87ma8lrE\
+Hl4g+qJGgu1iC+Ra\
+debfwz+1cFjFsURb\
+oy6v2dX1uazupSRj\
+EhhwfCLjeP/q11N1\
+/5rlcrcysrwsPirX\
+DvUldTrR1euE+qIR\
+EZv+qzq+0AO8Nhlk\
+W1rfOgFKCNxOG37D\
+1UGV6bujlr6Aowbu\
+Ds+PCyadHT//7r2L\
+1eGx2tplniNfLua2\
+uJS5494x+GJgUNII\
+fF/YO5aV9f+rv9VK\
+pXJleH5eY93mpaYj\
+8eyhoAsXBEDJyPEj\
+hUq9cu2cye4cD2fN\
+MCczo/YRgMjAl7yQ\
+yMmRdYkhg9+841Y9\
+Aki4qkPnNe1DGfzB\
+ipTVUe+LSPeEj8mu\
+iSc/APgswkR+bTVw\
+GfHRsSt8ZzgtTx58\
+f0EkFYA4kMfeMgAj\
+ipLhdRhXGljxMqhs\
+VSlj5Jyz+vZtbqid\
+rhvH+fi9W0hcZ0Am\
+gKkbDd1w1YoFhdDk\
+2I89lJtcxJuEKvv0\
+U54Ch90hfalmrsyw\
+YPPqFMqhmeugQNIY\
+Ad919LEFQfa7hgqL\
+4+5eWPAcTLbCmTO6\
+runBrvIdMySOjdc0\
+lsTK2N7M/n5aBz8w\
+UzwvxjoltLwvuUA8\
+Iw+mUDeIOgqiE886\
+gVqTBSDzFvDOmokE\
+/wUOxT5weqJuA0mY\
+YGZt+2FhYP2jzxXx\
+3lXxQ6Eo7Nt5UimA\
+ByzwtTSJcI/7OPmM\
+8Gv6DPqIQBR1RlSg\
+hHynf9Og0mqrLeiy\
+NpOW+LKazXTG80EP\
++d9Bxv/pc7IBD9p6\
+5rjCJnVifcI281qV\
+IoAqANAa2JnUR8pU\
+Mv0UpP/gITidAVE3\
+xeSmbco00tVoEZXB\
+k707XPDYgTIxBwfx\
+il4VEeER+BXlEliH\
+CVK5tRLRVcVAQIK9\
+hgzVAMtE2k1y+BKH\
+kjbcrAoynoscpqmD\
+sgcfFYStF3hwNA15\
+hk5ENv/pEiQ9CSuE\
+jy2cWPyzPigAtX73\
+j8Rx+I3NiLjfVjXU\
+DBzAqHyfSMFQKHtv\
+wlcCAVYFmpFFA/hu\
+Azs3jE/ZgY3k17mz\
+IEtniRr6LOT+gwyt\
+zs8msiaOTDVZYIf/\
+HsGgcB19M7OzvbMz\
+vb2LnFQf0ejMkexw\
+4YhkVOHJZU4GiZNe\
+WD3algsFuV/XcLq6\
+uxsP+sJvV+dUV5mW\
+DluwdXHmblOV3I+B\
+bke0ESet381DBVy8\
+6Y/qPfV2SUGCWvkN\
+deYe/ktC/w3u7U+V\
+pU3HO+vorjNa0g/y\
+Nas9zo9ljsAmsrAf\
+pUYEVcfP3WEhnt0r\
+BZD4ouWPmOP7oJw1\
+qnaMgDp9iIroJ/0Y\
+qj52pSXETr0hiRs0\
+wgjf6YDYrOGX2/ok\
+DXX+uZvDeWekJBrc\
+0fA7yAB5OXOL7WxL\
+/usMs/uSS9z+vEJx\
+6slr1+gP7ANgj9hi\
+6lZK2UE4vbNeQwK3\
+p6M1ZHr3zOfYnbrW\
+NXcCFkDGNvJ8IS6F\
+FfzmC7qey/DVg7bp\
+smZFvasLW6/dBhIt\
+n1n1KcOgS1Vgu0lT\
+Asn9EuNuBKXMdVx9\
+QVcHSHyBGXNxB9SM\
+4hIxWqHZ9WeGYwPp\
+A+mjjFvmWNURuAjI\
+Xcuai5h3gKus+pLV\
+VUV2TOzHtgC6mgPb\
+EWqzsI4JNmC84pM5\
+YzxVcaXkCMnNTWcK\
+lp7PsEeJHbWnMFKC\
+4tHI0veqJwWvy3zi\
+Rr8xGJLGBZDuxNCC\
+zO3m90coE9St6TGY\
+H1LToKokDlHcWiGZ\
+A6ze7jUUcQEWPcA3\
+xiiViw5XjGiZkT2+\
+fQ+yRbnGIPsk8g55\
+1OWjfqLaGjItIeED\
++nD2oXKLbwVqA6xk\
+pxfnAtJcwjXOEmYN\
+DAeAMJEakGWaxiGY\
+oQqJNaDFjgdgvJfh\
+ZPyKXUfxc97WGFJ0\
+tk3cU4Ys5O1MrXO8\
+Vh6i8yxgjXud+X/W\
+a++8WZ8TbPLpYg1M\
+cO70t7Pl6QpukY+3\
+o74RgrV+plc4qbO+\
+s1PZP2I5UoTUKbOm\
+IY2GO5U4yyxrCVyC\
+2iChLd0zgCJUPiup\
+2obYNpCr352rDNrC\
+ZHLOMwd66znH6bJL\
++5YtsL4HS81PFSHY\
+8Pr8VDUjF6sP88ay\
+zcH/G82WDKYxiRaL\
+WGKFD0JwbyEYNKtI\
+IzsumtsQmyisfbY4\
+ySmlGlBe9KyTdvAh\
+BkNHMYkW7MOznWSd\
+4zr9herA9SxVZSIE\
+1RxJmOxR+KV+A5cx\
+umue9UJHUHwIRN2y\
+BlSLPLAmf6v25h5S\
++I2wg4upxzkeZdgO\
+wAcOSYrKkaVRbNO+\
+4RWi4s9xgPWHuAbK\
+NaUq7PunR0ReHrE8\
+IRByR8RAGLLpIZ4w\
+hzRIZ8E6YpvtsQd1\
+wVfe9eqRXfH8HCeA\
+6EsDQmtHarWrG3td\
+T2+tjaIpi8iI5Uj8\
+WPWRkyxo+NRQ6MAj\
+grzqEETJ/f4jaXX/\
+sJ+9+qYha868iVOu\
+yFBnkFhsY5BISP9D\
+WpiqnmiLTh3uWQxJ\
+CSVZGpqhQ1xvli7r\
+FvW3IcGeAlzlyOc8\
+gxu/tXVJ4ztFn2to\
+ACBuwaUN0sfu+TlX\
+Ts8Zll5ZBN2ExlEs\
+01rA3O34GXqMIgML\
+m+CKVWrj3nX26Gl+\
+IzgV3gDE2lj96f50\
+IO6Z4mf2G3PsTLV4\
+OaIYVcxDjt5rRkMH\
+E/dNXvWmbexagPlc\
+rSNO+gE9o+1iTf8C\
+WMqnTxpQR01doDg1\
+ZHD0zG7vr7+5Elv9\
+ypxx26ALVZsB9Bsv\
+bu3W5TeHhZxdjjGM\
+XWKepD09XtWFx83i\
+dL8JQgKhYL8f/nUl\
+6a1Cb93NTXEXO+dW\
+FxrenHqsjigXNBFH\
+lkon2o+o0xXOJt35\
+XnY1leGPVdSxPvm5\
+qbm5lMIIdBAVDOaR\
+TMWJyYmuruXxOvE4\
+vumJgkZwAbwV9bfy\
+mVx8IvF3qoYjTPR+\
+bF1QoIBAcJgDW7gI\
+pnpOurVqFnIvbn5c\
+lAAIRIy8RIE5UAL2\
+PwYBHwXLXA4rCx2D\
+y6LjpyYtbhhwbHY4\
+N014CG5yWd+DA2Lb\
+bKY5pwRyAX8sjo5h\
+xYooAHrCfld7Qdto\
+Q1mL7GhXG6WPIzQo\
+Hlks+EL8zsQ3cxnC\
+dn8ZE9ANEnoTV++S\
+8jyB/kaYBPlty+Sh\
+4/jQmbUIYUYYMYmT\
+irWX2yKCed0Iyn3p\
+uZTdPIAcAcGbEDtg\
+EYE8KEcAOvhiELhh\
+azxMSpcZDse0mD9y\
+YCHDkmYWIr5Bhwpr\
+CnszZeJ7UEZVRHAB\
+hZ1At4jvFmyqeLrK\
+UmbNUOQzNQBjf0q4\
+IaIINcCnUQu/izpE\
+oXxU5koXmaQA/MF2\
+yrfLwstal7LmxzDR\
+iIxgDEPi/Wp2oWtk\
+di/lJkcOZIA2gToA\
+7JEll6w98tSjR5zv\
+hJL4pOOGvyyhzTzP\
+BZ31TQ+a5I0TcbKa\
+zDEg+80PhK8Ulgu8\
+1TjY8eUaYvmUAdEN\
+Yr5zdpQXtYiLJPHI\
+WxaK7UpItpos4ikK\
+kOvKcmLvly0tK3GZ\
+D35KE4n7lbT8vknm\
+jcunD59+sKBMbJ0Z\
+GoMSRS8MvdcBbSPJ\
+O+xZ4f3zew7fMBIf\
+iJvpKLBD1u+x/nCq\
+2Au4lGjKuf37DmMx\
+C0DS6hIx19Gm1JAE\
+qFqBw8O7zFl5v5lq\
+UWR587Qeeh0NXZtG\
+QfsaD6xAR70ml3fa\
+Q1+U570YAGQMyOJO\
+hpIS47OwGCWPynze\
+GBmD5VNSUSSF5oOU\
+EhrRm+UogPHrGflS\
+ixq7I2X9mj0EhGz8\
+mQHUeDgnrSOGpUoH\
+2gF4PLD5mmhSNTVq\
+GZJntN7A+Dt+MUWs\
+2U6YcMtA16fe+ZgG\
+QwON+vM2aIhRWKpb\
+2/3cOytm42nm98Da\
+JOEQGd1ktJM+soUp\
+0m+cPg0Ul6VfdwOY\
+hc4UQ1pLQQGYzMSd\
+Wsr4N9sbLywRhJMD\
+4dlMdMHU3VfraJZc\
++vWeej1w4GKuIyQA\
+3JI5QLiRZuPjnefO\
+Xzm8D3Fv4ei0jP6D\
+NmJYYMo+Xw9hRsEa\
+07/t2/v3vYjl6XwB\
+IYxsNWgkGXF7MAQP\
+EDWY0gglFVDv/Rut\
+yhX/tyz57wAv1jLQ\
+CuQ5qcK0QbhMQGnj\
+92F1Pv69vb1yZMeV\
+nw9bA1IHOtYpk30U\
+9kI/u2R3e2728Xfl\
+UsSvDX8T8w+MB2yT\
+Apr9Q98AefmKvvFx\
+gt9EvzP4rS7j6ge3\
+/MAuexEORg5BGAqT\
+WigtfWtFHu7+n9Fc\
+lFJrfYkqwZmJitXo\
+DU+5xU3785S1a1GQ\
+RlRft6tOlwJ8Bk61\
+gAMeoABQYE1RzdAc\
+F55p0tH2ndjWRNst\
+ERYK5nCLC9MQmPyO\
+ubG/wrKCPDmvH9qg\
+wMaikyHuEu/BXY/F\
+MZapba8283K3luNt\
+wxbfDypRQKCBQOpi\
+mfD9Ow+irHpzGkl+\
+L6fzTk1ccasyFJLv\
+UyiN3SSbSurjco/L\
+ZgqlBja+/oaj1uSI\
+2njb+AzId2sy0GZ5\
+WZv/XcvsaYdRH+gT\
+jerFF0IXuqqacHev\
+ltnuIrVcrOQpXjC7\
+pdaCReqEsP4vcjWK\
+9rUB+Q70Rtpu17Gy\
+J2asE+wZoaTRoDfu\
+zbBBAgsTUy+wSnuU\
+c9iOl9cUS9abyAl/\
+vZpjb2PVE3yZl+gG\
+cHsDHAGgmYarYgPr\
+WBqdpPk9/ZRoGLmM\
+4Cs3EfKF1wE/40zi\
+/VUcpLQhVsSOdgad\
+eq3Uop1jTvKY5I1f\
+3Lw7T8L66tPnpgkB\
+O8azRyAX0le6TPHa\
+ouJOZsT2tb0EeUN6\
+a2QvYz2HA1Owdgi3\
+a6DMpqxbM3un4VMm\
+HTTvIxeysNUs0HWo\
+uTCfNhxAX4vGErT4\
+Ze1uUGiayMPgIMgY\
+ZQuY4PWK0h3Bj71/\
+B4z/DTDPenFWoeAY\
+xHS6cY1y1DK8k4iG\
+eOhL40I2bxImUXHy\
+r9eofYr8H19XsLyk\
+0bjs94Q/xl4J/ikV\
+tjXbIi/icbGtT5S1\
+3YELyVPYQDXVgjJ4\
+LNqwwEZA1/ZzYsCb\
+3mXGuuSFUabyEGeO\
+mo/3ig5b7NG0EaE5\
+Q90OCmRlQMiiY7py\
+wFTCEvyRBygjYPfp\
+Y7+GfM+Rrz8yQanN\
+fg+pq6gsJruAcEGw\
+cNbmfAHUmH3vGtXd\
+bQj5x0M1ADf+snHo\
+FLlJHKmOMdYl69Oy\
+EGIlDyLp5Sp3DNDF\
+p0FYwUdhCHtcRiIp\
+pJzXprKyLLZ+Mm1m\
+CD5Ey5yz2N6o19gd\
+HVbgJdOqs9i6z7lp\
+Gj2CdleY3TFnJRlK\
+nPaDlgMPMoCTwPcj\
+upY1sFxGXM/3suNf\
+LsMD1rlcIRiAHK0L\
+CA2LTA7yQbPHIFYX\
+oHv2/vYYxEAN9BAX\
+vwdcg+GLeSs6QnZK\
+hsS/H8pNGg3lG9tP\
+VAoGIMelGHqGCdsi\
+Pzow3Rg1s6qkYFZj\
+mwV/QK5laNO/7gtY\
+N+jZgn+dN/PnPJH9\
+kkcY9yka67XnCw7I\
+Me+91j/tQvwjYt57\
+/lgxiLLjCK8j8DG8\
+Nn6xaYLSvSWuv4ps\
+e8LkOh8AMhMPU4a6\
+O0P1CjwHZP87j49G\
+LFwp83Wt5GhZDGb+\
+cDMkxn3yrWKi02KN\
+41XEH27Hga23gegE\
+BWzPiDrif63EOiA/\
+tIRhv69GgbG5muoN\
+cxlGtbcQM5Y3Ipwf\
+/b7WrPizflLR1DR1\
+DiqVUc2AbC+AO9lW\
+jErwzDLbHqrZpveH\
+kFXfUXO21y0U5IY0\
+634YCBhEJi8dkblf\
+XPTkJqivATO8colP\
+fXB+ZJj7UzanH1qy\
+uftEQ29/d3MTelEL\
+KNiJR3w1IJRCOZjW\
+sp6AGMi/VUuh6gpy\
+tbWP+VJj/zZqqcZH\
+zCn5AxWA7Q7aCe1I\
+h/Uk3z73slulJNOl\
+0TVFzxyk5RdE7sy3\
+9x8AvCCP+W+ODask\
+kveG43nBXapo3qST\
+pb7ZaK2kXOOYdVhm\
+KS8tKBmulsFeLOsQ\
+1zRn9xh1RTamhotd\
+CI2tQJ4YVNKW4scJ\
+lrLIO+CCRw1Q/64c\
+uVdOUiL2MZmcJZVt\
+UGAH5LTxNj56cvv+\
+g6Qc2lJXMQY1BJfr\
+3o3L8CktCkzY8Zrw\
+uo2yPs/yg38oXkCI\
+xLUYBOdUV2tjRdE/\
+bqXU0dyWsR6IPW7L\
+WjPGlCRpzY1vlera\
+A9mtOiN3GYOkhdSb\
+hYboC3qFYgNbF8bw\
+JQfTnHvmZbVL/rW+\
+S2zjZt0OD9gdwxNI\
+Xvg1SJWyZpaOFb9T\
+Zx5wJcPAmS0eDce2\
+ORWIHAzcSx3edtq5\
+KAc3Qu5PLqWx3DvN\
+/paz8VFaxL7C3HSZ\
+zNGZDPPHqSvV2oPd\
+MWeN6DQU34fOwzqM\
+3Og8EXScs2zAZMNp\
+BklX18sZS5YoBsie\
+vYhVj3eohTNKTkyG\
+jugFyDHTI5BOWAeV\
+vukQkE7//+wBdoyC\
+B4G5uXC2L3D+/btO\
+/xW/PRFJh+8Z+7ex\
+7Q3br5974a2lG84U\
+Cs2c37WcYa16p2dR\
+CNM+JF3VogA41imA\
+DjA+kPlM6xh/6dLd\
+BwG37ZsPWgcqQlfF\
+30vRHOKJiCz54QhK\
+CgXaJEh4G8Bzegry\
+jdNcCFaaWUEydwrt\
+200xhGLLKwP5VeZF\
+HfKGu4FyHOVKGaYb\
+adu5VspOaUznRLjE\
+jCEpg0w5VTJFZFBD\
+ZGmTYLNzh+RBeVyE\
+B+5BC9UworLWTci0\
+2hx+D0SD2rANLo94\
+qvMsi9Jk74F6n0m1\
+8T1HNzHTOKrj398k\
+ZxZzLGeI0epdNXFL\
+3xLQmcx7+XL2KyZt\
+FMBKgesERhLIqMpn\
+AFTBHoLRcC/LCjzf\
+pHo6cjfg1BFayC/k\
+P0XaJ5vtNOSuOXcf\
+G+iuekPNIrklgJQT\
+6sdRrwBabKhTxm9r\
+vzpjxdNOksoZ0qwd\
+UHvMPVL9g0aHje9s\
+MjyXUkHpLRK7M3Nk\
+OCUnXQggnn78roKT\
+/BzKES3TjE7nGn+I\
+1uq5f/YxRjLoICHQ\
+OcIsTef4ZBNTOLky\
+bBEP/euzm1TddwT6\
+PGLrEi9EBzZbZcra\
+QubQuxrEdpAy7ty7\
+KC9fuJdbo5et9iBe\
+BOI4y2esgCYTqDWC\
+OLEwNtO2EyLjD04t\
+XGbx1ZuPBMzH2l36\
+KmMMtTWMW6qkBdNH\
+zh4cGwMwcRThYIYb\
+QpOqtDYwfvPHl64z\
+dIn+QlSU4VSb0o1O\
+cpaGyXUSSIYKpUaS\
+s/uyzaQcWQ2U8c2h\
+aDgaK9xWAcPPGsoL\
+Ty/HdUR0sodBmrdy\
+uzQeAbh0AZcfNjQI\
+BogyrP7b2ULTFCv+\
+VBmfcBUQQfEB+/Lw\
+0rnH/GACs7o2z/YC\
+pBwF2qrdA1aN6Ouk\
+Zg5dK9BgRc4RCccO\
+DhGuotqHJAFNU15c\
+OCZOurmEE1k5Lz72\
+Hz2HWZ37dq/cgyOZ\
+nLwuSiUOZqYLmnks\
+oh31QBypNCMMuPN2\
+H3dX6XpRWZcct2B9\
+5fcD01ouzYyCjyss\
+Sp65qFCYpogPyy8H\
+Utf1zmooZcaNs/EP\
+IkdCTAx6Y8jeaTOG\
+1AZGWWVJdPx0abCr\
+NivcJVK9w+OxRRUf\
+n5wH7TkueVHs29oM\
+T/5XQ86uTo5NZCRg\
+XN8s4GKwibx40jJ2\
+FDBddM3DTfPQMvJG\
+tZYqR+v9YiWn15vF\
+YvF7XOvfkrZoUs2g\
+J/P9eAAv2Re5PvDx\
+TAMZ+WVRN3qcqrFB\
+eig8xMWSfBTUl7h9\
+ZXlFFCGHFv6MqA71\
+eK5k6l77R8cT7P6s\
+gG3zwNoMEANDZsXq\
+3h11Oo0dsoQ70LLy\
+jsz26MjlUyyPFXXM\
+X3t7Ox8GRa30uHv2\
+rU8OJ+ehHRxWhHe6\
+oKbi+YSu6VN+GnhD\
+E+n4dN0XDSj44OH8\
+j0OZ0teivVRgO9cF\
+63Yflpr3xPL8vkO7\
+iSgFtbi83tGH0H4p\
+YZpdRuQ2/dK2BzOP\
+5+TxLxdnxo8mibwt\
+lefXznSPal69uvHT\
+1V9fd7rjMaeWB4+Z\
+tkC4I4XDd1UNp8p7\
+0JUDC/oPhFfb06kz\
++PeuDsyWKn5WIWTH\
+0QvVrfPWj++pqtAq\
+18/fQ230zSXNaAyP\
+M/IQ7J79LAB7b7W0\
+NvTaIoWFp29VZsH5\
+kfmKokPw7DLU4nwZ\
+edfWzb6p9twBeJLR\
+f3tzIpU2V+Zm4IkK\
+bp548VpQxHdAQv38\
+OO9i1xX/A6v481wJ\
+b/vOSdB/tXZ+ZcL7\
+7W5klVs6/xLED93j\
+bsq3f396kpKWuW/S\
+NJv2FwAM1Rq2ECpd\
+/T39rR0txzLrp6VD\
+xJgVYj3zitny8lft\
+fCrd5R9O5e/zmGBo\
+qVnie7EJ16mSyrgE\
+TZ9gTT4PCJv6e5pk\
+UfVBf6svs6z+vGv6\
+pa77ekWuwNAmKm1V\
+NpaROkR/3o70P5Fz\
+zXm6QUTMcimXNTY+\
+8Xu3d0tvT09vb31g\
+D+J18iHxZhFPLtlc\
+N/5+PLjnV/PJlWQW\
+LyOpaXebtmEln64F\
+HfiubQ60wvAHvE3L\
+Td19Lb0tvT3635iW\
+W65wNOVwXHRPv2Vl\
+Lazmpv2J4y961jq7\
++npVuIXjv7RdMO96\
+Zsl5nTPeFGHEDe2T\
++rstzoejHeyaK7g/\
+/g1SSefflB3T/v6s\
+vPlp7DoakVa6UJPI\
+xvQK+GLxkxsbE4/1\
+LzXpmbT9/olcqMWZ\
+p0x+3b4WF6ZUOOO0\
+NgY6eV2fh+OntF8D\
+3zDq6yMREUD5I3Jj\
+g9Nl0rM2w519Budt\
+sZH2Y9RsMGHoQhkP\
+hWTdvhMdx+bFd4jV\
+6feReQY7SwJCZ8ZW\
+mgooehLDRMdsN33+\
+M0vczwwh4MvFoXkP\
+4WJbnQbiFWVghnNM\
+QToSh4LdUwMbUKAL\
+Btwk3cOjiTlX1705\
+8wF/eHLzjvFRHNyV\
+nmCYvWTurOY/yYb/\
+QhDYwEcOg/jW9mIa\
+R4WQECm3qN8zPkJb\
+5pQvRMWkwMYRfvi+\
+ldzpsyHY3S54kSQG\
+9MsPi5tOOky1E4/G\
+s8zxjtHN+IQ/1J22\
+lYa2wPxXtY9mMc9Y\
+K+bAHD8uRn2qb+L1\
+CnxlM3R7ADnFdxkR\
+rmpJGsjy1lFLTpV7\
+U6d8wi1T8SR+I9fK\
+FFY0xBBEJk8/Z5Ff\
+Bm9GCv4sfNOmBq9f\
+BY7rLLBxniNIc0hm\
++YckH98yMzQqBkma\
+7eE0epozYcRvqI7m\
+ihLmTre+0lynsO4n\
+mrvlwdqXIz3aOgeD\
+ktUUFZjCCw3zac+k\
+6DtdZHirr9SfJQpn\
+/FmdECGlBnCyRt8+\
+sJ+EbQZuodzgWBsO\
+LviCRqjc0nn6fp9l\
+t965i8RsteIGn+Ce\
+yuRbG4MxsZnJ47eT\
+ZGhkf1x4aVwNue5L\
+Q0DmewPNOTNoDWm6\
+pLTXi14KxnZhjufw\
+l9rWadzVatCfbpjg\
+8SetqNzdzPvS3B8C\
+CfSRHDA2mgcFGuJM\
+VN01rt3f5mfP2bUu\
+spvOyPfaobrZ6sp+\
+UPyqYVTd+8yGRIJk\
+AjQ5o0hbWnUiPw4p\
+7zPeoGTzjQfh5XKm\
+Po9GLGYO+hs1XYL2\
+75Vpx8/K7Ek9dYQG\
+xfAxoty2/FgebtA1\
+L7Obgv1sfNjMSvcn\
+QN3AxY8V6oj6aAaT\
+Q09hzkyIfkzKGWf1\
+8KQu7ZIX9YiKnpCl\
+BGW5mPm+Poa07uEA\
+v4mLkb2PRqa1gNAV\
+S6y/Swrwz2bJRuce\
+a2GcBMxEU92Zg/xK\
+raE67jxP2yJvItD0\
++heGxoWc2UqW5VBX\
+9BN/+50vryT7p9s8\
+J7FPqs5IKcayzGPh\
+s7TMKphIseVb9AFz\
+nw6TAnoWbHsiYGKn\
+Sz0Xcq2MbTJRlITe\
+XKb4YTWvQ89xfbqR\
+zGsDnNNyVR85wzml\
+DUywt2GRUPSRwH8k\
+qshbE/A7dQFY61+J\
+Xk5KVAthp+zsWva/\
+B0z6fkXh54jaUQTo\
+rp7Dmxcvxn6ieFTm\
+GsyqYLScKkN4vadc\
+1gWRJbbQ9MwApTFU\
+RwzAnRahN6J98OsY\
+vunr2H4IVNXEbzPq\
+ojZYHYm0Da7AdHxo\
+YcUzpcavISHP8QOY\
+mE+1uh3f+z8qh1rz\
+hkqnlKPp+D8ZOdlv\
+GG4RGSzUCqRl3LAM\
+k8VW1l3bqf89a/Or\
+8LYbPV01wW+DnPmW\
+cuDsqiwDGfLFupuP\
+Dqprx8FY7a6W3pac\
+j0/Xt+JnhH7ex6P+\
+cgaBC442T+jlXEr+\
+4cdyGuS79Vwq6Wlp\
+6elpSXnc+sPeShQr\
+KrOx0s+em4mPhRtF\
+vh2X93m8+rKQILVx\
+x/wt9EWOaMsZ3FzL\
+kMc5TXFHD+e0IiMt\
+YMc/+3nuCAiGnDTq\
+sw32XmV33MklPW2S\
+ORyQj/nIvgyIbcpk\
+Sgq4r3hkPx28TkAL\
+8H42yO/Dffduzo3y\
+qrBavk9cfu71TpEd\
+29LPuz2g15coLamp\
+Zg9b+K5ga7+Ns2+A\
+PAGo+gUmn63PiN5t\
+XQh/nKCv2odbkdnv\
+vUr/uRqnX+BpvoaN\
+HiPUYSfrW3QpIdpE\
+jnX1/W3dHf3yKWLN\
+znB7wIg3FnD6XP6r\
+o2SWZFViQhmhwhqc\
+M63PJXqu5aEvirO5\
+54MH7UU3pGH6trRq\
+bkRz4Po3s2BFaqyc\
+Y/Z+fMkWo0spnxtm\
+F8F9RlV6mgxJaell\
+Lfr8QGZbX81J80Ey\
+4pX45KNRwu4lF8S4\
+J0l8yTLsTwFDsua+\
+VSkF8YmL3Z42Cc35\
+uQYx0EGXTUco3d70\
+xBevk7bPPNTHkfeN\
+nmM9gNh9CtTWceyZ\
+9u3BI+nQY3Q9FObR\
+1EZcge+LWJgJpcFb\
+SPr+6lZNF0j3zxm8\
+cWHpZ5eGRzUsXA4h\
+8n/Vi77wLDV314Nz\
+xudZ5x/rpCwnIkac\
+cqJyetWSzukl+rpz\
+o9d3c+PeR9dfnd1B\
+sQNpLBOOm1S/mC2z\
+9OS0IFSbTm2TY57a\
+Pm9/l5hLfMvvMmyf\
+4Tjjrz5ufjymsUr8\
+J7ww3OUu5ztc6xXJ\
+pYTFUgNE36qu7e+L\
+AVZuiZXxudFGVlJy\
+d9BMjB9RPOzwVLON\
+nx22YF8y36Wujx/Z\
+XBYABgfnqwzLTFXI\
+VEmWKfbmFXWUDruh\
+u3ZjyPf8VLzruOL9\
+3CCu/TI8z37psc/G\
+roxlWkZev7NBpztO\
+8Nap6/Uzre6vqPga\
+TAUc/u1If8AAAMJS\
+URBVAue9xAFb7JV+\
+HRhbme/U+Uq5zgKH\
+H+B3DLB+QluadRe9\
+SSr7EjZb1wXBlMQU\
+uofhihLdAJ+h9mqO\
+hImdqh0GUhWB+Aqk\
+/8Ix4ENlOUMCl5Hr\
+srOlKPcvjvgpLmh+\
+XkPolQMtwayq9/Zc\
+g3D1sRMzwim+0r3a\
+BuapjpynHak0Hwsy\
+NOitQcRvZz58NwLa\
+GpduPKvgK+1JAW2s\
+qSnbYBN6IB/tLmZ9\
+NxiRzfnQV9vJhjUz\
+Ed67zz4+FQFK9Mwf\
+bCQsHrwo6MblLy77\
+mGWao6flwmtpXsPN\
+5Iux/muq0D+uaKn8\
+Z0n9DJuyKQBufB4L\
+uS4ofxgjV220fiI0\
+OBcD0MN3knE0Pz5w\
+Rp7FGe4mSFhmYezY\
+RHAJ8xeZTyQfKfLC\
+hOzj1ynJsisAZmGd\
+y7s9yCmJPHfyKx/J\
+8v+rGfRrhZDlYZ3r\
+tjLYKPd2YmxXe4yX\
+jucV49eVQlVr2Wyo\
+B3Oy6+DWSfYwbIcZ\
+bDGF6xRKRonZc5af\
+MXz96wz7GB5w+c7j\
+OKiUkqk/ZCUdLa4y\
+jsES74roXakDBCDu\
+X0kdPKht3rddytkv\
+5Oz/YFDQTMnlJ6cW\
+C0Wf9W7fi522CMWX\
+aZqn2DnysmtdUc9z\
+TsGAh2CNSbR4Wmxx\
+8JtFP0HDUjOyozjf\
+kuMKFlY0pcuCi5M2\
+V712LIIkCd9rngny\
+9Mt8xxjK5yPeDs8P\
+yxSyu/JsMPsYF3W+\
+CMihLYt8wS99aX0r\
+C0RlX2gLPdzT6zeM\
+Vr7I0j/ij0HfrV7y\
+SOfymx5aOUQtm31J\
+yj1jwD/FBN7w61zJ\
+3e1HVq5zqmvssl6U\
+VvNMWEH7QGN/SGB5\
+dPP29vb5z6/Pom8a\
+Ds0MsAb0BG6V0eeF\
+NGZMxgc/YFeyimwG\
+iZLTxhPZTv562w/b\
+5839YPHUnY5F8729\
+vf3d8vMqoR0sKdbQ\
+kVaWpb6+5f6u0d+i\
+JlML08xYTnlUvKfz\
+tEzQOu47PNfKa/hw\
+aofUjMIT27h9fj/J\
+rIc5bPObv/1da2rs\
+E9um1T+fw1WvvLTt\
+uBLjVsnmHL21faH8\
+EPeyyZrlf8DbgJ4S\
+zuJtLoAAAAASUVOR\
+K5CYII=\x22>\x0a\x0a     \
+ <img alt=\x22\x22 cla\
+ss=\x22position-abs\
+olute\x22 height=\x221\
+56\x22 width=\x22440\x22 \
+style=\x22top: 150p\
+x; left: 432px; \
+z-index: 8;\x22\x0a   \
+   src=\x22data:ima\
+ge/png;base64,iV\
+BORw0KGgoAAAANSU\
+hEUgAAAbgAAACcCA\
+MAAAA6Xk4VAAAAA3\
+NCSVQICAjb4U/gAA\
+ADAFBMVEX///9Nmc\
+CTfmuUe2OQd2KMdW\
+GGcFqEbVqEa1JNmc\
+CbhGucf2ibhGucf2\
+iUe2NHhaiQd2Kfin\
+FJm8ajhWubhGucf2\
+iDeW2Qd2KBdmuMcl\
+qKbllzYExJm8ajhW\
+ubhGucf2iMclqKbl\
+lJnctEnMubhGucf2\
+icfWKQd2JChaxJnc\
+tEnMujhWubhGuegW\
+Wcf2iQd2KjhWubhG\
+uegWWcf2iUe2OMcl\
+qKbllIodGjhWubhG\
+uegWWUe2OMclpEpN\
+dBoNOnimujhWuegW\
+WUe2M8iriMclpsWk\
+hDp92ljXOnimujhW\
+ulhGSegWWcfWKUe2\
+M4i76VeF2Uc1mMcl\
+qOb1NCq+FDp92tjX\
+CnimujhWulhGQyi8\
+WMclpPrdxLrN1Cq+\
+FAquM9quM/qOOvkG\
+87peCtjXCtjGunim\
+uqh2o2n9ujhWurhG\
+SlhGQ2ltKcfWIvkt\
+Avjs0yi8Uqi8stic\
+WUc1mTcVRpUkJkUU\
+FardVTrdhPqNSvkG\
++yj3CtjGutiWenim\
+uqh2qrhGSegWWcfW\
+Iyi8UxiL+Uc1m9po\
+q9pIa1nYJgrdNirN\
+BardVqqsezmn2wmX\
+5aqtCVnZWtlXq0k3\
+NapMxTps+sk3a0kW\
+6yj3CvkG+zjmymkX\
+ZTositjGuljXNSnc\
+OtiWdQm7+nimuqh2\
+qfinFNmcCrhGSchn\
+OjhWtQlrx5jpGlhG\
+SbhGuUhHWegWWmfm\
+Gcf2iMgniVgW2ifF\
+2cfWKTfmtIjrVCjL\
+SceluUe2ODfnhAiL\
+eVeF2PemR6enqQd2\
+I7h7qZdFlChayUc1\
+mMdWE6hbZ0eXw6g6\
++TcVSMclqOb1M6gK\
+aGcFpqdX2KblmMa1\
+OEbVphc4GEa1JecX\
++EaE4yeaKDZk98aF\
+SDZEwxdJ5RbYF5ZF\
+J7YkswcJZ1YU9Dao\
+N5XklzYEwubJN0XE\
+kpapM5ZYFzWUNsWk\
+hrV0MzYX8tX35pUk\
+JoUj5kUUEpXH1jTz\
+xgTj9hTDpbSjpRQj\
+ZSQjNMPzNLPDFHOS\
+1CODBENyxANCs9NC\
+86MCo3LSgwKSktJy\
+cvJyUrJCR/7i4wAA\
+ABAHRSTlMAERERER\
+EREREiIiIzMzMzM0\
+REREREREREREREVV\
+VVVVVVZmZmZmZmZn\
+d3d3d3d3eIiIiIiI\
+iImZmZmZmZqqqqqq\
+qqqqqqu7u7u7u7u7\
+u7u7u7u8zMzMzMzM\
+zM3d3d3d3d3d3d3d\
+3d3d3d3d3d3d3d3d\
+3d3d3d7u7u7u7u7u\
+7u7u7u7u7u//////\
+////////////////\
+////////////////\
+////////////////\
+////////////////\
+////////////////\
+////////////////\
+////////////////\
+////////////////\
+////////////////\
+//////////////WB\
+VVlgAAAAlwSFlzAA\
+ALEgAACxIB0t1+/A\
+AAABx0RVh0U29mdH\
+dhcmUAQWRvYmUgRm\
+lyZXdvcmtzIENTNA\
+ay06AAACAASURBVH\
+ic7Z0LYFtl2ce7DS\
+8MxsdgE0VwoOxTUW\
+FsMHCICKKuXJSbOo\
+G0xSGKjG0OAbmo3N\
+wYKDbYnKWkBjsGmt\
+oOEyXIGNRUvrVOOk\
+tpCy2jI5hmTbuypD\
+ljY03p97z39z3nJM\
+2lJIPmaZqce855f+\
+f/XN5zkpSUHBB20O\
+zZcxacsuCURaWlpY\
+tgYPbsaYXepaKlsu\
+mfWHBO6Q9+5LKyH5\
+R+fkah969oZptx0j\
+nf/YUlMcl+fsHcQu\
+9n0bhNnbOg9Ae14z\
+EjtsFz57kfKPQOFw\
+10tmB8mQmr9SC788\
+wiuoLa1LnnZAANDG\
+PzBNpfWHV4ofd98t\
+qMLy7JCBrj9kI0Ft\
+P1gYWF3v9JaVPnlv\
+48U2rUTwZjcV2P6/\
+Ho8YU+iMlns865PX\
+NqLpcbc9P1WDyO4A\
+1/vNDHMcns89ZF2v\
+iGuLWD2PS9+/fpMd\
+BcoY9kUtmcLFykAO\
+cHXvrIWCIxsgcGvl\
+bog5lEdkrW2LDgQr\
+oO3MbGRscSe8BZFv\
+poJo/NzZ4binB+SE\
+v2AbWxxNjY28CwKL\
+k82fTMqjbFUErZAw\
+EOmCFLjAG43YU+oM\
+lipdlzQ56yfliPv4\
+X8JLb9QK6YWObFDs\
+uBGwLXoseGEwkc4Z\
+C7LPrKfNlXcuCGQt\
+x2Pb4HgCVGsbsc3a\
+vrNxX6kCaH3ZEjuK\
+GYvo85SnjZH48VS7\
+l82Cdy4IZzk1h8+O\
+3RUUINnOXIcFz/cK\
+EPajLYolzAbYBiIK\
+7H9icgn0wkcIwbgR\
+q8mJ3kwc7PBRy6mh\
+OP6YgbqQbAYvF4MT\
+vJg2XbR8nAtUH5jZ\
+JKym5sbE8xrcyLZd\
+9LScC1AzhwkaOjOM\
+SNjo3u0eM/LfRBTQ\
+bLodsEg+vS43GeUi\
+KL63oRXB4sF24IXA\
+dU3KSESyRwcrm3CC\
+4vlksZR1xlTB9D5F\
+iGsne4CC4flqurbI\
+P0H4U45i6LMS5P9o\
+McwbXo+vA7VGyjkF\
+4m9sSK5UA+7Ls5gt\
+uEygGUmIyi7koAFy\
+uWA3mxnHpO0PXvmB\
+4fSZDrqOgawTvgOo\
+s36eXBcrj8Te7wig\
+7r++klnTHc5aXHi1\
+1eebCpaX46wMo2IH\
+B9qB7A1HAHyv6YHi\
+v0MU0Oy/jOZWH4Hu\
+Y2dOfCKHaTyGHuLd\
+67kCebkyM4vx6L7U\
+dOchTjA09ZzE3yY1\
+kXBBvIpz0G9fheEt\
+8gsxyJx2PFEJcfm5\
+UlNzfh5umAAuAd7C\
+dH8bWB4gXwfNnnsw\
+NHuXm8wzHUeYJvGB\
+op3iuUT5uTTb8XE5\
+zH0wOJ5H7c3/UOup\
+O5eONC/uyQzPtPaj\
+k3j28YdLYfFd9747\
+FYUXB5tTnXZqs3sF\
+YAF9u7fx8UBvqbhT\
+6SSWdzMlKdR7FeQB\
+ZDH4/To8WUMv8244\
+vpxrpaj8GCyFvG9f\
+hw8ROphbFZX0nj5i\
+ETNrDmaFyP6T89ut\
+AHMIlt+nhfumCBDV\
+mg44pc5XbEEcd88p\
+OfOvHEY/5nQo5kEt\
+qMk0pZsuJ2j6s2bH\
+ede1QObzjliM9++X\
+JbuQ2svLzMZvv+5d\
+/86meK+LKzGSed8d\
+1fuOvBEJja2g0GVA\
+0N9cQ8njtzoXbwMa\
+d/3VZeVlFuQ39ltv\
+IKgGezVfzwhu999T\
+MTdziTzA6pT8tOzn\
+LzUwBaWXk51hogKw\
+O1lYPkkOoqyst/uH\
+Llim8W2WVn6YG7KJ\
+tNT/nUly9D2kLkkM\
+jK8T96YIYw8P3lK5\
+ev/MlXiz4zC7szLX\
+C+jL/G6+DPngWgyi\
+uQvIjGsKsko+XEb1\
+bYgNxKYFeUXeZ2V3\
+qS+3RGGz34xK8jjV\
+E+jBiWHFabjfhKCH\
+aYHKD7XhFdhrZswn\
+3llE+eVUZ4lSE0FQ\
+hhBXDC4Q3Toy+Y7Q\
+9XIndZRJexpQnurn\
+S3d8zplwEs7BrLyl\
+hcox4SMcTRrgKll/\
+hhK7+BSA7sm8VYl4\
+FdlB64+uPS2djBn7\
+0cyayM0qqwEV6kAE\
+AShEEmN1zUAdsfrs\
+S2YvnyIrpM7Nw0wX\
+1r/E0dc1YFJSIlIr\
+YKChEqOQyLukqUtZ\
+RhjMup4lYgfl9994\
+/4fWJnpgluPF855c\
+TLy1n4QukHfiYe0k\
+YrORbgysqI6pDnBA\
+1ev5ImKPjle0XRpW\
+enpgmuPmXfyRFfvq\
+yszCalHsRb4jgGcM\
+rKKFQ8BXd7oQEcA2\
+3fB2jLl9M4VxRdun\
+ZyuuDOTbqJKZD8Y1\
+woaFWgBBKRw+6yrI\
+JnkjYqP6ZLEuGQ01\
+xO9UaEt7wourTsuH\
+TBJfOVR5x+Ge7Kwj\
+KiAJnCsMO0sX4utE\
+SFjURAlr6glxuo1J\
+jkVq4sVgbj2+Hpgr\
+P2lcecJUoyBK+sDD\
+RH0eAYV0b7TigmhB\
+QXAwwtzL2BQaMVXd\
+FdpmMfSBvcmaZ1p3\
+zq61hURGi44K6wUX\
+VVkHSkgl4WoB6yjF\
+Ius4mcxXb9cllv5L\
+XoLse1tMEtM6w45c\
+TLKLQKkoiUEQGV2c\
+pInxaurytQtCvDAi\
+OdzTaMWs5krmfEhK\
++E4qBIbhxLs7MSTP\
+nVgYNPv7yiolxKOC\
+oqSD9yGVVWWUUZ86\
+FoHgtyVI/kEgHpx7\
+x+pWyM3k+K5FLbsr\
+TBnSpWOuIs2gViY3\
+0g5bR2oy82lFrCE4\
+tvmFoFzVfoarRiKL\
++eslpBanAa71asKK\
+YoKS3dPq/6+ju/sf\
+jqxYu/AY8rr7rKRp\
+qfyAklJTbGyMZkxy\
+8H2OjFbyY9RBGVDT\
+SJuV6IjSCEkmAFGi\
+ySS2FHXpg2uHqHww\
+6P3z5w3333rb0P2/\
+0P3nzLLbdceSVwvK\
+qCwSKlAetHriBdJl\
+DS2fAF8DJSfuM0hX\
+Rm3kD1Rvu+lmNyaL\
+joLSWbeuSRJ8ybd/\
+Y3Fi+9+upbHWCu9M\
+G5GDbGDQbI0FrydP\
+99999y8y1XXXkl8p\
+I4kJH+ShYJcTJjIx\
+klml2BU9Ablq+glc\
+By0oeykjOc7OSmH3\
+nsvHmLF199td1hx6\
+pBT1g/Dvu69MF5KD\
+ZrW4sea8kL1eP999\
++CBIkdK7pqYOPXw2\
+HCVT8j9rvn/vnPp/\
++J7Ll7nrvnnrvvRg\
+GOOs0VUwrddIWwmZ\
+wWAsSI2SkwB+Fnd6\
+QP7k8PSCpTEKn41i\
+rjYvT++5FjvQXB+t\
+1D+O93Dz30u4f/z2\
+D/AIL3gPZWrFi+8n\
+uFbsQ82qHHzjtj8b\
+eXElYUl4O+CGyYJn\
+le53rcMz61uj/98d\
+GHDIgQlLX3SQTXqk\
+8GpGuVldeCIG+++e\
+afPYzVhoAp+P55z9\
+3Id06CPpTps+advX\
+jpbURV5OFgGkPI7O\
+SZDiiigyEN3QubGt\
+sjjzxsAnefte4k52\
+mpPRnu75988mlkTz\
+739HPECEdQ3j3gNd\
+/HqeX0mUDsahG2qD\
+Gx8QehSL0l056D+l\
+Ey4nRZ8wNsjz76yK\
+OPCBJridpMzNZK2h\
+P/0oJr+WQ6+iiCBg\
+/K72ky+vTTz8HjuX\
+vuvueUY2ceObXQbT\
+zBNvNzoDEHp8JwMC\
+p2iaPiM+2K4tgCwq\
+FqTldtrSCIsD2CHw\
+8aSBlwyAqjU34P9u\
+jf/vbkk//4F9jLr7\
+76+qvw//quXbv60X\
+//q6++8carL7/80r\
+/+BZ7yack4xj+Rnb\
+x16dJvL1589rx5nz\
+vyyEML3fDZ26EnnE\
+FEZmfeT0QwO/OQds\
+FMcYsO7i0ZX7G+QY\
+yac91vH3gYDAF4+O\
+EHefJoYQ/BIo8Aoi\
+cRIuDzOnDZRQmRVz\
+IOL3QSfmWzib3+xh\
+svv/wybAB85ZNPIx\
+U+Wa2EaXpmakuXLl\
+28ePG8efNmHjnrvS\
+HIY+ctXqplryZ82F\
+yOQquyx5RWggLAWk\
+0PAiYC6aXXX3/1DS\
+6hXYxVv4RkJ5nWT6\
+ftFKAYWvLYScZ29h\
+PI/f2vv/HyS/8wOn\
+TxIg7hVszxjHnzTp\
+g588AT5PTPnb1Uam\
+a73S6UhYeZppTM0W\
+6XDlEkK0xhKj05d7\
+E7fvsAzf3x84NIUB\
+jU6wRLvwGAEBXj1s\
+/I9DN99bOF+vlyQo\
+FknZ0SUTSrxs49iJ\
+3to90uOxh6RMLX3M\
+Yd68xZMwsLbdYZ37\
+nVIUjIslCHpQMxzZ\
+NTSWVd1ShJUm4/9P\
+tHQVgv0bjUL2BhFq\
+LNmXIUpNIIVyDFht\
+ftZ64TD4LSELV+Bh\
+0vuvPv8o7Zxemm+h\
+GLQxBh3r506TXEsR\
+47a+b0PFI74exbxa\
+6rHs3Y/lkfm+wl0W\
+DlA3/8279eelVQEG\
+IRUus3jlBf2M8IcT\
+q7+vu5h+xn7IRzZV\
+vY2S/5UZjwyhPKyc\
+YOgz3bxf4qh2bnh+\
+4wHB4+4luXXvMdIs\
+hZ72Kmc8J3bjMhko\
+5BsJGkxOcpaYjKmr\
+tMaYxupGFLxyu7WC\
+OK5t/J1dNPfRpTxi\
+7h3tBinAiRUj+lv5\
+OKqR8vL9FluPvlc+\
+S/rzz/Z4VF0vM12W\
+nMYr7KVTlu8nLNNd\
+/GAfLYCcR4wq34PZ\
+zaOg1SPCfYOvyHHu\
+rearJDZJOUY5GyyW\
+QHDYs4uwYG3uR+ET\
+fyTtzS/XScQlBdIs\
+04cFrBVSPAMx+a1t\
+nw39defP4JiGyaeT\
+/FeSaa3q7Rg9PUk5\
+THfqlVDPQ189mgXX\
+MNaPFz2SM8aNacBf\
+NLx/+JlXXrnMobc3\
+CmRNHukJuCHa3iWP\
+Cru+Hvm1988bXXdr\
+IG30XhGXJ3PqFfTk\
+r6WX7ZT5UlgpxEqJ\
++nmExm/btee+2V//\
+x785/Xy+eZlCuRfd\
+c0A0XpSBUHw4SlHJ\
+rZUpz04E7nnZAJv0\
+Pmzi/9UYZf4+TkSG\
+SHr/FpmvFINbHPVu\
+cp2cy6xx77++Z/v/\
+jKa//l6cROpipGZK\
+egwtJGlj+qpCXPSJ\
+T1Gth//gOsNj/x2G\
+M1bE+Zu+Y7IyvPLr\
+GRTkI1gskDMmJNLC\
+u5T6U/V24kNuHW75\
+xxwrgJzbQ5i76b9T\
+fOO8WbSyCMg6ldv2\
+axPDm89Y89sfl5LE\
+SLCEbJqJU1L8/6ES\
+KQ04vwt3nz5r8/Bp\
+zUd9AMb6cJoXEBGR\
+KRiTxBZV9k541j5+\
+1hR/Q+kbzOn1Z6e7\
+bQGLtxkxFNnqbxpq\
+EuU1qDP8QWNLaoHa\
+SI7InN2P79Ith/nt\
+8s25/JEutoG09I+L\
+EYnoAz0rACO11U74\
+mHrznjWEtus3L6dQ\
+ej7OyG3StouFD2J7\
+0cSRplO60RAcnnXh\
+5OUsUd3Ha2md0hE8\
+HN5fG4yfsqISAX06\
+zGNHlUS754UhP7ZL\
+2ClmTu+Ju3mxYx76\
+QyT1Oz1/He4fYzVJ\
+95UE4/9UaNfFlJ0r\
+d+77ZWMkt9HHzzFp\
+bybDZm32wCXemcaR\
+K4Bbljq/V4NgV3vx\
+lpc5l3xdMWjASDbW\
+2BTR4P3RVFldQPpd\
+EM5iMzKk6Tjpcp1H\
+xOaJrG6JpmGt5Sna\
+/J20+9r1beQmNHqi\
+U7YDZLS7Z5113iJt\
+Opt+eKjfz48zD6mr\
+uhx1nb0LdydYYjkc\
+ggsvAgvG4Ptr2waZ\
+OnVmpXtq+aeT+Vca\
+nxjAevJWtOaWuauT\
+k0eU8Nrtg8QTO+p3\
+lXNXVc2rZmVrtYSt\
+15vhGLhT1e77JDKL\
+hTctabx1M/pMdj6G\
+vuYlG3chS1IUSL/i\
+OAEUIwMhgO9mxr3u\
+TzuOTD15TDNYvTyD\
+dJHLQUhOVprplwyV\
+swn0rG08VIj6uev5\
+91ELAMCWxNumMWO7\
+zBC3bXxwi4XCMc6K\
+1hKK7H0deBgkXk08\
+UVHCRqGyTkBtURMt\
+4X7Gxr3lTvcRpOT+\
+WoNe5nkuhKos3e3/\
+IU5+pOGhs18aJuWj\
+ktNONqyZyo7KKtdt\
+zBdsiwkvwmZLbbg7\
+h5fXdhzc3InZsnCF\
+5yeO/+t/fqILuAdL\
+p1ErVFJGJYcaqFw1\
+SUOyAUgh/1WJ9upp\
+aQXYwmPZSmVZaxEJ\
+gsG4t1pVhpcqLKuH\
+yOJTu1lMXVzRn2QV\
+kD74YLqPnwA7zlRK\
+QmkE62ILGNJBJjo/\
+tiw3pUvGM995MUkE\
+AmCzGs8kSYg70YYa\
+3xICQ1pm1JpWWYax\
+k1DUsY9iFPHsGJte\
+ZD0Ag79N10F+QIDh\
+xlFAQ3gn+db2xvTB\
+/28x3YgWBQdlR4EY\
+aGq09aJDLIl2Vow9\
+t72logFLqNB5i5WY\
+U4c1i0jnbGZY26UM\
+4F68A2/ulmpVSniz\
+hIrDT26luWe4jz4F\
+/s1vGP4MDfO5CgBB\
+1OhxNd+vERBmEOjK\
+mK5JmRSFiSGQ+Cim\
+vFI2E0I9LX2wElBQ\
+qFEAzhCf2j98HmQP\
+02eI4GYxqejlsXz9\
+XwXCduG6fG1iDr41\
+EHz/TJJtEKbCk8xo\
+fxdumGNbQf8E/3RC\
+NHzd4LT3TQt3GQ9e\
+HNHJqT7aeD74qDHo\
+HmZHsA7+Jyb/DItB\
+g7GPWX5PgjtDjCRf\
+X4Hvx7YaOgur3x4S\
+g5Gs3Zo/jESAQDI7\
+AixhSFTli/urKq7q\
+nmzu19IgulNMNcq0\
+EaCp2s2fETvKGGGw\
+C/oofGkBI2DrKURh\
+qdrkea3kHbkzWyg5\
+4JGmlc0p6apvE3c/\
+LV6TJ8Fn3FAOh0yp\
+TtH56JBzUHm+uge4\
+7nI2INAIqT8spDeP\
+iDJdNzExxEuEA8pu\
+9PEGyJMfTjRR5yWr\
+oiHJhIISNcceFBiR\
++DG179K2a/rnysrm\
+nr9iCTY4RtSQqPwR\
+5aFTo1RlFqfidmCV\
+PdbtKxU1uLv1AYEd\
+A0rjiNnfgaWYW1N5\
+qDFyVLaFjDggPXj1\
+CmRrZH/zBqHP34Oa\
+Sx93Ly3SUKRjNdeD\
+cbaBjzcWI+iR3Rnv\
+dbOSeV0BohSCXxb7\
+yRX+mLxWPN5Jh9Si\
+aiJpbgP8ODEeYzKW\
+CUuzT9ymRrKmvqnm\
+3q3q6Ax+uFuVz7em\
+koFJ5NahfS4C5XLX\
+IQ+OAbGhpgcIMbgy\
+RujumOtjrFZ+HZNK\
+oz6leopjQHV7/G3t\
+RBh5mbpN6QsUaDyG\
+uhgsojqJicozQdm/\
+9LHywpmZ0zuOG4/v\
+YY+T1MkFxiTzzeQ0\
+7TZo6EiSvCBQM5iQ\
+VNVXImW11ZTd0oC3\
+/CCQ+G6ZaDO9pwKF\
+zHG4spUaON6FwHbY\
+W+vFs6pxWQGheXxs\
+8DIhXijkWopGGMh1\
+o0m3pFTUziz+QFoc\
+I/aNIgwTCYTwlqsp\
+/03fu1D6FqIDdw8P\
+4B9CO0BBv6RdPEPl\
+0Pkp3sMTDh4SyMJS\
+OrjSYhaKAuOThhv6\
+msq2vahgimyEpJKH\
+zc42SujkpF462p0d\
+MdncVen98PD/KE24\
+ySxJrUmHSFpySnAY\
+1vXHlc7w6NvRMWFR\
+a7x9vgha2j8OXze/\
+F74XdF4QxPRqPkBX\
+YAT0ZLIfPiWX5/IB\
+yNRm/6WknJoTmBg/\
+O2Jx7Xqdrw72LuH9\
+Z3k0MIch9IuimFox\
+scpMEqzCQX4Zlkdz\
+rgJDe6vq6pmbpR6o\
+S5vrngd6BQ6EehkH\
+opLhHuUeFYaiElaE\
+D8/DjG+MkDs4QWqw\
+f/KkRJciCabPC45S\
+Bncy0RNJY0OQ/89I\
+xAo3COwAvess/r53\
+MxFi97N3IKIX4+pD\
+y0Ip7XGiX28ZKpuY\
+ILxXQdaW0MgQPVjc\
+T1KDmMMMv6OZcIC0\
+kRXgdEBDIyMbwmI3\
+KKG23q7A7z80NKeb\
+gMw5DNNAd8HpdTU/\
+MEjeuF5ggUmdfHWt\
+zPz30iST+ox+uhhk\
+KUwINmC15eCYyEie\
+qaAPH5DCt6qRrRal\
+6yLhqn3G760UdLSn\
+K6iArgduv6PlLDoV\
+9WTCRGYnECzjW+ug\
+YFWN4PHU7LV6awSu\
+xGu4MsaEpxVPTNhE\
+NBVBU2eFgSIjJ3rk\
+JM0GvQgU80vg/Jhg\
+1yKIq6iI/zKtMliO\
+oaRF2Cq9+rLIH85J\
+sIW+/Pq6o+UlKS+S\
++8SfYH9DvrUAyMkb\
+QSQlxiRI8PY9dei5\
+uKFG5SfwnJTSJcZq\
+ZiwSKvzM6YGxVBkJ\
+84sgsXVSEjpwnnh/\
+yhG5dVvAV97MXn83\
+nldlbamyzklSZzLf\
+n8NMDJMQxsy5bWjq\
+5QKNS7RVGmdFIMAL\
+bB+qpqDG5RLuA8nn\
+o9po8kaFaJdDeix4\
+bxIddKZ7kgI/V28V\
+RC0l3GQS4dQ270ma\
+bO7WFZdRJK2sEzGE\
+I9pAEE0cUTGmFuiI\
+FeqUU5GC9zpF4f1y\
+SWKI5RfKZfWo9Lqb\
+Glpa2jN9Q3MBCVrK\
+9RBudlTrYNcftDFb\
+KP5FjIeTz+OPoFWv\
+Ib6yjGje1nMc5tKt\
+9EyR1J0YR9Ew5OGL\
+jRvzZvw90yTO2DQo\
+9h5tYRxiD40hcCUB\
+p65DwG5OdpIJHIJ3\
+Pw+aQkUQLDvJ1wgT\
+AQ2NLa1hMMRRRYiu\
+0OsK3J4XII5tRVMX\
+DZ/+ozBrdJB3CIGj\
+VwlRgcHCTvpsKuEk\
+uK9ZhwTGEFHC4IBl\
+NUchNmvwY32ry1O5\
+hmP2oQVYdEjI+vw/\
+2+jAdpVtnj+alHVE\
+YDLVva2jt6gwMDg0\
+lpyTYkTgpaO3h9KD\
+NpQ9TAVUJyUjI3J3\
+ABXY8TYgksu8S+mD\
+6IP1+wLigHFBbhwi\
+LSKWm7pLns0sosbX\
+VlTd0zzZ3d9M4K4S\
+FSXoMK7tgRDoWCoZ\
+6u9vaurq72LS3YAi\
+0taKgVT21v74AlBs\
+IDQ2mhwhYOd3fv2I\
+2Gggp3TDAEk2uI4D\
+C4ktKsubkxOJ3+yD\
+qR3Fu6HiaepY0Dk/\
+q1hODIqR3mC3HLKz\
+hhKBtFCPuUMl6xiD\
+IjfR7jqCvc19nZ1L\
+SxjoipqqYPTQ34jQ\
+ZAe6jgsKssmZr1lR\
+2oBvzcVSZwnEvs1f\
+UeAq5ZuEBx7Dif5E\
+kmTTHDg8KrFgycsN\
+W4okD5qFoKyr4Cxn\
+bnhKsv3Nm9tfmpuh\
+pCAj9Vo0d1VU0kKk\
+uOxrgtMLG+SlZcyU\
+HZlgRQevr0eHwEZZ\
+O4iIMnGH8Bu0qnh3\
+hGcvBheuzhMO0exg\
+3AUgEl2Sw4OMnWQE\
+Ja14xrCtNlpizADY\
+WD3Z1Nz26sYwCqqq\
+urqxg3zq8OLdtoEF\
+w7TKtmC32E3umVZU\
+2AOg2G4/H9Y7izCz\
+vMd3Q9Vk+zsJAIZJ\
+lILx/JSRb2a4iGf2\
+1u6uzuDpLdTi92Qb\
+AMdndva276y8aaKi\
+urVhRHnrphxS4DuJ\
+5oNMRX+ii7uXJONh\
+0ouEMuGtffRld0UI\
+wDyb0diw27MLZ1zg\
+BhxXt9DfAi5pMYB/\
+5CE0rLflNZWd3c3L\
+wVOMKjGyQJ1tdJRj\
+qbkf21DlBVW8ISep\
+P4SSSR5MJ+tboP0Z\
+xSBVdy0KLaTLmR31\
+qP6PF9YwlCLjGa2K\
+PHwqzucfWReyjDCj\
+RDzI+Q2ywHmfYGOw\
+vNJG2rFHqRBSTEQ9\
+FUq55Q4aXIrrqaDU\
+GUe1MJcn5/OBp9li\
+8uwJWUHJJpdkn6V3\
+sgOxklPSejo4mReF\
+xv4RXrJt4DqWZmxk\
+xtkMVBNPhsoXmkbZ\
+UKqmSiMujJer5hpL\
+otasoroVx/ii8ggy\
+spObQ0E9XR3xHeQm\
+/NGxtFYe6tuB5zg6\
+t04T9njzmn5n0WvH\
+KTXClylzWF5pG2/T\
+oFAmtWxmmKp2SI0e\
+BGANeugoOQupEv/p\
+ES1aZ/Me1YRxylx9\
+MwHIu/RYqB0bERPa\
+6HMDIU51xOd1BKGd\
+XbYuXYhy8e0JKu7w\
+DNTSxsjWViUW3wn9\
+V8jqVZ67UawPWYwD\
+3O6X60xGQnpdcFxr\
+h5PGEd91bipHKfPh\
+z3w1wn01xtj0g9pK\
+wkHDFmKnxka6FxpG\
+9rkoCQ/KOIbYKnhX\
+OUQiBdBIJcyFR/1/\
+HljIrDNvuc8WUn/X\
+Z3QI/pe0mQG9FjcZ\
+6aUNEFQplV4b8pNI\
+70bY2kLLNqpFkp5J\
+ZMsUGUVhoVx+vvKg\
+vFYZtbmvp2S49sQ/\
+Hh2F7MDX3Syitzw6\
++eQGtPUHBKfV11W6\
+FpZGCrjfoyZI1ydi\
+kGZYrJY16nCRwkJz\
+6+zWTgSkqmzV2SNF\
+OpVbh5AsPoswP796\
+FPyOkdNL4xblh26M\
+njb27fwa+a0ktw0j\
+VOIr2+A6nbZDxbbf\
+RzCiVlptE9Wk3mrN\
+G6W9kVAm4RlFWOpz\
+hsU+deYOUzDdg86M\
+M6sRhoDf0PXSuk6u\
+RP0sreQFtPkN+jZ/\
+rgznsnpURG29ngL4\
+1ckvjMpM61GqFrik\
+YjKjgowLfypVKCQ3\
+bYoiVKu5upgdVDER\
+4HfxmP7/4QaHX2/K\
++cfy1m5hTkOEA8UL\
++ppWPHwCCvvXGNjo\
+f6upvqaioLTSRNq0\
+4JwpRZsmmqRK3BPx\
+uN7lbB9UajvXzJcc\
+Ehw19dU2vNjJIL6d\
+hP3vRhsdaMOQvOX2\
+IZKTlDjy/Q1tsnkk\
+op7QR+f1l/wPOTkF\
+Qr/9VGmVklMcZCgN\
+UNePpTJlfZBSj5sm\
+mBQ3b4yecuuzM5OU\
+8g+ObQTz9useLskx\
+adf+3tjJZT5YdH3Q\
+2B1o4d1lctd3Q3bz\
+yA+ZlxmAaqiaJSdV\
+kac9Mk4FqgtHucLZ\
+A2OEJvzqnnXris3g\
+rcsnM//YEUa06fve\
+ArS65NluwQ+W1qbt\
+vOLzuHxU20WH/Nf1\
+1feeBV5gYJmYBYjF\
+jXD9VGKVY9Y8oqG6\
+OszytjcNSmHnXyqW\
+dedNFFS5YtW3bhhR\
+eee+qnj0oFTbJD58\
+4//9qUhUZtPSQvIT\
+nyDbIMJnzA8Vudkp\
+Gx/DZBNaUu8kAzJC\
+fkilwjGH5FNTnTZF\
+bgcrWDZn8B3Kcb35\
+ZPHvhjEC786sITGj\
+a1tAUHknS1AL+nDg\
+h+qw2gUvhDQ0ln4m\
+zqatmGe04aGTYYQB\
+fkon+gC1j2nOTJDp\
+kz/xxwn26ZoNslRt\
+wujz/Q3qN+ZFW6qS\
+jc3VRgfqtFP5asnm\
+qJkgrLWI1Xs8VFWs\
+LmdkMOSZAhePg1EB\
+VX5AqiONUOmzu/9L\
+o7XIwW0h8nR17qIX\
+kJRnjaydBRPwr5Z6\
+H85xojGcvyLbu6HP\
+xiO+FFwDWSSi66ni\
+x0AIAjNm32F845/z\
+omN+I73W5JgK4GX0\
+t7L78Nk2uP3f5XCP\
+2tkRo+RUWXatS4AT\
+ZeA4xamOAINn8jul\
+1oAN//UJ1mUpE3g+\
+LvgiW/IAEPBz0Kks\
+nQtQGSl47goCo/6Z\
+MIfdvzyM9wPS4JPn\
+NvJRs0CFQehaRyd2\
+MjCXDkBQ31InL1VV\
+XrTy40qCQ2C4q/6+\
+5ws6AnQh81Vz1EP/\
+zBVJ6yyNV7eDC8PR\
+/+s9Ioltx7utjgdp\
+RUMmp+DjBE70C6qd\
+CEUtr0WSR7cblkZj\
+JC1HMWFB8EZxdshR\
+RBf3XvHj85wzCwS5\
+7sJ6GnGvKUPY2CGn\
+9l5D48fvMV3Gb87/\
+zzl/zSrZgcAt0bcM\
+c1728Rt0rTEBgJb9\
+/6zLvAb7WxAkijIy\
+XNHpWtwGaLX0BjCP\
+2N7ehm2ejAhwpNJX\
+1Dxd91bp5uGs3lbv\
+AHOnr6eN1A07ooEQ\
+AAA8RJREFUnSbvB4\
+URzG/irhupF8CN92\
+lZic3UUWlZNIDgdq\
+N+E8ZKGEa5pbWr69\
+5C08jYcPF3nSI7g3\
+kDULurn+CS7v9D/9\
+1bn50Qfr+xVougKK\
+BQTCZ9VVfJrpbXCu\
+jDA22Cm8BHKvHGxo\
+sLzSFbmzF3/vk//q\
+WbdbqY/WetD9znDr\
+V2pxU8Y7g9R35qv0\
+mVrCALPEmEZ6oVAG\
+4NZCboYhzlJEU4Lr\
+yPFRpAbjYNXXr4sd\
+tl1h6bAO6zrTc0GG\
+F3/puz0Oz5rTE3fe\
+aX3cxg67biKNYqKC\
+nksPq+VOiWnxg7bM\
+58VvwlMeDX2iH8J7\
+5qG+GFILr7Jbx9W1\
+NdXWUmdypVjpMbVl\
+cpLtNCXvJyVY9vbN\
+7WzT9IEmxMYe8Tbs\
+xmzwX53ZGMHfafKP\
+71ivKPfAkVc6G0gu\
+/uhBKiZvwcdE1yIA\
+ZxWfc+8z6SjU1bu4\
+OGD9uFkzHb1Nh473\
+GFbul3xabNRsVfUv\
+nhmtC7CfLPYMR41U\
+88Y18a7N7anEKElQ\
+YASdnwC9tqrllT92\
+xz946w5Sd8epOr7V\
+70PV7vY5sxZ36psf\
+gzmRciIMpAkxYQpC\
+gMb7cQ4RoDIakLK/\
+UHPeqeam7r7rMGFo\
+3uHgr1tgeSYzvt/Y\
+2NG2QvpdeNg8/t9n\
+gDre29wQH6NQzSh4\
+vozWjsQ35UhKDC1V\
+ZSs+q7IhNr6kBfW7\
+u3J+MFJXUo2NPeki\
+qyNd573nGFbs882y\
+FzFvDiL7UEvYFAe0\
+eQ9KJFFOUpV5TQ57\
+/DYQiHnc3Nz2zcWL\
+exrm69jK5m40Y09d\
+mmpm0Aqy/VR1cHwq\
+Gu9taUwLCtOu/4Qj\
+djwQyKvwt+PJ77FA\
+i34K+3GGQ3UShf+J\
+fbx78psJ6O1i3jE8\
+PQPv0e6uJ6t2za7C\
+8suuDH6eFD5sMqJA\
+gjpCDM5QsXBgdCvV\
+2tyaOYkdnFpx03Sc\
+Jamob7ztKUH1OhL4\
+AuBgbDGXxxCbXdkY\
+FQqKenNXUQU+1eYP\
+ZeuAhQGJudgftktg\
+F19La2d3X1hkKhoa\
+HIkBnk0MDAUATD6u\
+pqTSOCGXV2aZFZWo\
+aKv9J03WdD8gZvST\
+NoJbd7rzjv5Pd4R2\
+QB7DB048Q4/DZ4c0\
+STFNmqSxYeX5RZLn\
+YYuM9k4S+F3LK2VV\
+ect/BjxbRxwgyFvy\
+XXbngX5bbqiksWHn\
+d4oY/z/WoHzZ5LHe\
+hEYQsAsNNOPrqosf\
+zYtKOOX7jw0kuvuH\
+FVVrRuvPGKS85beN\
+rxRxersgLa4Ucft/\
+C08y655NKLV91446\
+pVN95roISmwuPSiy\
++++LyFC4/7WNEdHt\
+j2wTwm8v8Pkm+rFs\
+KSnCYAAAAASUVORK\
+5CYII=\x22>\x0a\x0a      \
+<img alt=\x22\x22 clas\
+s=\x22position-abso\
+lute\x22 height=\x2249\
+\x22 width=\x22166\x22 st\
+yle=\x22  top: 297p\
+x; left: 371px; \
+z-index: 7;\x22\x0a   \
+   src=\x22data:ima\
+ge/png;base64,iV\
+BORw0KGgoAAAANSU\
+hEUgAAAKYAAAAxCA\
+YAAABQ69KMAAAAGX\
+RFWHRTb2Z0d2FyZQ\
+BBZG9iZSBJbWFnZV\
+JlYWR5ccllPAAAHX\
+RJREFUeNqEXW/Ebl\
+d2X2u/rxBCCCEk7k\
+jdunVJ3XHHMBVCKo\
+RUxjC0OqaUofphVN\
+MvjaE1NbSG9ktDCa\
+H6IRKlY9IZMzoavV\
+q9xFyuiUYuISbmao\
+iGEC7h2avrnL33Wr\
++19j5vbjx5z/Occ/\
+bZZ++115/f+rP5h6\
+/8KRUSov2j/2cmkU\
+IsQsxVf2X9z8/p//\
+Zjpqr/Ff1vu6bYNV\
+s72/ft63b9dn78fv\
+xPr4f22tUMbbYnCv\
+5f+5H7V7Xfhavdsb\
+8Hz+1t/dPXg2s59E\
+/78bj24yHozwP6uW\
+LtTn1rzxpNcW8F29\
+7HpN3zkd77wRjPbZ\
+y1vVt8wfj4e7RxEm\
+JruZ3n8J77HLHsfa\
+z7Pds8nGjd/7L3jt\
+Mc5fFqv0j/f+l3nv\
+b29+u2Bqr3o9JZeC\
+b+83PFxinT2TkSpQ\
+0CiT0AL2bBAadO0P\
+12FnhAhQnyiWFcAP\
+tgSyfGUyCqcRwHUG\
+wi9uP+PKSpQJTc+0\
+F0TS+6T9u51k9d1d\
+/v19MPax8u9Ql8RK\
+95dPRzvFeBd6W0RG\
+LfYEJgMdjQwKQjAW\
+5EuWjvM23j7f4u97\
+SP72x91H7d0XY+1d\
+/u6nUf6t/39fPxeP\
+a4vxGJz0Ve6IPI23\
+zUNp87w5HDd2yLWP\
+yerW9jzMcYdRoYRL\
+e/G8cWfQyq0wmctb\
+nXs+dErbH2UrW9mF\
+BqdLxre7Hx4rSv1N\
+iB8EL7X+7DUoG4qR\
+OW2KpqE9GuLX3gCN\
+oaK3PiopWvabuXdY\
+A2jnZJf7usnwdZ6l\
+X9fn/mLsilkYBspL\
+d+CRKKDtNGvAcT18\
+bA7y+hzcFdauj3ip\
+vA+fu0jev2O9cnUR\
+LxxNHkjrb3qR7f1q\
+58ov28oz/e1o/+5U\
+9ojJ10RrqNbSfOIR\
+Hau5XAdHDhsfWx2o\
+Jq0rOzC+600NsS5h\
+XfP3jfQbBj/Nrx+W\
+DJBA/fxbmtKGgWuA\
+FyOOnk59du955s+g\
+a3bNwYWXgTqU4gPk\
+AM5/XLA53wtgm73M\
+XqZT11dbxIHADxQT\
+cFIIvfg0kQiSKxCP\
+xWYLWLccpGaFn8cT\
+s/1Ixt8XdOg20MFS\
+AuEpQ0oD5xXRHylT\
+5/18dP/u71o41A9V\
+i5Lr3diJXe0+l9f4\
+hjJwzvU1aJdsnWJZ\
+xJCKk2rkVAfPMJOR\
+n0B+cJVSdJdNO+n8\
+9CarBYgcFtEyzseh\
+HDgwdhj4kb322F2c\
+o7WVeNa3AQ0PfrPV\
+/exK0eX9PjK3r6ih\
+4/whQHPagZ/bm167\
+Zb30oifO73chKp2F\
+7kp9XGb3AHTmJxfP\
+f3dXHHSUXa3l3qgg\
+jLzI2jxGmiefSBgm\
+KD11WzD4DRPNw/T0\
+Z9VT7Te97WFt7ZOO\
+6mJugzbqqOeHdrtp\
+g+K/ZpDIATIVGwIU\
+zn7GM++l+M6JFIV5\
+zZ7ZXzqGQ3pTnoK5\
+n9CiWi4DDZqGyjii\
+BGNGEyL+sTv6J/v6\
+wD9qQ++5qLx5om2X\
+UmVxEqiN9BTDh4td\
+N9VxFoVhGODK0qTU\
+S5qGPj5iUYIDLxua\
+UB03Ve15TXKkIkIN\
+BNRSYVYTAQBr39yO\
+AA1aCpCyTXuwTy9l\
+nuams39bFv6Xve1P\
+l7S9v+jKyfMi0cNL\
+Skc9rKpS8blIDIEG\
+QyToPOKMAxZYilxM\
+ZdoQc2TrXT91Cu2Y\
+wYXA1utZlBdEkH9F\
+k9fkZPP9VWsyRr1p\
+V3Rs6Kkz4WkJRm+U\
+sWy2TiPC4wDhM58A\
+DTs6Vzp+1dVCS5uO\
+uLduduTWSZASazJj\
+WrNTUYOn3JWL99ol\
+19GhyHko4tNs6nRM\
+A1EOWRJAgLRSZx+q\
+g+4+v69+vO2eoN/f\
+Om0sANpYsbUQLunA\
+bEv4t873vijDImWp\
+bqy+jTeeYYwwgx8Q\
+AK6XiFQbwFpgGNm4\
+3b7Fac8P369Gf1l2\
+e1vY0YH0c9w59RTB\
+MMnKy/7DTQXao1Ec\
+1GDhW4yNCNBiG1SR\
+MYqAEZDU58MopiUE\
+VsgLvRQGixy7zqMx\
+dGLumwi4tAvH8seJ\
+4seDZuPxlNXCedlG\
+3RNChoydlFApd3hs\
+RJRO8M5KmOkmxGlh\
+Kn/Ex/+4FO+AfURf\
+xY8gWMKzGpBu+UFh\
+wlzIXHmPzrK3+yd2\
+qILVxJjlNy4pTFRO\
+Pi34P6UWLk39Vrnm\
+1644G4Cvjn6Bxa/A\
+hr9IE3LFWgT7Q0HP\
+A5JFG3C/AUcOW9fc\
+PjuC+yutAB4xJziK\
+tMXHmFsV6MV9LnYo\
+GZI08GE0fi2/u1UB\
+2iYRLRzBkWi1q4qi\
+K3lPm8oXTwekcBJg\
+On0ZMbwf4+bKpjXj\
+iNUXQuWRAKoGIcx1\
+4SMSeuJlY6pd+nLW\
+wi4Ef6+T/9vKbNf2\
+2DazgJNwHwYXC3ap\
+NZAxY3rq27yCYwAC\
+StOJ6mq4lbJ6IsNh\
+yeiqgEiRPlgK4yiD\
+70JFQTSodfRhvtWh\
+ufgNGKLW6XHEIO4f\
+jknMK7be8ki3fFMR\
+1QDSIJNtYSNeHmAK\
+EgDbu1B6qFJEeIYx\
+r6jOtKN9/Vo3f1vd\
+7VG/9Cf34kM5FqRt\
+ApMLZBR7zA0cv8oh\
+wUJk4QysZBdqu8NX\
+hVz/+tHv1Kifif9c\
+rntINnbTUUIA6fRo\
+RvULxlCL0NDoD1Im\
+CE0MQp86SxiaWIz4\
+1n7lIC+kEJq6Pk5X\
+DCOZu9PeBwaP0d+p\
+PrkNt9u6rBZKJ8qA\
+Zu4fOEOGCfd+B6YZ\
+Ay9tiA7QISKHMlNK\
+ikj4Vr4FG1QIZSk4\
+3C4IXbIbzv6jv9r5\
+75kfb3eW3/jAGrdp\
+YyoxB5HkrmZkIIi5\
+TJEus6n4pq+k/99X\
+/02wt6x8PjJZuHoB\
+HG1qHokcAn+cv7ZJ\
+BN/JjYedVKGOBhiO\
+wvL5zwXJm4qkFaE+\
+GUlYUAepujCS5R6m\
+T4BBCcx+KS7g0Z+J\
+5M+mGFsV4B0yiumx\
+J11t+JE9ccALgEaB\
+y5Z/KhdclYgmwbiw\
+7Rh/HetS9SJgFdv0\
+uZsv/ynH7/oR78Sj\
+9/3tU7wGQ5oRVOeU\
+NnLdEt5P5QF3Ft0H\
+qnvqbHP9fjn2zYWN\
+Pdsp4ny5cb/ndJBO\
+Cck4NP10QS1bCWMq\
+ENQhFyfQWJDPvWxG\
+iyAhPWlrkuT+4DWL\
+jMafI4Ep5IIP72Gx\
+9oirIU1cihKSyj08\
+QNwwIWwJ+h3wPOi+\
+OLcB9P3j0jRlucCw\
+/YWEQ16Pcq1uWv9V\
+m/1OPv6eehRrhAH4\
+KSR0xNKpJWU2Si3J\
+wfVJ/SSfqF/vAvOi\
+DX0deZDQoTKv3lxo\
+ANKCqMnRTUjpKokA\
+jVLCZTEBFAX7DM4m\
+JX8rkmJZt2ztImiQ\
+3tdIJwWH/lZhsLzR\
+fbyiXH0X0LhCoTsH\
+QC7A+dFyUs3ov/Ra\
+9dvsdUDUlcFqQWwz\
+g57lwnr9m8aKLHxx\
+ejPKjH39E2f6nH39\
+Er7gsL34zGjhJvhq\
+IEnU1scAfF6/E/6d\
+//0FNP4EAzGBhoUN\
+iAcyOo3RvBbCKDGN\
+qY3IkUjBaii9x1KS\
+AC3GeTiAXgOd7TJ0\
+j68hE2vzHCTnsblZ\
+dGC+K1JholCMX2To\
+t3jRYuEmoFRkEA+Z\
+AbFYixjjNSlj5pzo\
+iCSICJogRxl3Sc31\
+ndCR4vKRculq6/Pq\
+Dtfk9b/oUePy1JvR\
+oLYDfGSwexax8c+L\
+fBPe/qTd/M+FzuGB\
+IUupd4QBaSFW+hgY\
+Jm4nbCiBw0DopcsF\
+JlNmjM2i0L7h6NFu\
+pgtXRdaFjRPHSfrM\
+QLHRgtEtQN7iLS9N\
+Ouc5txVhPKwAJPKR\
+OURlTDmKAqEz1MUR\
+kqaQ55IYVEOATYBD\
+dtJnsI94vBiV2C2Y\
+ITpKErevzv+tmY3v\
+0UEJ7uVh3cxF1vdK\
+YvvFnar21Kq+DDF9\
+YwAsBZD+RueXLQg6\
+JxseuI3YIXC+HqA8\
+Rsv8+DUvpE82Qhr1\
+ZwsUCFDp+wTP4aBM\
+QHsF+4ggZZzc+PQR\
+zRuMCFKoELDiPBiF\
+PExsh1Vu6OLQF/9C\
+kYH0gowbgUn1gGCG\
+i2ASCUcAoVFAt+Gf\
+1qc7BGUff5Yj58xv\
+CmYUgkQIjf1N/+W4\
+8eRzRkN5xxYBv10r\
+9px17wlV2J+ZhFIx\
+eMkzNHxGTPicESYM\
+EPg2rXyYSDch5xQA\
+/OCMHC4/ksUx8Hsa\
+TVC9wIpYZAgG/kQu\
+a1YUrhYtFnfYQDcu\
+J2PJCMjmy43dG5tk\
+mjOoEtQTXhGgKoaX\
+G1v3OZdV3hpVcpEP\
+0CvWChSZ+PqgMBE4\
+mSucXJ8s83Yxqx8Q\
+IiYlOEXttk/+QPhV\
+W+DMtaKNFECwuZ6x\
+zymzidrWIGkIoBlC\
+/iLrdkySHRsOFzED\
+CwIPIBJrdraDKcgo\
+vTruPJ6l6pDoMb+j\
+vWJZF4DOrQyYff2I\
+F2N8bEPHRHvMI5ep\
+bXkoJxOCExcsh+2t\
+yJhSNGw0oORT5io4\
+3DC3ju+uyxPLQ5Z/\
+T4iTFHZaxI/fHv9b\
+Ln+cCrwlQPQBsBOK\
+lMCrJHHNEUsCCTSB\
+1GU0nGGE2ruhktZc\
+k53JMihvU1YDt6oX\
+YxzTXERNbgaSmgj0\
+YYSYKTgBe+bbdqkY\
+Ohfj5Ep0NqjRgN+J\
+68P+BgEFnAbY4LB8\
+eAyIyLdkJDo2sgDL\
+PTpSYm4otfmA7uoa\
+BbBjxUVlKXH9RzP2\
+kQEzUcUz/P6RP+eO\
+VnJgh0FSqTDjHyeo\
+b+VQh0ruFeWoSJxZ\
+UKxF+5p1ycAVH0/B\
+WJoWPMx6kPA6pyNa\
+MupNXczvDICEROFQ\
+g8yJjvalFQ8j2vIK\
+9hHaNHrHBEAnzcxN\
+JPUAJ4ny52QqwJBr\
+17Yvp+kAy8Fu3oKg\
+7pIZxw4JwHZoE5dU\
+JGuvR9VD/fN6VHT3\
+5/tnjjimw6k4tf4z\
+IQp4cuyMBZhh+OUG\
+cSEDmQV9QnB1MuBn\
+RRuIZBmMQicDac9H\
+VUTYZWSvCETO67AB\
+9FXQt1NgbDDY2f4H\
+OnMi3Qi4I0CCJ3ME\
+SR86IL3J4Xi6aAa7\
+mE9BFKILxQDEyOTo\
+uYRsIH4XV1wmORuM\
+u0cPpY/L7O41XV2M\
+qT2wGKpzHBWdQUiB\
+Uc1liMpu6+ZCabnL\
+EinIAl5I6ESagdGs\
+krdQFdDNbn8EZMCE\
+O1oYKoqQCGS1c9gh\
++YKWW6lBD0IBBwEq\
+LIJeKrA8vMqRYXGZ\
+EVUYbRtoxYzAODJx\
+hoh7azqUct2asapm\
+w5SUAwjkJIQDWyKx\
+M9VYN7en8avSxBeH\
+TCTIAVn+l0vrCJ8q\
+dXWXaSpAAnrjjEU+\
+B6TJYhxws9CO+vpo\
+Vh3ktvR2gKt0VIA1\
+MJPDyOAmfx1GGG3J\
++smNd+LobHoY+cek\
+zqyv3aHAgYreTIxD\
+5pwiZyObgPI9eQvp\
+CHYWcKVRtEijH5C6\
+s4hL3NVoB53pLUAR\
+HqgS0shqG6JOCsAB\
+izwEg0RB3cGD0dLE\
+heqmKtX/TU1tKjCI\
+wO60+ozPpIWpUleo\
+n66j4DhsYgtkoYxI\
+Hwx2iWNUAdXXuYoT\
+i/87DGMTrblXa0kN\
+2TU2n2G8/IhEwii1\
+N8I8I6Iy9/wz1k4a\
+UJrtQRrZWMlPY7T/\
+7sHJzhzEImRwctJF\
+5WKRAZQIeI47pue7\
+QFVwIN7M8UXiIUY4\
+FmaIohumpysrBc2s\
+7cc5Y6/LXVQN05Vq\
+5OCrGsuFvtVqZdXx\
+eDEXUyg0kAoEaYJH\
+sYOBCL666mizGHEL\
+hchIBTTGVW8mnSq0\
+pSXWTponNssi0QxG\
+iDFc6cgiBm3TJPdk\
+xym8PHPDGQJySEJn\
+EMDCYk9on5rEOoYs\
+dnBxwmNiqnEEuaxy\
+TgoUzBeK20ylOSe1\
+tLd7IoDH5YBENZDv\
+ygMhFd00FpAZPUoE\
+sZpzQ/tQRvhUfRtG\
++r5K3heXAiLSmnBa\
+ahpXwAB59z1V13qo\
+kb1gVxHJstwcuTC0\
+t01QD1+Gig0NKzFS\
+e/TAsi6+DZykZGgF\
+FgqIeiRPO5lRCmVz\
+CoOzseEoQ1heQFF2\
+mO+dzPvb25JN/Qzy\
+kmt8ME15kb2oukUP\
+oQgT6tRNDkWA70Td\
+TlZGEg1PBsEykSLd\
+ARMLtaZF5lRA6MEI\
++0ljkMd9buJGO3nA\
+LDZOmFGf6raaFBqs\
+HIaXK0Ik+kWKT8yg\
+tEyUAJ+fEiIfGNl8\
+lhtDSy8lgMHNtD6W\
+T2NMEiY6HlIoPF+4\
+PNJXlXr3zVNbwOJX\
+DPAl6AwzkkXkJuJC\
+/1DPfEsLndDBLqf9\
+t1EfQOE8wcn820dv\
+ElH3WemByUa8o/WO\
+8eh8lmqXKo8tNUlZ\
+GUhzGFAb7JgbGmck\
+RuvPL5Z1GOoHks5V\
+OX6kAMpcsqB0/oh0\
+iZkYK9ryXEIOQI1a\
+H+DacH6rliKED18e\
+tpM4UqRFCYdLmrn3\
+8oHYp4Ubv1iQWhcg\
+0BnEexKAN0j0aDxz\
+fmgShc3Z2XCB4j2d\
+1rQwGfNHEm4HOWNV\
+SyAsDHREwBIUygV1\
+MgMFMRhGIFDsIQPj\
+m2MBN3ZlyIUmBixX\
+TEI+w1BzrEsRCQJi\
+Vx7bUbNCarpcJcRl\
+SnGMFaZKnKYFkut9\
+alG3+zY4IxdkGCd/\
+Ev9eheaZ4O3qj097\
+SVUyDGXvSqBpeYE+\
+xYKSs9YhZ94mVSwC\
+s0IohQRCDc4AOW6x\
+wNmCbpUQEvjFYrog\
+ZzwO/s98XgVWIJET\
+sIi+Azs9VqYWsyA8\
+qlQzh4PcJ2GN2zcu\
+LlsXBpUqkZ18Uj1i\
+/whR9BTdyDqBm8eR\
+TE8ME94pmtAzpcMb\
+QJdGd+Xb+90iLYO3\
+alF/9Ub/lWcPj3qO\
+scsznnupSlAn+RRw\
+ND9zOXyGB4nhjUq3\
+LM5spqxXSNldXqPv\
+2kkwparZOC7glt4o\
+BS45I0caa14ZiirL\
+rox5yi4OSQFA3KvD\
+DYohTIkNFcX2kVkF\
+ig7zEqjJdFC2nCTE\
+M/JYYFooQAx8VPdZ\
+z+wCrujUiePmH/qE\
+19Vf9+GnOTeeHSuw\
+jgPZqEE6STZtFCEE\
+fIMDweeo9prrQIWi\
+1JH8v6GhpykoyioQ\
+th1mBJ5QTX7+eE6P\
+BVjVFIh8ZW9qHPsY\
+3ZSPG+Y9aoWDZpxE\
+hdJYoitACawlNYnx\
+zGbHqkfYlxlRNK4u\
+ZdCXCRqxuEMZsv61\
+1Kd+WzYUS766FPut\
+72hn75on674w+WoA\
+MugwFC/UOZ/KUClT\
+cqFGwK4DHXUJ3Dc5\
+M78UsSK6k3Pmld70\
+1cCgu1ogvWjKKerF\
+YWabqrXHK0HZDAxl\
+W5XudMlF5ORVKOe3\
+ZhVsxQDMaOeP9qAr\
+LF1ZTot5YJbVgFIs\
+9Sqpqw84UvSV0beV\
+11GdmUDOeNEP9o++\
+w1ktBjNPSBWASG3t\
+OLv6S3v0TJ9I+FBG\
+Th+3QOJL3y14wXQj\
+GDrmNlQwX96Ty5sO\
+TAkvT40V3tEOfEwf\
+IFx5KH30XcrqAFyn\
+WpToQUZJbkaz4Opv\
+WyM0JEcwXPKZ4SKj\
+eX7M5EzxkuPOR0PZ\
+wuRMiHynV1CfOEcL\
+pR+kWcI+fwP5RyGV\
+xfLM7b2t5v6a8v10\
+XYXMHqbgUSkbTprU\
+7Ntzfuqd9vodUYSa\
+1M9X1GOL13PoLDJV\
+QlPpmSvXRBGtjMk/\
+hFvC4bLzFCfoZNRr\
+DsWr9lIoQ4unXqiz\
+JXzShLw61CqFeMbc\
+VwPAruzmEUoLHi+e\
+q+QKZCY0txmrxZlS\
+FSPpZlzFY/LWJMTS\
+XpXi0vWsYHkmsF+v\
+Mnek7pir+o7d1a6/\
+Bm1AKYXDnUCtK/t/\
+X7l7TNb+nx+wLpoa\
+EKcciBcUA2exMQ3k\
+BrPIrDXgZwCbtwCM\
+nyGMW1qVUPMgfDX8\
+lGUFm6KEsotlWWVT\
+MQZLaA3ZIJMVu1fK\
+HljF6tYkhGOYwpCB\
+4wzCEfqSjB1Zg5eV\
+mYNrwKT4N40QouzE\
+IHNaXu6T0qgek39N\
+xLWQUQkBS9dI2A/i\
+aAL6bKuKJmPMuv6z\
+Xf0M/bFvLGvPRyIL\
+uvIdKcJn1qPw+F5U\
+U8GWzlJ0Y4BWMCV5\
+mchnJIWaaYDghrCq\
+5gBi7O4KU6CwMvHH\
+Vr9K6Yw0DmwNtRyG\
+pO9qcLC1mN9OoSUh\
+xmw2ykfXDwZJVkzC\
+RJMTJEVyFqVJY6PX\
+r5Sk+2qzEAaKsb/3\
+d6/AXaJbB8uEJgQv\
+SViFc3yBAQB9+ppT\
+icdLBf1cZ+U899Vf\
+/+eH6L2ZtQFpl4pu\
++MQgQIsbDQsp5RTi\
+PgdaKV764AQsbyzT\
+ml7p5AxwWPSu9CtT\
+qgJ7h+RilWNZAy1w\
+h4pcXLyTIdZW1g1o\
+VXKG26cIjjSlAFeB\
+UtNRXlLYeespnT+r\
+P6mLyv7byov39Bf/\
+sznfCP1u9XQrEyY1\
+orR/t4ZXcN8ir66A\
+1t6Hf081hD6+muTB\
+YjQTBqLKs3ezMqAn\
+BzQDCUd2GoELeK2c\
+Qkq1xzUro17cSApf\
+9QJ0ZHZYW6P2WxIN\
+ZRQvm3kirmoTPiKG\
+51RaSxekqNKQ1Qoj\
+HjuBGyO9J7EQiVCf\
+DHRR1dj3s797T9V/\
+XdfluPf00/f6N3fj\
+xqj1YpM3KBBhIjB2\
+ZZxAlCSWvGUoF5vZ\
+pv86+0k4/pGGuH+K\
+W+3UcopJrxubqo8l\
+ZT9d0wgTyXvA6QTo\
+riWa9q18Hcul2BxP\
+Ug+1NS6USadMfMHZ\
+F7E0R3YxprsfFx//\
+/KETBlaY6YRqEAue\
+26nvDk0o3v8nkIh1\
+icaJgLJijFMyAf+r\
+Ge+0P9+5jOyTf075\
+u5fM8usYqAPl3Azo\
+B0mD4m54MIRhKWKf\
+pcl3F+Vsx11B3CgW\
+R6Ux/0ph5/W+/5il\
+73PO0VPbZKwgRh2V\
+HMFDCO5nA1YPljhW\
+GmXxY/HRvM+iZPVd\
+OIiMr0naCQ/UUuvJ\
+JKU08uzeHOkzUMhv\
+gp5pKvtm0ZkgaT1o\
+SyTQBzZQVpS0AniN\
+YbKeS8n2yxLzZS+F\
+Tb3KoKv6qf7e8nIT\
+5XeL5H1s6WqULyKH\
+WN+TpWo1c41Vx3w8\
+YJeM0pwFK9qd9u6n\
+Ne1C+Ps+x115/RyX\
+paZ+yhodvZ9huhAo\
+WXreZFTXezBmUOgs\
+VwLyxStdpVLRe4ct\
+BJltao9VNiBQ6/Mu\
+4gx1IDr5twXyjYgr\
+uboajEeut8YCkjV1\
+5VRHEVC7BXce5qxb\
+4gh6ukKnl66ob+dk\
+Pn7Ibe9+aq2nILWR\
+S3IWRd0tu3A6FUjt\
+Ujts6DNcRQ49Iakn\
+ksWLoq40n9Y4ejOL\
+hm1Gww08v6rJf7it\
+h2S3hGr922TvmK3v\
+xIqEBBEV+M9Snr5x\
+S+d104hrChjhlLZ6\
+PICvvvbKKnFvBI+S\
+P2ySqu8iQXW4JXYp\
+15SjlAjZgL1EIXdz\
+nykdSoqX67E0TccQ\
+25OhYfqyGvP+0+8p\
+mO8Vs6xspc6L+UUD\
+bR/KnHXA7O7fhC1q\
+stS7X3kRc0ZdxevG\
+r18ISdD0gjuskqbK\
+x0mv3kkN8tYDxUi4\
+qGPQ/Z3WLg+bmlE3\
+DLV5tc0mep6D/thM\
+ptq4/7UPFueSVt0R\
+SKosp356IAbsft6v\
+JODnIoOn0Hj7PA0U\
+MEe1A5eBKV+fuqTj\
+ovAk2CGJ5C6WTJgY\
+K6Ilj2WnyjqL2mal\
+0Q7n79e3q8gd0bId\
+7UuXmrQBQY5ugzBK\
+8YkSUJGne1OMrhgv\
+HmWV04R9+zVTwb7L\
+vUxXYhfdVImXxtBS\
+xstNBtZUIN8I3biA\
+XRygc6MR9op14HTr\
+htNDp2QXtCj6/qs7\
+bjh91TBQVH5SxZn6\
+nimfRnhnxpDs4BOt\
+jhYS7dSostWlLwhK\
+EBdQraiHnrtNDt3B\
+/dJGL00dewD2eFEg\
+slbD5LM6x1Swntjr\
+awEeK2S9qdfas/aq\
+tvqD1jbnLtSlPnsJ\
+AYxwV2vGclhY1agw\
+48kmlANThf56+wBQ\
+vPK3+OZFltJIS+bt\
+vL0KJtyHQROhjs5m\
+XaNvLkn7XB5hF8sJ\
+USUQLla7T/pSvKTS\
+9z29LvALjtJZiFpv\
+ykuBlV3GkhKuZ1Od\
+i4zSDRvL9O3K2CPR\
+9feHLxVtTtko8Aty\
+gpy6BkGjtDfKxtvK\
+fXbftJvrNxQz3eCP\
+C9DB0JGEACW/exZH\
+dIXUihbn1U3mNHim\
+2oRYEIc9l0NP7yBq\
+wF1Irzw4CMvLvsAl\
+6wjjJuRrrewJMBEr\
+GkNYsckuCUm2OiCb\
+af3ixAeYv23bso43\
+TXu9i6ohdvWzlf2j\
+ms0EO6KB7XCdiq2V\
+0N26eERSUhcJjJ9w\
+MaBWFXbkOckChqxS\
+Y9MACJADcsxknfg/\
+592KG5LSTxjj70pL\
+/f7rz0Hb3/HvcdeS\
+URBG7klbfIs1pRY8\
+FUV4tWUfkhEknE3J\
+zZtRvF9wzm07SVCh\
+NuyHqeO37EAacBA0\
+KksBHdabEpEy0gE4\
+aa7LKMHMqbKg0D63\
+hHXbrVjahbBOgCc3\
+af7e+5bRN91tUDIG\
+LTqR7Q4ytjb0V/J7\
+4eYwli5t+80ZLhfh\
+/obx9RTIf9WLv4Pq\
+gkW8du9zbe0fP39J\
+6d2OI23dy2Zk5qC6\
+cM0zGcdez01t8t68\
+EehUS2t6W5ZIVgN7\
+YK0U4npeEzYyfHaE\
+1Uk2yBjBjYNO9jD8\
+//F2AADp/9/kGB8W\
+MAAAAASUVORK5CYI\
+I=\x22>\x0a\x0a      <img\
+ alt=\x22\x22 class=\x22p\
+osition-absolute\
+\x22 height=\x2275\x22 wi\
+dth=\x22430\x22 style=\
+\x22top: 263px; lef\
+t: 442px; z-inde\
+x: 6;\x22\x0a      src\
+=\x22data:image/png\
+;base64,iVBORw0K\
+GgoAAAANSUhEUgAA\
+Aa4AAABLCAMAAAAf\
+1ZMtAAAAA3NCSVQI\
+CAjb4U/gAAAAXVBM\
+VEX///+znW+znXGz\
+nW+znXGznW+znXGz\
+nW+znXGznW+znXGz\
+nW+znXGznW+znXGz\
+nW+znXGznW+znXGz\
+nW+znXGznW+znXGz\
+nW+znXGznW+znXGz\
+nW+znXGznW+znXGv\
+F0qvAAAAH3RSTlMA\
+EREiIjMzRERVVWZm\
+d3eIiJmZqqq7u8zM\
+3d3u7v//6qauNwAA\
+AAlwSFlzAAALEgAA\
+CxIB0t1+/AAAABx0\
+RVh0U29mdHdhcmUA\
+QWRvYmUgRmlyZXdv\
+cmtzIENTNAay06AA\
+AAnhSURBVHic7V2L\
+mqo4DF6Og+ggg4hY\
+kWne/zGXW9skjddR\
+ATVn9xsubUn/P0nT\
+FvW//8YmQRjOw0Zm\
+Q2vyESrzMIrjJMty\
+pfZKKd0JtP+1R6CV\
+2m7SVRgMrep7ShBG\
+qzjNskIp0OZfx1FP\
+UU9YyxWgC2qbrqKP\
+wz1DapJqJ9qqA+aE\
+ydE7YNlrpCyyeBkO\
+3aGXlJ6k0gKPvaUn\
+gR9inmQG26ulyn6W\
+80+IvIeEi1W6Vb8M\
+Yhz6ulPABIAdtFyU\
+hJ5LRpw7q1SexuHX\
+0B2epsyiON10zgQO\
+VuhocDyB40XTsoQV\
+dxc0vUmZbUTtsjj6\
+hMgLZbZMsn3psAUL\
+PqCwZnIHYLxwhqgL\
+MkZdezx06nZgS5af\
+LPKoBGG83irMhAhv\
+j7BFGTCNzMfuQHe1\
+z+oQ+WENSRDFWVE6\
+mGz2Bgw87YYpfIu5\
+Cq1AYqV0Lh860jvj\
+UPk6/uT+YZy5PAIY\
+dvjEOYr9w11OINcd\
+21REuIezkjPTg3L3\
+rrl/w5Rg0x5CJCaS\
+gOaVhv4/UwE4WZgc\
+25DgkZxc/rw293+b\
+EDlbpsrHSJNBy2V8\
+GHSwTPGZlMUfgJ5j\
+dngNO/ghWnBAFf3Y\
+Xety/5cOkVFaVAjh\
+v1k5bcAMNAx/C+/p\
+OHfkBvZqppQlfJ9n\
+qxfM/cOfAo9BGBB/\
+3QEAxTzARbk74Ivn\
+SGGjkz9AIsVITUdS\
+z70fFspik7zMwBau\
+S9JfBgV3HJ8boIXI\
+uEaJesTsmdwkxdH6\
+cWthlcrSVfhvaLz/\
+IkFSepGNgmCt9kRo\
+koKhUBxMWOSXJWvw\
+HRLcrAzFPTqx4A/F\
+/maCgtqm8WKSi1px\
+RbvJwdDYkrt4iXl0\
+to5asKFNYB/DTI8A\
+GQTRhY9yJEgep+oY\
+g9A/Cia47p9aq3vW\
+YoTvO8wxj609oUM6\
+kaPeT0zNG+skmzyo\
+LJnIun9BIRfBBs2j\
+JPAopUWIHSrmKTRl\
+QHD71NAZnOhEaFyy\
++ad7MKnsndgIYJX7\
+rXP/1chz/yAtwTAg\
+GjacQNRHkcQpi/mg\
+qx3eba844NCstcqz\
+MS9qzdfH43wPCTd4\
+7m8IQOtUQnhDf1zj\
+AgmeJl5Mow8AXI+V\
+EubsiOkTM5du3X9o\
+cnwJFEN3uo7hLss+\
+f0OmWalNMqZ1/+Wh\
+9xUfIAq+tEtPMAeT\
+cXkWTsH2DEBwsb4i\
+MCWGG2P3+VDv/ITL\
+OA5bNw+iBG03Wp1H\
+ta3l+wbT56mZpKpz\
+/+9nhUizezW1pI0b\
+Aq8K3FXRerPUAUlw\
+c66TR7YYyv0m+X5o\
+7h8s8+rdI9q9DbBq\
+tkbnjwiRSfXyJt/v\
+0SCWHrarRhuoB7bN\
+fQe2iMMA4smjFuk8\
+p7EVHaiTT/3vmfuv\
+KvcUo4C1GRqkSCFB\
+hDiIHQB13MOCs3zf\
+1STUH1NniBXOSmV/\
+z/1nWxBUAk2ugt/3\
+XqlDscnW8Sr+yQ+m\
+f6dDmpQ5YrPQtAV3\
+jVKPEea8GafkPkjG\
+XxDrOvCtHlIHHKWm\
+JWyNuHekq+151az7\
+R7ev+4f5CTrA/eN0\
+qIzaSp3+5+pDB3om\
+6SeQ+/XAVty6od0S\
+hrpxSQioUjkch6tM\
+WXVxyOFp5d82OTQv\
+7ed79jlCby6OHifM\
+VX7eteZaqhteZv1K\
+K9cwCJ3Gurl+qm2y\
+kDKfecMZSHUdYIJB\
+Tn54cnWutc1mQ/ua\
+9/2D1UEMDjhfQEgi\
+1apis5I4C+O0+NVc\
+eO7PnklyMwMOiFza\
++wgrIP/LRoeptYbj\
+uYxvs4x9qjHWhkwr\
+uBpnllX3l6/7L/JK\
+EwESJo4o2J0URx4x\
++27eo/qk+6YSdUrC\
+K27lsEuX50kL4r2k\
+qGvTmTpXtzzR7GyZ\
+7pglcBjYkgW6Z3p5\
+1LhNbeDzbTSMOG2l\
+9RvUin30UaNCjfWq\
+EXvxIxQAUYXphqo4\
+PrubVZFG5973CdcV\
+ge/iNO5cktNw5t7W\
+0dNK44CrpPFziesB\
+aRWXpST6TyBKGVWL\
++Fwa8s2DIvUnirSV\
+i3LSJtk/MI21fuX1\
+Q/dgUtk7QVGA+192\
+NixGGfExwbIJrPXf\
+4hK2HGel9pskrTto\
+GSb6DUPk9vw7kO6l\
+UAOND69Tf3ft4krv\
+Z2OPRd5NUhx5NXJU\
+QAHAZYkGR78xqif2\
+A1umWl4A6SyxM17a\
+S6/36xuXwvpJtWtx\
+PPNXe436h9OAoIvL\
+PGS5Jb0Iz1lSsM5z\
+a6ylmN9GVi/zeKOc\
+lthtGIQGP+Yxvjcy\
+96IO6AlHV7PidIBj\
+1outCc9CuGK0qqAM\
+UplEE/PU5EI0/y27\
+1INQjnDa3mVvYB5n\
+e5LhHIcXa8IijlSv\
+m2gjzIUgx7DB0Akg\
+XzGku+BIypIQIvfP\
+k8thrgea9kNDfrAo\
+4ntuv9WT6l31iYWi\
+2cHuOizDJK/AtV9P\
+4/LvR7yW8PXtJtUO\
+X6a9S70QA7yDpNfs\
+jNQAygK7iQ/R86zh\
+EHd94McPrwd7FiVZ\
+sf8tlcoe+wmbelJN\
+/PkNs3e8wNEeLR6I\
+9z3kXz9Bk+flzn5J\
+wNQkmBLEkG8BRWgS\
+8/LV0HxcIsGi4Qzb\
+Kwi9cX19kcRCU7ob\
+uWTuNQ5pF0IwBR6y\
+OM7zm6T406a29hmS\
+XWGlQHtxwkRD17Fa\
+JvZBwSBadRM0RhMP\
+gsBuY5Ic9II/4VMA\
+B5nvzjIDBGtDFkJe\
+KA7GLX318TOaYvnQ\
++N8kYcPZi4Y7opQ1\
+xu5vNd4PK52V9htZ\
+SPLx6unIbzQ05n8V\
+s+tJhyaNgyAZRDzU\
+gB9qqbiHuCmP4qQ/\
+ojGD+OvksRrhR8pu\
+kY4z8LuMFxeIP7DU\
+gxk9D5U8NgI9lMOw\
+MEM2nJnwhh6AfZe2\
+YsksJpZmnJavflI9\
+tggmNOVUEovx0N02\
+fNH2ydTka5lsS95v\
+fkwABI0zP1LER98C\
+yCo4t8GOR4ZKYP51\
+3VJnmUz6C1pOSr9T\
+7VxKsHJ5VCLoMtYG\
+nJIXr+hZVAK7eOWz\
+IS0VskwBxOsax0rk\
+PY98E0+lE87er5N/\
+UbLBX784tUGszJfj\
++aT6s8R+ZSYHa5Rr\
+7kazQ37XbcSJSbMQ\
+4gwfNEcRkTL4rkq5\
+TaL38ypfmlf26fuT\
+Bj9vrGKQ0vxA4geT\
+bDxHs/1j4ka+ErX8\
+XvSm9TvJzE7QOHAn\
+UzYv46CH3mjVkewz\
+jHhkc2W1eefwd1Ka\
+N0J+n5rhaVQPUIlW\
+yjwZ+z7x8DJbrrel\
+JWugja+qSBefgepi\
+qSdo25Kn0Bxl7Gy0\
+GM7BifuRVrxQCT1T\
+n4HqJmleJSa/ZMCH\
+LkyA24ZyWR8jkKUw\
+wG630e+llmwHkK/v\
+NC85uoyL3ttsfo5D\
+37E0nbhVVWSrF9kJ\
+GYMEi5/O0eSE0AY9\
+7Dh4H82bGrjK9Xzq\
+E/weIuYHef42OFmp\
+mm+0eN1F9bFIuGy+\
+J4R6F8tITq8rdr/g\
+8SHqmTIL42RT7Bkp\
+J1fmK1VkSTyN78h+\
+VQnCMI7T5keezW88\
+A15p0krtsmwdx4tP\
+KjFOmfU/oP48L/of\
+eFiF96pE5uQAAAAA\
+SUVORK5CYII=\x22>\x0a\x0a\
+      <img alt=\x22\
+\x22 class=\x22positio\
+n-absolute\x22 heig\
+ht=\x22123\x22 width=\x22\
+304\x22 style=\x22top:\
+ 73px; left: 467\
+px; z-index: 5;\x22\
+\x0a      src=\x22data\
+:image/png;base6\
+4,iVBORw0KGgoAAA\
+ANSUhEUgAAATAAAA\
+B7CAMAAADEzSzaAA\
+AAA3NCSVQICAjb4U\
+/gAAABgFBMVEX///\
+/jyZz02KW2pHvdxZ\
+u2pYLny5fv1qWFel\
+7Vu4OlmnasnHuyn3\
+uKfmLexZbVvpSEe2\
+Lkx5Ts27LSuIXGs4\
+vFsIrZxJbs0aLPvJ\
+O6p4Pp2rHlzZ3WvY\
+3Puo7dy6DayaHOto\
+TdwZJuaFvJsn6llX\
+Pw1KC2o3fWxZ3ErY\
+Somnuekm/HsoSekm\
++AdmKomnucjm3OtY\
+vn17GcjnOllXO6p4\
+PKsIjSuIt7c2O8rI\
+WEfGmSh3ONg2V1cG\
+GUinTt0Jydk3FzbG\
+HPuo7kz6GJf2vn1q\
+3q1aTfz6majnm2pH\
+uyn3u2pYKyn3vPuo\
+7s0aLOtYvSwJm8rI\
+W3lXKllXq9q4ndxZ\
+vVvpTexZbPuo7SuI\
+XErYR7c2N1cGGEe2\
+Komnu2pYLPvJPGs4\
+vWvY3OuJF8dWmNgm\
+xybFuOhHG6p4OsnH\
+vOuJGsnHuEe2LFrn\
+3Gs4vHsoTFsIq6p4\
+O2pYLKsIi2pYLZxJ\
+a2pYLayaHZxJbGs4\
+usnHvbv4+vnHalkG\
+6Jf2t/eWx8dWl0Xq\
+RGAAAAgHRSTlMA//\
+////////////////\
+////////////////\
+//////////Ebv//3\
+f//////0Qid////y\
+JE7v//Iu4iRP8iRP\
+//Ecz/M////yJ3d4\
+iqu8zd////d4iqu+\
+7u7u4RESJEmarM3f\
+8iMzNEVXeImZmqu7\
+u7u7vMzN3d7u7u7v\
+///xEREdqVUEYAAA\
+AJcEhZcwAACxIAAA\
+sSAdLdfvwAAAAcdE\
+VYdFNvZnR3YXJlAE\
+Fkb2JlIEZpcmV3b3\
+JrcyBDUzQGstOgAA\
+AUrUlEQVR4nO1dC0\
+MTVxbeMDNOrGQmEU\
+gIECCKiooFQeUhKj\
+62iI+uimhti692pb\
+i2dq2P2tb2r+99nc\
+e9MwNJVIJdDiTzzG\
+TuN9/5znfvjPiPf2\
+z7+Pe+dp/BpxX/Pv\
+2fdp/CpxU7gDUZO4\
+A1GTuANRk7gDUZT0\
+7/cnvo9cr6artP5B\
+OJtdeX9vZdGhw6NP\
+hyB7LN4931vX17+/\
+okYkODhx7sOLJN4i\
++Jl4pLg4NDg0PnF9\
+p9Rts7Fgy/+jRiIi\
+8ftPuUtnesH9+rEZ\
+OTQYnY0Fq7z2k7x+\
+LxvX0Csr3HJWp7Lw\
+0NHRoafL0jY9mxLs\
+XreB+8SYINDu2Uyu\
+x4LRX/eN/x4zovv5\
+BJObijYpmx8IWKQx\
+D/UvGm3ae1bePi08\
+ePe3sfPybAulXcmm\
+/3mW3XWJRqL0OL/t\
+4vhNsXsaP6WfFOar\
+4qkyr6vhhS5rXdp7\
+WNQzvWPqn4ErEhJf\
+or7T6rbRy3dbeoT7\
+PskmCXiMvtPqttHI\
+t3Z5TH1zEzMyg59l\
+e7z2o7xy9vtdxL1C\
+69eiUB+z+0YdPz38\
+3N3bpy5cr98zoevX\
+n08MWLhw9/ui9WXv\
+lhbm563lTCp2+PHz\
+d49Q2+fSU0//Wf7T\
+35LYz5i3O37j+/G0\
+d+f6VDRtjB48DZXR\
+hRVB+4++LZlan/vt\
+WeQiA2OHRCMOz/om\
+O07+Ktpz//GkccJw\
+OWnIQIXMhBU3G087\
+UwX+VyLMOrHvrb4z\
+U9d+vqr7FfQR6FOA\
+0JrpBtrRBmJQlYKe\
+7VEfd61d7z7W7Qx4\
+yLt652x9EFCw787W\
+AQhrANaHdWoyXiZO\
+euOFZoife/M2ACrI\
+lyP4fK0qzQAszBTs\
+VZSMldKht7dUr2lk\
+uPlifb3bgPHfuePP\
+017udcCm3NSgAU2p\
+wzeta/q37y9z9u1n\
+o1XDIl47JK1UfLs+\
+1u5AeLfWeu1nJJTi\
+UByQi248mbN2/+cW\
+S8psCSqHUKhmEdvb\
+b2d+iDP7ka51Jajy\
+JFW0KiV8j3gfew4+\
+bN04X8kZFir4JLMc\
+yLJ4apgpYeLX3amE\
+3/cLcfWstSzyWXpV\
+8mKuKH5tTPqT/y+X\
+xxZCSv89GkpGDdKH\
+MdpfOff7KYzT3MIQ\
+qivTL6ReT6c34uJ1\
+9+VI5UlCO/XC7rua\
+hsVkLoRbG2HAjA8g\
+KwWFVImZJC9Cfyp/\
++4eaokgjAba3fTW4\
+mlN/0CHwmMbLIvMR\
+LRryGrXKiYCCmIUq\
+F0aWpZr9O7VTqL+a\
+ICTOdjr7IVE8V8/v\
+TRU8OnZAyI+O23en\
+3gpzPtbn9z8c1yJL\
+C5YPBI2CqeiEzVcE\
+0Y0hqmYrWiYljR1E\
+jlw+JuSbvCyM0Bya\
+1SVBcx8NvAwKlfr3\
+w6qfnnAxuVkL071s\
+sW/zQzwXePC5CSvd\
+qIqZQUwiYgu+l0oX\
+aV6j99324kGop3t1\
+MkPcNNhIldWekMk+\
+j1/y4B0/oV665Rt8\
+IrXywMu4gJzO5OtR\
+uNTWPxtp12YXrbQw\
+5kAsTUaqpz2veUhv\
+VqJ2YYJqM4kARMxN\
+3tXTQnb3dYqmOlmp\
+uShAq5e7dbae+hZv\
+qrWvBlpawSYL/b3N\
+qFRXPgh4V2w5IVbj\
+K6TU7jXjqV0uYRN/\
+HR/khrWPWGAWw8JS\
+ExTt1qNzKp8fU6B4\
+L71DCRYkki4b58x1\
+QgYXJB+Lme7nJt/P\
+ffR+tZWBme3d2GLm\
+Mtgz1pTU/tSbpkSo\
+xksJTlH+/nyNBsyV\
+odfbnNKubi9fTWZ9\
+gEzsMUkBvpmBNuLm\
+CpHCvF97eR+v+1ni\
+LpYeKdVQIqAwypkP\
+264G7ke23ASjQtWe\
+u3T16udTjhjEMkYH\
+TUyAEomYwuQno33H\
+Igya9SGudKPy+0Gy\
+oZ39zOUpctI91ZO/\
+scqrE124Fkqy4TnI\
+qXZk5dsnQkwnJkYU\
+eY2mmi7S5CmXJWv9\
+JuvNabYUImXpScIa\
+1J8NHJVXbIswTJZq\
+C9aKv2/+kUx7TIqn\
+7ppTAMzS9hmVkzQ/\
+iEULHG483F9uG1aL\
+EjzSWkN3dz2xBati\
+v1cxbdeN6B4Ce1TC\
+9GbTP+a851phzMUq\
+WNANpwU5iGG7v1e5\
+ZgKSVdrFUNBKL324\
+OXK18diZalAoayll\
+YO4ICpRyES84xVrw\
+MN6FeJoHveDrxuu2\
+1JX3A0jFdGO5+zIn\
+TdRkjAIeQVCYaViC\
+lwsU1tkH4u96HTPJ\
+sPDd8xSlsbgpYxxB\
+hUuGojZqVh+OUWI7\
+ZwvdlC1kikpGiDCl\
+nZMCPbj9jC9Q5KlA\
+6SnSyrGtqk2SBrM3\
+HM3k0i2IyvAMS2Er\
+DrvAEWPDZWYWqXKd\
+l6W8SdLXiERFbTlx\
+5wiFRyZ0rJQZ8tfO\
+5nJdU2WLMND2dZZc\
+9dkbgMWR3O/mTelZ\
+KosXk5ebZVeD1IRS\
+ixziZEkhfpaLt11D\
+50aukISfNT1KrE/Y\
+S9fWlr8FpHIbYqYo\
+e72EAkiLXhAbK7TW\
+GGTm3izUpbMnixuk\
+Gr2pWXZwGeJvOy9M\
+3Hx+vrClxecEJ4uZ\
+M4JnxTYtOG4xjpkT\
+QpYRZem8ajjw/YS6\
+t1WUmZDVuWlr1Pya\
+1YQKXKlbMdN35o4X\
+83OTm5qF+Lk4vi94\
+Fsc0UzrFLpqByoHB\
+ChHsRRs+q9olao1W\
+rxQn9FPsqjHncScz\
+rUXL96Bkr9Vvpz6s\
+ke9StftdHRHvEjQ7\
+5P1B7XMmLipIjuky\
+pO1QbskMu12sApNV\
+eDdXUTv93/PBHvo2\
+x39GNKfs43z3TpiH\
+xc9tWPnvi+fu7LLO\
+tdc7552MlsMQc0G9\
+VCBBvMjvow3YHneY\
+H6kVMvCAI9xRVqRi\
+8Faqv5AG40n8C9vI\
+Atsb0DOKaa/vc9CI\
+bt81ljJTBq2WeIqX\
+b6gK0Fp8+Oksshmr\
+A/Ak1IqjU90HYLMY\
+8BEcDqgBqtNuoVgK\
+jBxuyl8fVclIMAVg\
+TV1gFbVW2LWEuoPZ\
+xjRAzebp+v83MMKA\
+MX4seZitET2KzwGI\
+UYgzRAQcBJ4xAOYC\
+JsGMSGuMA08V79rm\
+XA1oEu2A5fE0yuiN\
+gm4gjSiNCVOZcjUv\
+o+7acTUrOW4apePY\
+xc1CTOEVxDOzE+Jv\
+KP75FIVITe86pzLQ\
+O2AnQyVMEkguTEzN\
+ITBydb5wBgH5IR3h\
+FwHzMeGBZQ4zBlHB\
+CRVQRMgGARDCiGsA\
+rz0OPfIH+qrY9h3w\
+GQGHlyvM0cH2sf1n\
+YHSVUHUOsiJzMRUl\
+8CZlOBpU1gsQbzLy\
+DZI9AshNkmyErYka\
+ZXW8XrXRIqyB4f1R\
+p2iajZFgcpB/Fgzg\
+JlNV0LsTDqMXVnOH\
+gWmYxied2xLN39Fy\
+5c+Oc/L3Q2EPxI+i\
+IgA1+1CtiaaVwE4s\
+PUzKIUJi3DgSkV0I\
+3A9sFSRFg+uD9R4I\
+9yDnGSEaEgwcTMKM\
+M++mzz6OTIswoiX9\
+VWBxfXc1bwksj5Zn\
+PFKXdsQddbKrDiox\
+EDk+irdxhFqCzNDi\
+zAwEUFVfZ9DQEG/o\
+TlIyxUW/2HSytcWV\
+ywInjLgfNkdAIUrK\
+QjAGGGXEYS3NwoSh\
+JLQKvIsTZ6XkRXsU\
+GGsXrCDiRVv1Wvf4\
+dzhzkI34fciohqJr\
+kiqKjQfqyrmIc+w5\
+TvAplpIB5lZQ5duO\
+Xu0VLIaUx+sZyF0s\
+jIns7OPYeBYWgo0P\
+SaL/m8Nbwm2+hate\
+g341onkKW+ZlghL3\
+/y+UKhoJ/ll289Pd\
+3dAWNYwrWqL2ixc7\
+RGOqRiw56fDSqlF2\
+LF0DS9S8xim4yw14\
+3Gen6mPxN0G5H0gW\
+EFCVChWDCPpecVeg\
+KvHg2YXX3Rm+mcbA\
+2wdZswKZUfCJdjsw\
+llsvZitcBUYF0JCF\
+3gm3/D8hBO5afeHy\
+j2DfgGHwEr5PVvoa\
+iIJkETgHUzwAJ+BT\
+xjOPbsCRZaAmwlu9\
+uSUgkBF2IVdKNA6e\
+jjvsNLNk+w3fBYoj\
+APwS0FcEK+RXhdkG\
+H5okRJZ6aCrICAfb\
+YnNYxHa+0R4shQwE\
+0qn6sV5RVAQIzjCP\
+HEY3XRZh4b2JCAUQ\
+/aUIr8GIxRGNmRra\
+zjeTCG6XTUUibJ1t\
+Pd0+2dOzI+vof6Su\
+j/1cEUYC11jiZt7m\
+xFbwg79jKqHrVAZw\
+qPw2ZyGKkxEZfrcV\
+m81ePx8XNHjiit16\
+AVJbkAMK1hafTCY3\
+lPWwFsTZ/7xx6UyM\
+zuwE2UTmb3SauxNH\
+TDIaJYM6xg4MoX1T\
+/fUpBJhgUjR86d27\
+NBdnveL60Atu5zVC\
+R0AJ7VZM4lH6yERa\
++cb61ixZF9Xm/jV6\
+cKHW2LaC7DaFKN63\
+Ec1+U/6j0iCAYM00\
+ABcErDRkR0BjAyZn\
+cc3qNz9DKjIVThIN\
+8+zoB1p40J8gw6Na\
+xfrmZ050j+c+d4RD\
+FMOQmslHnDMFYls2\
+1L9VgLgPnAq5yl5B\
+uZc+IeS9yIOGXLIB\
+4cP8A1X2gYXn3o72\
+Wbc7kigotlRL8A1l\
+VqmHYVOiWh8w19Lx\
+y8xi9spXO0SPbbmH\
+s0A1xzyI+B4rMEBc\
+OmIfFpN/soNFyBn5\
+Apye1EABYVRvBxXN\
+BDAGO4kAYwJV0mKw\
+3TGGAeaVZyILKVMr\
+m2NeaBV1ud7UC2qm\
+serBzkK0xrJ+CCQN\
+coTy6sqB1/gbpGHh\
+6akRgdSwtjiA9Qpy\
+JqlaVdDClX5p3sop\
+LgI8c4oFY6A6ROQb\
+THUCGB0KSJn244ET\
+Ku+lUg3WcMs8ByR3\
+dPNA/YSwWUsgNRAo\
+acGeWzeEdo+h8CbD\
+h5yBp39BVKG7ZzFL\
+47AlthOpAF2aPUmF\
+Ff0gYbq6RRgObL5D\
+fUCjaqh0yhhjntla\
+OCPmqWbRrAn1rJrY\
+sCLwZ6n4hreoAMYz\
+7fI0LojXAB2GgF2n\
+2dnXkrJbFA8tEKva\
+ra9D9/WH2fm9Y5Bi\
+iyDzfZGZgxdBHFVo\
+ps5AGQJ2VTT4BhEq\
+Ii2Vc5dMFsBRNAGm\
+pDvWz6r6tcdrOwdT\
+FKHIgN3WbfRo8Sl5\
+2Pr3o4JMaUe8CcET\
+FMewo1WFHEviSlpA\
+bHtsS6s9XZdOfowZ\
+bkHfHV50jKtygj7x\
+jpiHt67YTBGzVMm1\
+UYrFCAQUpalhj7Xu\
+BWWugc3SE8GFJIgc\
+hHs4D+ymxkyYuOAc\
+oHpaXPduYZDx+NYp\
+6CODLKRw0Dt7sU1O\
+XfNeIDiIUC2HxjXh\
+VgR8blaAVLSNIxGG\
+bzmh1D/HoryZRjlt\
+fAF/nRRoMULjWUIg\
+VV+Veg6qJHKbuS4w\
+U15Jo3Bsx0xUnDiE\
+xYUvg3BtPNAbZKNs\
+Hp1WQ8a2OzkTjjs/\
+JqPu4r0Ih8ZO4Zxc\
+oxoQEko/s6aPxZYQ\
+jknSN1GHD6haIeyj\
+djrmpMH2zFZy701g\
+UImu4cXUYgGC6MAr\
+SIKWYTxgKOSqCV3y\
+xd2f6GfxHIFk7QUS\
+QNumlnLVLesYwaVt\
+AWjPrfajxM8m+P3X\
+tXs5xhnU12jlYwnS\
+KGFruFhGzzuVTZXU\
+urSjDjQXhnyJ2clA\
+EiZwDxsDWIYQ9lTJ\
+Tr5Tiu18bH5fAOqL\
+2imevDPrNT/DA/jM\
+rwJjtHdzZvUQpZLC\
+h84JXZEe9hyk10Q5\
+M+bPUVclGaUgX8ST\
+AiGIA6qhjm2zdBwL\
+0WdF9S2Ipz546oIe\
+rAKilYefVbc52jdz\
+lLV3AkYQuLZgSApI\
+p/ogqofaryTy6X6w\
+OCYefOQfcRiSYLJe\
+8aBUz3vUTRbK5ztI\
+qXH0pji2M0CCISUm\
+/a/GGxOMkwbs2hCF\
+hjNOYBC+p8mxtHaM\
+RkSvbgeBjdC2Z9VQ\
+Ssqc7ROjSXewnOK1\
+vDk2Q0295jpLaMzo\
+sKv2kejVkwF6s2lN\
+X3QJXETIRBnoLVl2\
+QpSCMiWIibK5MrCf\
+Xa6JYryRYg5TMq0u\
+dhH8tR4Ed4JVWAMf\
+I4t1zZ6IKHKKrOkb\
+5MhmFF6EkWjK0oJA\
+YQvcwht+YesLhjTh\
+1yiz+GZLiTs0I7Aa\
+ZihoZcwQibRp7JKy\
+O1PDKYAJCzAMlkxh\
+AjlpJF8K/CixXZbb\
+ZO9nniL9o6saqZBy\
+zeNezHuUtgEm7hyK\
+YGzQhxz7YtdfBcrh\
+/3sMPtcYqp16g6EL\
+vzbYiFOqaqJGmYxy\
+MgLqucbAKwtVbdJi\
+UlFgiGL7MW7Eh2Cc\
+Z6EvMhF3SZSbeJQi\
+dfVXUEdPr0LIrWsX\
+yRj7hCkmNusuyXx2\
+ri6XN49JDyCaVnS4\
+Z25DRubmjH6JjKDE\
+pJa2gnRcPotkCAag\
+baWH3SOGArQC5UGd\
+vGEolo5kM/ZRdjnr\
+HbbUzCGLlYoYsZw/\
+J47xsHeqzOt3Vkqi\
+6I4s9TU98fW2gMMG\
+wZEcnpO3LKWcnILY\
+b5HKamhqex++cxFU\
+HkFZkMrAZcfkTU5B\
+GoL6kFrADPo+Rt0b\
+cPx+5EKbJWR7t27+\
+7q6vpq//6Dl6fGvp\
+/dxMm+m5ycWltbW1\
+9fP7+y8qbceC75SD\
+zcaJdKFEffvSjEYl\
+8wjCSMyj4jQmounZ\
+Qf5k8gFtHvqyEeAs\
+whmIxqtXpCxL3Ro8\
+MiugReKsxULAvsLh\
+9slHf7ZicnV9fWlp\
+fXH1w7/7IcWdXzQz\
++IImZj3rmzPBnhlx\
+joF2Uy5+csW0EPoh\
+Stu0ZVFSdmZmaOHj\
+06fHS4a3h4NyCEWC\
+FaFnLyTWIneXes8R\
+7U/Pzk6urq5eXlB9\
+eunZd/3h2KJ2YVKR\
+dLN7YOIaO90abkYo\
+SKOyaQLtJ/rALaCz\
+DAlNYrhp0WMT4+Pj\
+Lydmbm3r0bXvXGqK\
+QQA6JLTbrMbFcSpi\
+5rxZf79z87eFCQTb\
+CtCcjsWJie/l4guL\
+y8/PzatbsCwTJPMS\
+aKDrPUcvLWUUyJxw\
+yEw6jkrSP5vIDWMI\
+mPiBOCP4pAXTYCLn\
+0ALURPwgY7vJAAXT\
+44NjU2e2wzLWs59n\
+03Pz03tbp0ZfnZj9\
+fO1+JYkLCJznscEH\
+cCpshpD1igAM2cuD\
+c8UTtVlSAZ3eF4dN\
+lM6epymQOxf//+Kw\
+cPLo2NjR2bbd9/zz\
+I9P31x7sza0tLy8x\
+9/rA30qjT2UeQgMY\
+3dH8BETNp9BU+1+k\
+oo0D2pQEKgh5EYu5\
+2USglLzrs0QDLDxk\
+QtPPZ12wDaLPZ9Nz\
+175szc0tLSsx+ff1\
+mrDcSghJJ+NV4bg2\
+qgCCQVWifYbrfNkE\
+pdu51UA11ia74yEi\
+QAOja7BX+K4WPF/P\
+T8k7kzt35Yuv/z84\
+c9J17NnHh1T+NjAN\
+LMAf50ucg4DCIJAo\
+0em/q2dY3e7jHboN\
+ykpZrIsPsHLwsJmj\
+o228qzhJ9k7OOJlr\
+BDFphKoy8fXBNF7N\
+jst+0+8bbFV1k8Eh\
+L0k9Jo6Ru/3b4avd\
+WxH/llJEhk2Oy3f1\
+sJev8QJmhMaHS7T6\
+OB+B+C/KOr0h4pdA\
+AAAABJRU5ErkJggg\
+==\x22>\x0a\x0a      <img\
+ alt=\x22\x22 class=\x22p\
+osition-absolute\
+\x22 height=\x2250\x22 wi\
+dth=\x22116\x22 style=\
+\x22top: 113px; lef\
+t: 762px; z-inde\
+x: 4;\x22\x0a      src\
+=\x22data:image/png\
+;base64,iVBORw0K\
+GgoAAAANSUhEUgAA\
+AHQAAAAyCAMAAAC6\
+RQ9kAAAAA3NCSVQI\
+CAjb4U/gAAABgFBM\
+VEX////kyZm1pIDe\
+xpr73qqnmnallnGn\
+mnn33aqjlXn12ans\
+zpi7p4PUvZPu1aXP\
+uo6tm3zr0aLfxZbN\
+t4xxbWOUim6yn3l7\
+c2NsaF2+rIStm3yo\
+m4C2o3v22KSznW+r\
+nIGejGuqlm3ZxJZx\
+bWN0bFvUvZPv0Jvn\
+zZ2MfmPArYq7p4PX\
+vo7Qu5LFsoq+rIRs\
+aWDx057ErYKznXCs\
+mnKFe2qom4CPgWSM\
+hG3Qu5Kck3OllnGj\
+lXl7c2NzcGeJf217\
+c2OJf23FsoqUim6+\
+rISck3PArYp/eWl/\
+eGWfknrGsIzArYrG\
+sIyck3PNt4zXvo67\
+p4Pr0aLQu5K7p4Om\
+k2zfxZbZxJbErYL1\
+2anu1aWwm2753Kfm\
+zaHny5aMg3N/eWmf\
+knqajnmUiXSMhG2M\
+g3OrnIGjlXmUim6U\
+iXSMhG2EeGN/eGW1\
+pICajHOFe2rGsIy7\
+p4OVhme+rIStm3yn\
+mnmejGuUim6VhmfU\
+vZPQu5LNt4zexprP\
+uo7GsIy7p4Oyn3mm\
+k2w+/MV0AAAAgHRS\
+TlMA////////////\
+////////RP///yJ3\
+/yIR7v9E////RHe7\
+/xEiu///RHfu////\
+/xH/////IjNEVaqq\
+zMwRESIzVXeIu8zd\
+IiIzZmZ3d4iZqru7\
+u7vM3d3u7u7///8R\
+ESIiIiIiMzMzMzMz\
+M0RERFVVVWZmZmZm\
+Znd3d4iIiIiIiOma\
+r1cAAAAJcEhZcwAA\
+CxIAAAsSAdLdfvwA\
+AAAcdEVYdFNvZnR3\
+YXJlAEFkb2JlIEZp\
+cmV3b3JrcyBDUzQG\
+stOgAAAFzUlEQVRY\
+heWXh3saRxDFvSzH\
+HQsczUEKCFVkiINK\
+FEW25RZFcVwjJFvN\
+Tu+99+p/PfNmCwfc\
+xYosf8n3ZcB3gjvv\
+797sm9nl1KlHxNyj\
+bngCMf7U/wU6929A\
+l/5L6X3nq43f5ud/\
+uf3ZpScARXp/GB/6\
+8q1fD4IHYXP5TC73\
+em731psnDYXS9dMD\
+X729nVZBmkIpVc4h\
+Xr188tCLA9CfAiIq\
+ftM/1WwTda90otC5\
+IeilbahkoYAG9Ocy\
+iz1J6JDSNw41Kg0w\
+vRTOTVC3HgvzwcbG\
+7ZJrfoNKLx8qTms6\
+IBxT+cPyY1JvHqgm\
+xrhlPpPSq54rm21W\
+yFyXZDzGGVC/OSby\
+8jYP1KRBdq9Y6Dnv\
+grn8cwACZRc+4rkl\
+U8FXIZv4xvGg20qL\
+eEDUPS576kjnfAN9\
+D5cUpxZYfeJsa6m7\
+x2J+CSIkBCFV/ZaF\
+WqVbSrtI6dwq7SjO\
+Dc9q7liFc2Dmyzw6\
+EtxP71IjDKkdNFUz\
+RDT5tkDBUUobOLd3\
+VND46urqjQZi6mYY\
+lsvl18oIQbE3T1ER\
+UkiEwEngjIOsdrvd\
+grQx+yzHt6c5xuil\
+3wlbgBJGEGY0Gk84\
+hP4k+idh+PxnPnWk\
+GIuH2tG0AIvQWAsX\
+RqFRiy+OxkyE2oGl\
+yd+wPP1IfeE6wSeh\
+9B/nmKB5sZjJZjNe\
+DGuh6lPUk6BTFiVd\
+IqWFWqR0avsZZ2g1\
+m6FXDLRYoQuZzEQS\
+VESsaU/mi7JyEepT\
+wE0+VRBaaYFGzmYn\
+YqCyhku11PUE9zrv\
+GJ3WREKG6HFK2TVF\
+VyadU1QrZwGVkEND\
+x0AXAa0nKG1EjCP7\
+J6GhKtrfbc8LSKnQ\
+0BryW4+DVmm2s36y\
+ewct5GZXitB2HTR2\
+dEDu8RGoWMTQMU4q\
+igIm1fu7khGuTI17\
+9JGgQdgut8t4604V\
+mPQyVEp2UiYOWski\
+Uq8kuFdGKlVEfCpI\
+aaAqvud7nufjQEdu\
+9TCSTm8BRopxUlGI\
+Ol3K1BJLpl9+ItJ9\
+6HOZUlohlIei8/ls\
+oNLMqcwgRieVoHlU\
+Uz1Jqe0xwprWaQ9p\
+/maZCJUsNTBGkk9z\
+ekUd/vVjoLKKx/ET\
+5nTAvJFlRDA0XdEw\
+pBYH3hxFoIsYetRJ\
+RYnM05Vk90a7jssu\
+l0w6PWs1cnY9Lhq4\
+l6GCe1J21EmktMKN\
+49MEaH9FkW4N0U8C\
+aMVmVx8HoHQXehLa\
+3YhS1DDFF/Fz6tqs\
+NGDhHMVQdq5v0F6g\
+TMmY9FbYSSM9qYgl\
+AdAXE+bUrcvWSq4X\
+c3p1Xi03MEp5TnFX\
+He1hxL7kXrmAJLyU\
+lN74zoD0kqxZrdTT\
+Zcolo1Jdo1Swk2JW\
+Nygt4HFeToQKl1jh\
+VlL8UQ44vWwi0yK4\
+H0bcK6qZOCeRUvQk\
+kjr8M9Ok15VLZLXW\
+STbu1Rq1XOx3Azun\
+uJF70oiTihisjiXo\
+agK0vzFxD6C1a/fa\
+KuUU87LjoLg51kmY\
+U3EWUmOdVLIrdv9g\
+9i5Up0rXqe/Anu1I\
+TinpyY42wiJG7QEa\
+66TSYOeLFKwQ5XSk\
+I+l5xZIe9N1Lt+f1\
+GjYYVYxyHnMa66RG\
+ZF9m59WuqrTKaCMZ\
+mb5Lr1OKHouxR5XS\
+Zh3GjnXSFEtsi3a7\
+uLCwsNi1WnkRV1hl\
+THK1YGxbVBTKq/WI\
+k4qcrIvwWJyTplgd\
+pqrKeYn2f1ZqSlRn\
+1+efiYBeM0YSet83\
+5KQip60HaJyTuGQk\
+VkkNjW7RsHOoGBsZ\
+rdit8Mbsmq5TGe+k\
+Iruil9STSvwf006p\
+bUnOSEaibQ7YKFml\
+2m55bB6GnFTkx95B\
+ocY5SdcpulvV2s71\
+ClunFurbOe0KuW96\
+r+mx2WEoHmcWNZOd\
+mZ5e61xvRaFLq+/S\
+r8TzFH/82bt7t/cM\
+x+87O/Qzcffw8HBP\
+NyTdgP2+e/eNUikK\
+3O5qE4iaifxziOrz\
+iJWVyZVJxPrMw+mv\
+O5+0YjtjUlz56MOP\
+X6B4//NSo/HdnTvf\
+9zY3N3u9/fX19Xv3\
+7k9i6JXJ+zMcF6Y5\
+fux01tY6a51WqzXW\
+crS/AGShj5noGrZM\
+AAAAAElFTkSuQmCC\
+\x22>\x0a    </div>\x0a  \
+</div>\x0a\x0a<div cla\
+ss=\x22container-lg\
+ mt-5 px-3\x22>\x0a  <\
+!-- '\x22` --><!-- \
+</textarea></xmp\
+> --></option></\
+form><form role=\
+\x22search\x22 data-tu\
+rbo=\x22false\x22 acti\
+on=\x22/search\x22 acc\
+ept-charset=\x22UTF\
+-8\x22 method=\x22get\x22\
+>\x0a    <label for\
+=\x22not-found-sear\
+ch\x22 class=\x22d-blo\
+ck text-normal c\
+olor-fg-muted mb\
+-1 f4\x22>Find code\
+, projects, and \
+people on GitHub\
+:</label>\x0a    <d\
+iv class=\x22d-flex\
+ flex-items-cent\
+er\x22>\x0a      <inpu\
+t type=\x22text\x22 na\
+me=\x22q\x22 id=\x22not-f\
+ound-search\x22 cla\
+ss=\x22flex-auto in\
+put-lg form-cont\
+rol mr-2\x22>\x0a     \
+   <button type=\
+\x22submit\x22 data-vi\
+ew-component=\x22tr\
+ue\x22 class=\x22btn\x22>\
+    Search\x0a</but\
+ton>\x0a    </div>\x0a\
+</form>\x0a    <div\
+ class=\x22mt-5 col\
+or-fg-muted text\
+-center\x22>\x0a      \
+<a href=\x22https:/\
+/support.github.\
+com?tags=dotcom-\
+404\x22 class=\x22Link\
+--secondary\x22>Con\
+tact Support</a>\
+ &mdash;\x0a      <\
+a href=\x22https://\
+githubstatus.com\
+\x22 class=\x22Link--s\
+econdary\x22>GitHub\
+ Status</a> &mda\
+sh;\x0a      <a hre\
+f=\x22https://twitt\
+er.com/githubsta\
+tus\x22 class=\x22Link\
+--secondary\x22>@gi\
+thubstatus</a>\x0a \
+   </div>\x0a</div>\
+\x0a\x0a  </main>\x0a\x0a  <\
+/div>\x0a\x0a         \
+   <footer role=\
+\x22contentinfo\x22 cl\
+ass=\x22footer pt-6\
+ position-relati\
+ve\x22 data-analyti\
+cs-visible=\x22{&qu\
+ot;category&quot\
+;:&quot;Footer&q\
+uot;,&quot;actio\
+n&quot;:&quot;vi\
+sible&quot;,&quo\
+t;label&quot;:&q\
+uot;text: Market\
+ing footer&quot;\
+}\x22 >\x0a  <h2 class\
+=\x22sr-only\x22>Site-\
+wide Links</h2>\x0a\
+  <div class=\x22co\
+ntainer-xl p-res\
+ponsive\x22>\x0a    <d\
+iv class=\x22d-flex\
+ flex-wrap py-5 \
+mb-5\x22>\x0a      <se\
+ction class=\x22col\
+-12 col-lg-4 mb-\
+5 pr-lg-4\x22>\x0a    \
+    <a href=\x22/\x22 \
+data-analytics-e\
+vent=\x22{&quot;cat\
+egory&quot;:&quo\
+t;Footer&quot;,&\
+quot;action&quot\
+;:&quot;go to ho\
+me&quot;,&quot;l\
+abel&quot;:&quot\
+;text:home&quot;\
+}\x22 class=\x22color-\
+fg-default d-inl\
+ine-block\x22 aria-\
+label=\x22Go to Git\
+Hub homepage\x22>\x0a \
+         <svg xm\
+lns=\x22http://www.\
+w3.org/2000/svg\x22\
+ viewBox=\x220 0 36\
+7.4 90\x22 class=\x22f\
+ooter-logo-mktg \
+d-block\x22 height=\
+\x2230\x22><g fill=\x22cu\
+rrentColor\x22><pat\
+h d=\x22m46.1 0c-25\
+.5 0-46.1 20.6-4\
+6.1 46.1 0 20.4 \
+13.2 37.7 31.5 4\
+3.8 2.3.4 3.2-1 \
+3.2-2.2 0-1.1-.1\
+-4.7-.1-8.6-11.6\
+ 2.1-14.6-2.8-15\
+.5-5.4-.5-1.3-2.\
+8-5.4-4.7-6.5-1.\
+6-.9-3.9-3-.1-3.\
+1 3.6-.1 6.2 3.3\
+ 7.1 4.7 4.2 7 1\
+0.8 5 13.4 3.8.4\
+-3 1.6-5 2.9-6.2\
+-10.3-1.2-21-5.1\
+-21-22.8 0-5 1.8\
+-9.2 4.7-12.4-.5\
+-1.2-2.1-5.9.5-1\
+2.2 0 0 3.9-1.2 \
+12.7 4.7 3.7-1 7\
+.6-1.6 11.5-1.6s\
+7.8.5 11.5 1.6c8\
+.8-6 12.7-4.7 12\
+.7-4.7 2.5 6.3.9\
+ 11.1.5 12.2 2.9\
+ 3.2 4.7 7.3 4.7\
+ 12.4 0 17.7-10.\
+8 21.6-21.1 22.8\
+ 1.7 1.4 3.1 4.2\
+ 3.1 8.5 0 6.2-.\
+1 11.1-.1 12.7 0\
+ 1.2.9 2.7 3.2 2\
+.2 18.2-6.1 31.4\
+-23.4 31.4-43.8.\
+3-25.4-20.4-46-4\
+5.9-46z\x22></path>\
+<path d=\x22m221.6 \
+67.1h-.1zm0 0c-.\
+5 0-1.8.3-3.2.3-\
+4.4 0-5.9-2-5.9-\
+4.6v-17.5h8.9c.5\
+ 0 .9-.4.9-1.1v-\
+9.5c0-.5-.4-.9-.\
+9-.9h-8.9v-11.7c\
+0-.4-.3-.7-.8-.7\
+h-12c-.5 0-.8.3-\
+.8.7v12.1s-6.1 1\
+.5-6.5 1.6-.7.5-\
+.7.9v7.6c0 .6.4 \
+1.1.9 1.1h6.2v18\
+.3c0 13.6 9.5 15\
+ 16 15 3 0 6.5-.\
+9 7.1-1.2.3-.1.5\
+-.5.5-.9v-8.4c.1\
+-.6-.3-1-.8-1.1z\
+m132.2-12.2c0-10\
+.1-4.1-11.4-8.4-\
+11-3.3.2-6 1.9-6\
+ 1.9v19.6s2.7 1.\
+9 6.8 2c5.8.2 7.\
+6-1.9 7.6-12.5zm\
+13.6-.9c0 19.1-6\
+.2 24.6-17 24.6-\
+9.1 0-14.1-4.6-1\
+4.1-4.6s-.2 2.6-\
+.5 2.9c-.2.3-.4.\
+4-.8.4h-8.3c-.6 \
+0-1.1-.4-1.1-.9l\
+.1-62c0-.5.4-.9.\
+9-.9h11.9c.5 0 .\
+9.4.9.9l-.1 20.9\
+s4.6-3 11.3-3h.1\
+c6.8-0 16.7 2.5 \
+16.7 21.7zm-48.7\
+-20.2h-11.7c-.6 \
+0-.9.4-.9 1.1v30\
+.3s-3.1 2.2-7.3 \
+2.2-5.4-1.9-5.4-\
+6.1v-26.5c0-.5-.\
+4-.9-.9-.9h-11.9\
+c-.5 0-.9.4-.9.9\
+v28.5c0 12.3 6.9\
+ 15.3 16.3 15.3 \
+7.8 0 14.1-4.3 1\
+4.1-4.3s.3 2.2.4\
+ 2.5.5.5.9.5h7.5\
+c.6 0 .9-.4.9-.9\
+l.1-41.7c-.1-.4-\
+.6-.9-1.2-.9zm-1\
+32.2 0h-11.9c-.5\
+ 0-.9.5-.9 1.1v4\
+0.9c0 1.1.7 1.5 \
+1.7 1.5h10.7c1.1\
+ 0 1.4-.5 1.4-1.\
+5v-41.1c0-.5-.5-\
+.9-1-.9zm-5.8-18\
+.9c-4.3 0-7.7 3.\
+4-7.7 7.7s3.4 7.\
+7 7.7 7.7c4.2 0 \
+7.6-3.4 7.6-7.7s\
+-3.4-7.7-7.6-7.7\
+zm92-1.4h-11.8c-\
+.5 0-.9.4-.9.9v2\
+2.8h-18.5v-22.7c\
+0-.5-.4-.9-.9-.9\
+h-11.9c-.5 0-.9.\
+4-.9.9v62c0 .5.5\
+.9.9.9h11.9c.5 0\
+ .9-.4.9-.9v-26.\
+6h18.5l-.1 26.5c\
+0 .5.4.9.9.9h11.\
+9c.5 0 .9-.4.9-.\
+9v-62c0-.4-.4-.9\
+-.9-.9zm-105.3 2\
+7.5v32c0 .2-.1.6\
+-.3.7 0 0-7 5-18\
+.5 5-13.9 0-30.3\
+-4.4-30.3-33 0-2\
+8.7 14.4-34.6 28\
+.4-34.5 12.2 0 1\
+7.1 2.7 17.8 3.2\
+.2.3.3.5.3.8l-2.\
+3 9.9c0 .5-.5 1.\
+1-1.1.9-2-.6-5-1\
+.8-12.1-1.8-8.2 \
+0-17 2.3-17 20.8\
+s8.4 20.6 14.4 2\
+0.6c5.1 0 7-.6 7\
+-.6v-12.8h-8.2c-\
+.6 0-1.1-.4-1.1-\
+.9v-10.3c0-.5.4-\
+.9 1.1-.9h20.9c.\
+6-.1 1 .4 1 .9z\x22\
+></path></g></sv\
+g>\x0a        </a>\x0a\
+\x0a        <h3 cla\
+ss=\x22h5 mt-4 mb-0\
+\x22 id=\x22subscribe-\
+to-newsletter\x22>S\
+ubscribe to our \
+developer newsle\
+tter</h3>\x0a      \
+  <p class=\x22f5 c\
+olor-fg-muted mb\
+-3\x22>Get tips, te\
+chnical guides, \
+and best practic\
+es. Twice a mont\
+h.</p>\x0a        <\
+a class=\x22btn-mkt\
+g mb-4 btn-muted\
+-mktg\x22 data-anal\
+ytics-event=\x22{&q\
+uot;category&quo\
+t;:&quot;Subscri\
+be&quot;,&quot;a\
+ction&quot;:&quo\
+t;click to Subsc\
+ribe&quot;,&quot\
+;label&quot;:&qu\
+ot;ref_cta:Subsc\
+ribe;&quot;}\x22 hr\
+ef=\x22https://reso\
+urces.github.com\
+/newsletter/\x22>\x0a \
+ Subscribe\x0a  \x0a  \
+\x0a</a>\x0a\x0a      </s\
+ection>\x0a\x0a      <\
+nav class=\x22col-6\
+ col-sm-3 col-lg\
+-2 mb-6 mb-md-2 \
+pr-3 pr-lg-0 pl-\
+lg-4\x22 aria-label\
+ledby=\x22footer-ti\
+tle-product\x22>\x0a  \
+      <h3 class=\
+\x22h5 mb-3 text-mo\
+no color-fg-mute\
+d text-normal\x22 i\
+d=\x22footer-title-\
+product\x22>\x0a      \
+    Product\x0a    \
+    </h3>\x0a\x0a     \
+   <ul class=\x22li\
+st-style-none co\
+lor-fg-muted f5\x22\
+>\x0a          <li \
+class=\x22lh-conden\
+sed mb-3\x22>\x0a     \
+       <a class=\
+\x22Link--secondary\
+\x22 data-analytics\
+-event=\x22{&quot;l\
+ocation&quot;:&q\
+uot;footer&quot;\
+,&quot;action&qu\
+ot;:&quot;featur\
+es&quot;,&quot;c\
+ontext&quot;:&qu\
+ot;product&quot;\
+,&quot;tag&quot;\
+:&quot;link&quot\
+;,&quot;label&qu\
+ot;:&quot;featur\
+es_link_product_\
+footer&quot;}\x22 h\
+ref=\x22/features\x22>\
+Features</a>\x0a   \
+       </li>\x0a   \
+       <li class\
+=\x22lh-condensed m\
+b-3\x22>\x0a          \
+  <a class=\x22Link\
+--secondary\x22 dat\
+a-analytics-even\
+t=\x22{&quot;locati\
+on&quot;:&quot;f\
+ooter&quot;,&quo\
+t;action&quot;:&\
+quot;enterprise&\
+quot;,&quot;cont\
+ext&quot;:&quot;\
+product&quot;,&q\
+uot;tag&quot;:&q\
+uot;link&quot;,&\
+quot;label&quot;\
+:&quot;enterpris\
+e_link_product_f\
+ooter&quot;}\x22 hr\
+ef=\x22/enterprise\x22\
+>Enterprise</a>\x0a\
+          </li>\x0a\
+          <li cl\
+ass=\x22lh-condense\
+d mb-3\x22>\x0a       \
+     <a class=\x22L\
+ink--secondary\x22 \
+data-analytics-e\
+vent=\x22{&quot;loc\
+ation&quot;:&quo\
+t;footer&quot;,&\
+quot;action&quot\
+;:&quot;copilot&\
+quot;,&quot;cont\
+ext&quot;:&quot;\
+product&quot;,&q\
+uot;tag&quot;:&q\
+uot;link&quot;,&\
+quot;label&quot;\
+:&quot;copilot_l\
+ink_product_foot\
+er&quot;}\x22 href=\
+\x22/features/copil\
+ot\x22>Copilot</a>\x0a\
+          </li>\x0a\
+            <li \
+class=\x22lh-conden\
+sed mb-3\x22>\x0a     \
+         <a clas\
+s=\x22Link--seconda\
+ry\x22 data-analyti\
+cs-event=\x22{&quot\
+;location&quot;:\
+&quot;footer&quo\
+t;,&quot;action&\
+quot;:&quot;ai&q\
+uot;,&quot;conte\
+xt&quot;:&quot;p\
+roduct&quot;,&qu\
+ot;tag&quot;:&qu\
+ot;link&quot;,&q\
+uot;label&quot;:\
+&quot;ai_link_pr\
+oduct_footer&quo\
+t;}\x22 href=\x22/feat\
+ures/ai\x22>AI</a>\x0a\
+            </li\
+>\x0a          <li \
+class=\x22lh-conden\
+sed mb-3\x22>\x0a     \
+       <a class=\
+\x22Link--secondary\
+\x22 data-analytics\
+-event=\x22{&quot;l\
+ocation&quot;:&q\
+uot;footer&quot;\
+,&quot;action&qu\
+ot;:&quot;securi\
+ty&quot;,&quot;c\
+ontext&quot;:&qu\
+ot;product&quot;\
+,&quot;tag&quot;\
+:&quot;link&quot\
+;,&quot;label&qu\
+ot;:&quot;securi\
+ty_link_product_\
+footer&quot;}\x22 h\
+ref=\x22/security\x22>\
+Security</a>\x0a   \
+       </li>\x0a   \
+       <li class\
+=\x22lh-condensed m\
+b-3\x22>\x0a          \
+  <a class=\x22Link\
+--secondary\x22 dat\
+a-analytics-even\
+t=\x22{&quot;locati\
+on&quot;:&quot;f\
+ooter&quot;,&quo\
+t;action&quot;:&\
+quot;pricing&quo\
+t;,&quot;context\
+&quot;:&quot;pro\
+duct&quot;,&quot\
+;tag&quot;:&quot\
+;link&quot;,&quo\
+t;label&quot;:&q\
+uot;pricing_link\
+_product_footer&\
+quot;}\x22 href=\x22/p\
+ricing\x22>Pricing<\
+/a>\x0a          </\
+li>\x0a          <l\
+i class=\x22lh-cond\
+ensed mb-3\x22>\x0a   \
+         <a clas\
+s=\x22Link--seconda\
+ry\x22 data-analyti\
+cs-event=\x22{&quot\
+;location&quot;:\
+&quot;footer&quo\
+t;,&quot;action&\
+quot;:&quot;team\
+&quot;,&quot;con\
+text&quot;:&quot\
+;product&quot;,&\
+quot;tag&quot;:&\
+quot;link&quot;,\
+&quot;label&quot\
+;:&quot;team_lin\
+k_product_footer\
+&quot;}\x22 href=\x22/\
+team\x22>Team</a>\x0a \
+         </li>\x0a \
+         <li cla\
+ss=\x22lh-condensed\
+ mb-3\x22>\x0a        \
+    <a class=\x22Li\
+nk--secondary\x22 d\
+ata-analytics-ev\
+ent=\x22{&quot;loca\
+tion&quot;:&quot\
+;footer&quot;,&q\
+uot;action&quot;\
+:&quot;resources\
+&quot;,&quot;con\
+text&quot;:&quot\
+;product&quot;,&\
+quot;tag&quot;:&\
+quot;link&quot;,\
+&quot;label&quot\
+;:&quot;resource\
+s_link_product_f\
+ooter&quot;}\x22 hr\
+ef=\x22https://reso\
+urces.github.com\
+\x22>Resources</a>\x0a\
+          </li>\x0a\
+          <li cl\
+ass=\x22lh-condense\
+d mb-3\x22>\x0a       \
+     <a class=\x22L\
+ink--secondary\x22 \
+data-analytics-e\
+vent=\x22{&quot;loc\
+ation&quot;:&quo\
+t;footer&quot;,&\
+quot;action&quot\
+;:&quot;roadmap&\
+quot;,&quot;cont\
+ext&quot;:&quot;\
+product&quot;,&q\
+uot;tag&quot;:&q\
+uot;link&quot;,&\
+quot;label&quot;\
+:&quot;roadmap_l\
+ink_product_foot\
+er&quot;}\x22 href=\
+\x22https://github.\
+com/github/roadm\
+ap\x22>Roadmap</a>\x0a\
+          </li>\x0a\
+          <li cl\
+ass=\x22lh-condense\
+d mb-3\x22>\x0a       \
+     <a class=\x22L\
+ink--secondary\x22 \
+data-analytics-e\
+vent=\x22{&quot;loc\
+ation&quot;:&quo\
+t;footer&quot;,&\
+quot;action&quot\
+;:&quot;compare&\
+quot;,&quot;cont\
+ext&quot;:&quot;\
+product&quot;,&q\
+uot;tag&quot;:&q\
+uot;link&quot;,&\
+quot;label&quot;\
+:&quot;compare_l\
+ink_product_foot\
+er&quot;}\x22 href=\
+\x22https://resourc\
+es.github.com/de\
+vops/tools/compa\
+re\x22>Compare GitH\
+ub</a>\x0a         \
+ </li>\x0a        <\
+/ul>\x0a      </nav\
+>\x0a\x0a      <nav cl\
+ass=\x22col-6 col-s\
+m-3 col-lg-2 mb-\
+6 mb-md-2 pr-3 p\
+r-md-0 pl-md-4\x22 \
+aria-labelledby=\
+\x22footer-title-pl\
+atform\x22>\x0a       \
+ <h3 class=\x22h5 m\
+b-3 text-mono co\
+lor-fg-muted tex\
+t-normal\x22 id=\x22fo\
+oter-title-platf\
+orm\x22>\x0a          \
+Platform\x0a       \
+ </h3>\x0a\x0a        \
+<ul class=\x22list-\
+style-none f5\x22>\x0a\
+          <li cl\
+ass=\x22lh-condense\
+d mb-3\x22>\x0a       \
+     <a class=\x22L\
+ink--secondary\x22 \
+data-analytics-e\
+vent=\x22{&quot;loc\
+ation&quot;:&quo\
+t;footer&quot;,&\
+quot;action&quot\
+;:&quot;dev-api&\
+quot;,&quot;cont\
+ext&quot;:&quot;\
+platform&quot;,&\
+quot;tag&quot;:&\
+quot;link&quot;,\
+&quot;label&quot\
+;:&quot;dev-api_\
+link_platform_fo\
+oter&quot;}\x22 hre\
+f=\x22https://docs.\
+github.com/get-s\
+tarted/exploring\
+-integrations/ab\
+out-building-int\
+egrations\x22>Devel\
+oper API</a>\x0a   \
+       </li>\x0a   \
+       <li class\
+=\x22lh-condensed m\
+b-3\x22>\x0a          \
+  <a class=\x22Link\
+--secondary\x22 dat\
+a-analytics-even\
+t=\x22{&quot;locati\
+on&quot;:&quot;f\
+ooter&quot;,&quo\
+t;action&quot;:&\
+quot;partners&qu\
+ot;,&quot;contex\
+t&quot;:&quot;pl\
+atform&quot;,&qu\
+ot;tag&quot;:&qu\
+ot;link&quot;,&q\
+uot;label&quot;:\
+&quot;partners_l\
+ink_platform_foo\
+ter&quot;}\x22 href\
+=\x22https://partne\
+r.github.com\x22>Pa\
+rtners</a>\x0a     \
+     </li>\x0a     \
+     <li class=\x22\
+lh-condensed mb-\
+3\x22>\x0a            \
+<a class=\x22Link--\
+secondary\x22 data-\
+analytics-event=\
+\x22{&quot;location\
+&quot;:&quot;foo\
+ter&quot;,&quot;\
+action&quot;:&qu\
+ot;edu&quot;,&qu\
+ot;context&quot;\
+:&quot;platform&\
+quot;,&quot;tag&\
+quot;:&quot;link\
+&quot;,&quot;lab\
+el&quot;:&quot;e\
+du_link_platform\
+_footer&quot;}\x22 \
+href=\x22https://gi\
+thub.com/edu\x22>Ed\
+ucation</a>\x0a    \
+      </li>\x0a    \
+      <li class=\
+\x22lh-condensed mb\
+-3\x22>\x0a           \
+ <a class=\x22Link-\
+-secondary\x22 data\
+-analytics-event\
+=\x22{&quot;locatio\
+n&quot;:&quot;fo\
+oter&quot;,&quot\
+;action&quot;:&q\
+uot;cli&quot;,&q\
+uot;context&quot\
+;:&quot;platform\
+&quot;,&quot;tag\
+&quot;:&quot;lin\
+k&quot;,&quot;la\
+bel&quot;:&quot;\
+cli_link_platfor\
+m_footer&quot;}\x22\
+ href=\x22https://c\
+li.github.com\x22>G\
+itHub CLI</a>\x0a  \
+        </li>\x0a  \
+        <li clas\
+s=\x22lh-condensed \
+mb-3\x22>\x0a         \
+   <a class=\x22Lin\
+k--secondary\x22 da\
+ta-analytics-eve\
+nt=\x22{&quot;locat\
+ion&quot;:&quot;\
+footer&quot;,&qu\
+ot;action&quot;:\
+&quot;desktop&qu\
+ot;,&quot;contex\
+t&quot;:&quot;pl\
+atform&quot;,&qu\
+ot;tag&quot;:&qu\
+ot;link&quot;,&q\
+uot;label&quot;:\
+&quot;desktop_li\
+nk_platform_foot\
+er&quot;}\x22 href=\
+\x22https://desktop\
+.github.com\x22>Git\
+Hub Desktop</a>\x0a\
+          </li>\x0a\
+          <li cl\
+ass=\x22lh-condense\
+d mb-3\x22>\x0a       \
+     <a class=\x22L\
+ink--secondary\x22 \
+data-analytics-e\
+vent=\x22{&quot;loc\
+ation&quot;:&quo\
+t;footer&quot;,&\
+quot;action&quot\
+;:&quot;mobile&q\
+uot;,&quot;conte\
+xt&quot;:&quot;p\
+latform&quot;,&q\
+uot;tag&quot;:&q\
+uot;link&quot;,&\
+quot;label&quot;\
+:&quot;mobile_li\
+nk_platform_foot\
+er&quot;}\x22 href=\
+\x22https://github.\
+com/mobile\x22>GitH\
+ub Mobile</a>\x0a  \
+        </li>\x0a  \
+      </ul>\x0a    \
+  </nav>\x0a\x0a      \
+<nav class=\x22col-\
+6 col-sm-3 col-l\
+g-2 mb-6 mb-md-2\
+ pr-3 pr-md-0 pl\
+-md-4\x22 aria-labe\
+lledby=\x22footer-t\
+itle-support\x22>\x0a \
+       <h3 class\
+=\x22h5 mb-3 text-m\
+ono color-fg-mut\
+ed text-normal\x22 \
+id=\x22footer-title\
+-support\x22>\x0a     \
+     Support\x0a   \
+     </h3>\x0a\x0a    \
+    <ul class=\x22l\
+ist-style-none f\
+5\x22>\x0a          <l\
+i class=\x22lh-cond\
+ensed mb-3\x22>\x0a   \
+         <a clas\
+s=\x22Link--seconda\
+ry\x22 data-analyti\
+cs-event=\x22{&quot\
+;location&quot;:\
+&quot;footer&quo\
+t;,&quot;action&\
+quot;:&quot;docs\
+&quot;,&quot;con\
+text&quot;:&quot\
+;support&quot;,&\
+quot;tag&quot;:&\
+quot;link&quot;,\
+&quot;label&quot\
+;:&quot;docs_lin\
+k_support_footer\
+&quot;}\x22 href=\x22h\
+ttps://docs.gith\
+ub.com\x22>Docs</a>\
+\x0a          </li>\
+\x0a\x0a          <li \
+class=\x22lh-conden\
+sed mb-3\x22>\x0a     \
+       <a class=\
+\x22Link--secondary\
+\x22 data-analytics\
+-event=\x22{&quot;l\
+ocation&quot;:&q\
+uot;footer&quot;\
+,&quot;action&qu\
+ot;:&quot;commun\
+ity&quot;,&quot;\
+context&quot;:&q\
+uot;support&quot\
+;,&quot;tag&quot\
+;:&quot;link&quo\
+t;,&quot;label&q\
+uot;:&quot;commu\
+nity_link_suppor\
+t_footer&quot;}\x22\
+ href=\x22https://g\
+ithub.community\x22\
+>Community Forum\
+</a>\x0a          <\
+/li>\x0a\x0a          \
+<li class=\x22lh-co\
+ndensed mb-3\x22>\x0a \
+           <a cl\
+ass=\x22Link--secon\
+dary\x22 data-analy\
+tics-event=\x22{&qu\
+ot;location&quot\
+;:&quot;footer&q\
+uot;,&quot;actio\
+n&quot;:&quot;se\
+rvices&quot;,&qu\
+ot;context&quot;\
+:&quot;support&q\
+uot;,&quot;tag&q\
+uot;:&quot;link&\
+quot;,&quot;labe\
+l&quot;:&quot;se\
+rvices_link_supp\
+ort_footer&quot;\
+}\x22 href=\x22https:/\
+/services.github\
+.com\x22>Profession\
+al Services</a>\x0a\
+          </li>\x0a\
+\x0a          <li c\
+lass=\x22lh-condens\
+ed mb-3\x22>\x0a      \
+      <a class=\x22\
+Link--secondary\x22\
+ data-analytics-\
+event=\x22{&quot;lo\
+cation&quot;:&qu\
+ot;footer&quot;,\
+&quot;action&quo\
+t;:&quot;premium\
+_support&quot;,&\
+quot;context&quo\
+t;:&quot;support\
+&quot;,&quot;tag\
+&quot;:&quot;lin\
+k&quot;,&quot;la\
+bel&quot;:&quot;\
+premium_support_\
+link_support_foo\
+ter&quot;}\x22 href\
+=\x22/enterprise/pr\
+emium-support\x22>P\
+remium Support</\
+a>\x0a          </l\
+i>\x0a\x0a          <l\
+i class=\x22lh-cond\
+ensed mb-3\x22>\x0a   \
+         <a clas\
+s=\x22Link--seconda\
+ry\x22 data-analyti\
+cs-event=\x22{&quot\
+;location&quot;:\
+&quot;footer&quo\
+t;,&quot;action&\
+quot;:&quot;skil\
+ls&quot;,&quot;c\
+ontext&quot;:&qu\
+ot;support&quot;\
+,&quot;tag&quot;\
+:&quot;link&quot\
+;,&quot;label&qu\
+ot;:&quot;skills\
+_link_support_fo\
+oter&quot;}\x22 hre\
+f=\x22https://skill\
+s.github.com\x22>Sk\
+ills</a>\x0a       \
+   </li>\x0a\x0a      \
+    <li class=\x22l\
+h-condensed mb-3\
+\x22>\x0a            <\
+a class=\x22Link--s\
+econdary\x22 data-a\
+nalytics-event=\x22\
+{&quot;location&\
+quot;:&quot;foot\
+er&quot;,&quot;a\
+ction&quot;:&quo\
+t;status&quot;,&\
+quot;context&quo\
+t;:&quot;support\
+&quot;,&quot;tag\
+&quot;:&quot;lin\
+k&quot;,&quot;la\
+bel&quot;:&quot;\
+status_link_supp\
+ort_footer&quot;\
+}\x22 href=\x22https:/\
+/www.githubstatu\
+s.com\x22>Status</a\
+>\x0a          </li\
+>\x0a\x0a          <li\
+ class=\x22lh-conde\
+nsed mb-3\x22>\x0a    \
+        <a class\
+=\x22Link--secondar\
+y\x22 data-analytic\
+s-event=\x22{&quot;\
+location&quot;:&\
+quot;footer&quot\
+;,&quot;action&q\
+uot;:&quot;conta\
+ct_github&quot;,\
+&quot;context&qu\
+ot;:&quot;suppor\
+t&quot;,&quot;ta\
+g&quot;:&quot;li\
+nk&quot;,&quot;l\
+abel&quot;:&quot\
+;contact_github_\
+link_support_foo\
+ter&quot;}\x22 href\
+=\x22https://suppor\
+t.github.com?tag\
+s=dotcom-footer\x22\
+>Contact GitHub<\
+/a>\x0a          </\
+li>\x0a        </ul\
+>\x0a      </nav>\x0a\x0a\
+      <nav class\
+=\x22col-6 col-sm-3\
+ col-lg-2 mb-6 m\
+b-md-2 pr-3 pr-m\
+d-0 pl-md-4\x22 ari\
+a-labelledby=\x22fo\
+oter-title-compa\
+ny\x22>\x0a        <h3\
+ class=\x22h5 mb-3 \
+text-mono color-\
+fg-muted text-no\
+rmal\x22 id=\x22footer\
+-title-company\x22>\
+\x0a          Compa\
+ny\x0a        </h3>\
+\x0a\x0a        <ul cl\
+ass=\x22list-style-\
+none f5\x22>\x0a      \
+    <li class=\x22l\
+h-condensed mb-3\
+\x22>\x0a            <\
+a class=\x22Link--s\
+econdary\x22 data-a\
+nalytics-event=\x22\
+{&quot;location&\
+quot;:&quot;foot\
+er&quot;,&quot;a\
+ction&quot;:&quo\
+t;about&quot;,&q\
+uot;context&quot\
+;:&quot;company&\
+quot;,&quot;tag&\
+quot;:&quot;link\
+&quot;,&quot;lab\
+el&quot;:&quot;a\
+bout_link_compan\
+y_footer&quot;}\x22\
+ href=\x22https://g\
+ithub.com/about\x22\
+>About</a>\x0a     \
+     </li>\x0a     \
+     <li class=\x22\
+lh-condensed mb-\
+3\x22>\x0a            \
+<a class=\x22Link--\
+secondary\x22 data-\
+analytics-event=\
+\x22{&quot;location\
+&quot;:&quot;foo\
+ter&quot;,&quot;\
+action&quot;:&qu\
+ot;why_github&qu\
+ot;,&quot;contex\
+t&quot;:&quot;co\
+mpany&quot;,&quo\
+t;tag&quot;:&quo\
+t;link&quot;,&qu\
+ot;label&quot;:&\
+quot;why_github_\
+link_company_foo\
+ter&quot;}\x22 href\
+=\x22https://github\
+.com/why-github\x22\
+>Why GitHub</a>\x0a\
+          </li>\x0a\
+          <li cl\
+ass=\x22lh-condense\
+d mb-3\x22>\x0a       \
+     <a class=\x22L\
+ink--secondary\x22 \
+data-analytics-e\
+vent=\x22{&quot;loc\
+ation&quot;:&quo\
+t;footer&quot;,&\
+quot;action&quot\
+;:&quot;customer\
+_stories&quot;,&\
+quot;context&quo\
+t;:&quot;company\
+&quot;,&quot;tag\
+&quot;:&quot;lin\
+k&quot;,&quot;la\
+bel&quot;:&quot;\
+customer_stories\
+_link_company_fo\
+oter&quot;}\x22 hre\
+f=\x22/customer-sto\
+ries?type=enterp\
+rise\x22>Customer s\
+tories</a>\x0a     \
+     </li>\x0a     \
+     <li class=\x22\
+lh-condensed mb-\
+3\x22>\x0a            \
+<a class=\x22Link--\
+secondary\x22 data-\
+analytics-event=\
+\x22{&quot;location\
+&quot;:&quot;foo\
+ter&quot;,&quot;\
+action&quot;:&qu\
+ot;blog&quot;,&q\
+uot;context&quot\
+;:&quot;company&\
+quot;,&quot;tag&\
+quot;:&quot;link\
+&quot;,&quot;lab\
+el&quot;:&quot;b\
+log_link_company\
+_footer&quot;}\x22 \
+href=\x22https://gi\
+thub.blog\x22>Blog<\
+/a>\x0a          </\
+li>\x0a          <l\
+i class=\x22lh-cond\
+ensed mb-3\x22>\x0a   \
+         <a clas\
+s=\x22Link--seconda\
+ry\x22 data-analyti\
+cs-event=\x22{&quot\
+;location&quot;:\
+&quot;footer&quo\
+t;,&quot;action&\
+quot;:&quot;read\
+me&quot;,&quot;c\
+ontext&quot;:&qu\
+ot;company&quot;\
+,&quot;tag&quot;\
+:&quot;link&quot\
+;,&quot;label&qu\
+ot;:&quot;readme\
+_link_company_fo\
+oter&quot;}\x22 hre\
+f=\x22/readme\x22>The \
+ReadME Project</\
+a>\x0a          </l\
+i>\x0a          <li\
+ class=\x22lh-conde\
+nsed mb-3\x22>\x0a    \
+        <a class\
+=\x22Link--secondar\
+y\x22 data-analytic\
+s-event=\x22{&quot;\
+location&quot;:&\
+quot;footer&quot\
+;,&quot;action&q\
+uot;:&quot;caree\
+rs&quot;,&quot;c\
+ontext&quot;:&qu\
+ot;company&quot;\
+,&quot;tag&quot;\
+:&quot;link&quot\
+;,&quot;label&qu\
+ot;:&quot;career\
+s_link_company_f\
+ooter&quot;}\x22 hr\
+ef=\x22https://gith\
+ub.careers\x22>Care\
+ers</a>\x0a        \
+  </li>\x0a        \
+  <li class=\x22lh-\
+condensed mb-3\x22>\
+\x0a            <a \
+class=\x22Link--sec\
+ondary\x22 data-ana\
+lytics-event=\x22{&\
+quot;location&qu\
+ot;:&quot;footer\
+&quot;,&quot;act\
+ion&quot;:&quot;\
+newsroom&quot;,&\
+quot;context&quo\
+t;:&quot;company\
+&quot;,&quot;tag\
+&quot;:&quot;lin\
+k&quot;,&quot;la\
+bel&quot;:&quot;\
+newsroom_link_co\
+mpany_footer&quo\
+t;}\x22 href=\x22/news\
+room\x22>Newsroom</\
+a>\x0a          </l\
+i>\x0a          <li\
+ class=\x22lh-conde\
+nsed mb-3\x22>\x0a    \
+        <a class\
+=\x22Link--secondar\
+y\x22 data-analytic\
+s-event=\x22{&quot;\
+location&quot;:&\
+quot;footer&quot\
+;,&quot;action&q\
+uot;:&quot;inclu\
+sion&quot;,&quot\
+;context&quot;:&\
+quot;company&quo\
+t;,&quot;tag&quo\
+t;:&quot;link&qu\
+ot;,&quot;label&\
+quot;:&quot;incl\
+usion_link_compa\
+ny_footer&quot;}\
+\x22 href=\x22/about/d\
+iversity\x22>Inclus\
+ion</a>\x0a        \
+  </li>\x0a        \
+  <li class=\x22lh-\
+condensed mb-3\x22>\
+\x0a            <a \
+class=\x22Link--sec\
+ondary\x22 data-ana\
+lytics-event=\x22{&\
+quot;location&qu\
+ot;:&quot;footer\
+&quot;,&quot;act\
+ion&quot;:&quot;\
+social_impact&qu\
+ot;,&quot;contex\
+t&quot;:&quot;co\
+mpany&quot;,&quo\
+t;tag&quot;:&quo\
+t;link&quot;,&qu\
+ot;label&quot;:&\
+quot;social_impa\
+ct_link_company_\
+footer&quot;}\x22 h\
+ref=\x22https://soc\
+ialimpact.github\
+.com\x22>Social Imp\
+act</a>\x0a        \
+  </li>\x0a        \
+  <li class=\x22lh-\
+condensed mb-3\x22>\
+\x0a            <a \
+class=\x22Link--sec\
+ondary\x22 data-ana\
+lytics-event=\x22{&\
+quot;location&qu\
+ot;:&quot;footer\
+&quot;,&quot;act\
+ion&quot;:&quot;\
+shop&quot;,&quot\
+;context&quot;:&\
+quot;company&quo\
+t;,&quot;tag&quo\
+t;:&quot;link&qu\
+ot;,&quot;label&\
+quot;:&quot;shop\
+_link_company_fo\
+oter&quot;}\x22 hre\
+f=\x22https://shop.\
+github.com\x22>Shop\
+</a>\x0a          <\
+/li>\x0a        </u\
+l>\x0a      </nav>\x0a\
+    </div>\x0a  </d\
+iv>\x0a\x0a  <div clas\
+s=\x22color-bg-subt\
+le\x22>\x0a    <div cl\
+ass=\x22container-x\
+l p-responsive f\
+6 py-4 d-md-flex\
+ flex-justify-be\
+tween flex-items\
+-center gap-3\x22>\x0a\
+      <nav aria-\
+label=\x22Legal and\
+ Resource Links\x22\
+>\x0a        <ul cl\
+ass=\x22list-style-\
+none d-flex flex\
+-wrap color-fg-m\
+uted gapx-3\x22>\x0a  \
+        <li>\x0a   \
+         &copy; \
+<time datetime=\x22\
+2025\x22>2025</time\
+> GitHub, Inc.\x0a \
+         </li>\x0a\x0a\
+          <li>\x0a \
+           <a cl\
+ass=\x22Link--secon\
+dary\x22 data-analy\
+tics-event=\x22{&qu\
+ot;location&quot\
+;:&quot;footer&q\
+uot;,&quot;actio\
+n&quot;:&quot;te\
+rms&quot;,&quot;\
+context&quot;:&q\
+uot;subfooter&qu\
+ot;,&quot;tag&qu\
+ot;:&quot;link&q\
+uot;,&quot;label\
+&quot;:&quot;ter\
+ms_link_subfoote\
+r_footer&quot;}\x22\
+ href=\x22https://d\
+ocs.github.com/s\
+ite-policy/githu\
+b-terms/github-t\
+erms-of-service\x22\
+>Terms</a>\x0a     \
+     </li>\x0a\x0a    \
+      <li>\x0a     \
+       <a class=\
+\x22Link--secondary\
+\x22 data-analytics\
+-event=\x22{&quot;l\
+ocation&quot;:&q\
+uot;footer&quot;\
+,&quot;action&qu\
+ot;:&quot;privac\
+y&quot;,&quot;co\
+ntext&quot;:&quo\
+t;subfooter&quot\
+;,&quot;tag&quot\
+;:&quot;link&quo\
+t;,&quot;label&q\
+uot;:&quot;priva\
+cy_link_subfoote\
+r_footer&quot;}\x22\
+ href=\x22https://d\
+ocs.github.com/s\
+ite-policy/priva\
+cy-policies/gith\
+ub-privacy-state\
+ment\x22>Privacy</a\
+>\x0a            <a\
+ href=\x22https://g\
+ithub.com/github\
+/site-policy/pul\
+l/582\x22 class=\x22Li\
+nk--secondary\x22>(\
+Updated 02/2024)\
+<time datetime=\x22\
+2024-02\x22 class=\x22\
+sr-only\x22>02/2024\
+</time></a>\x0a    \
+      </li>\x0a\x0a   \
+       <li>\x0a    \
+        <a class\
+=\x22Link--secondar\
+y\x22 data-analytic\
+s-event=\x22{&quot;\
+location&quot;:&\
+quot;footer&quot\
+;,&quot;action&q\
+uot;:&quot;sitem\
+ap&quot;,&quot;c\
+ontext&quot;:&qu\
+ot;subfooter&quo\
+t;,&quot;tag&quo\
+t;:&quot;link&qu\
+ot;,&quot;label&\
+quot;:&quot;site\
+map_link_subfoot\
+er_footer&quot;}\
+\x22 href=\x22/sitemap\
+\x22>Sitemap</a>\x0a  \
+        </li>\x0a\x0a \
+         <li>\x0a  \
+          <a cla\
+ss=\x22Link--second\
+ary\x22 data-analyt\
+ics-event=\x22{&quo\
+t;location&quot;\
+:&quot;footer&qu\
+ot;,&quot;action\
+&quot;:&quot;wha\
+t_is_git&quot;,&\
+quot;context&quo\
+t;:&quot;subfoot\
+er&quot;,&quot;t\
+ag&quot;:&quot;l\
+ink&quot;,&quot;\
+label&quot;:&quo\
+t;what_is_git_li\
+nk_subfooter_foo\
+ter&quot;}\x22 href\
+=\x22/git-guides\x22>W\
+hat is Git?</a>\x0a\
+          </li>\x0a\
+\x0a            <li\
+ >\x0a  <cookie-con\
+sent-link>\x0a    <\
+button\x0a      typ\
+e=\x22button\x22\x0a     \
+ class=\x22Link--se\
+condary underlin\
+e-on-hover borde\
+r-0 p-0 color-bg\
+-transparent\x22\x0a  \
+    data-action=\
+\x22click:cookie-co\
+nsent-link#showC\
+onsentManagement\
+\x22\x0a      data-ana\
+lytics-event=\x22{&\
+quot;location&qu\
+ot;:&quot;footer\
+&quot;,&quot;act\
+ion&quot;:&quot;\
+cookies&quot;,&q\
+uot;context&quot\
+;:&quot;subfoote\
+r&quot;,&quot;ta\
+g&quot;:&quot;li\
+nk&quot;,&quot;l\
+abel&quot;:&quot\
+;cookies_link_su\
+bfooter_footer&q\
+uot;}\x22\x0a    >\x0a   \
+    Manage cooki\
+es\x0a    </button>\
+\x0a  </cookie-cons\
+ent-link>\x0a</li>\x0a\
+\x0a<li>\x0a  <cookie-\
+consent-link>\x0a  \
+  <button\x0a      \
+type=\x22button\x22\x0a  \
+    class=\x22Link-\
+-secondary under\
+line-on-hover bo\
+rder-0 p-0 color\
+-bg-transparent \
+text-left\x22\x0a     \
+ data-action=\x22cl\
+ick:cookie-conse\
+nt-link#showCons\
+entManagement\x22\x0a \
+     data-analyt\
+ics-event=\x22{&quo\
+t;location&quot;\
+:&quot;footer&qu\
+ot;,&quot;action\
+&quot;:&quot;don\
+t_share_info&quo\
+t;,&quot;context\
+&quot;:&quot;sub\
+footer&quot;,&qu\
+ot;tag&quot;:&qu\
+ot;link&quot;,&q\
+uot;label&quot;:\
+&quot;dont_share\
+_info_link_subfo\
+oter_footer&quot\
+;}\x22\x0a    >\x0a      \
+Do not share my \
+personal informa\
+tion\x0a    </butto\
+n>\x0a  </cookie-co\
+nsent-link>\x0a</li\
+>\x0a\x0a        </ul>\
+\x0a      </nav>\x0a\x0a \
+     <nav aria-l\
+abel=\x22GitHub&#39\
+;s Social Media \
+Links\x22 class=\x22fo\
+oter-social mt-3\
+ mt-md-0 d-flex \
+gapx-6 gapy-1 fl\
+ex-wrap flex-ite\
+ms-center flex-l\
+g-justify-end\x22>\x0a\
+        \x0a<ul cla\
+ss=\x22list-style-n\
+one d-flex flex-\
+items-center lh-\
+condensed-ultra \
+gap-3\x22>\x0a    <li>\
+\x0a      <a href=\x22\
+https://www.link\
+edin.com/company\
+/github\x22 class=\x22\
+footer-social-ic\
+on d-block Link-\
+-outlineOffset\x22 \
+data-analytics-e\
+vent=\x22{&quot;cat\
+egory&quot;:&quo\
+t;Footer&quot;,&\
+quot;action&quot\
+;:&quot;go to Li\
+nkedin&quot;,&qu\
+ot;label&quot;:&\
+quot;text:linked\
+in&quot;}\x22>\x0a    \
+    <svg xmlns=\x22\
+http://www.w3.or\
+g/2000/svg\x22 view\
+Box=\x220 0 19 18\x22 \
+aria-hidden=\x22tru\
+e\x22 class=\x22d-bloc\
+k\x22 width=\x2219\x22 he\
+ight=\x2218\x22><path \
+d=\x22M3.94 2A2 2 0\
+ 1 1 2 0a2 2 0 0\
+ 1 1.94 2zM4 5.4\
+8H0V18h4zm6.32 0\
+H6.34V18h3.94v-6\
+.57c0-3.66 4.77-\
+4 4.77 0V18H19v-\
+7.93c0-6.17-7.06\
+-5.94-8.72-2.91z\
+\x22 fill=\x22currentC\
+olor\x22></path></s\
+vg>\x0a        <spa\
+n class=\x22sr-only\
+\x22>GitHub on Link\
+edIn</span>\x0a    \
+  </a>\x0a    </li>\
+\x0a    <li>\x0a      \
+<a href=\x22https:/\
+/www.instagram.c\
+om/github\x22 class\
+=\x22footer-social-\
+icon d-block Lin\
+k--outlineOffset\
+\x22 data-analytics\
+-event=\x22{&quot;c\
+ategory&quot;:&q\
+uot;Footer&quot;\
+,&quot;action&qu\
+ot;:&quot;go to \
+Instagram&quot;,\
+&quot;label&quot\
+;:&quot;text:ins\
+tagram&quot;}\x22>\x0a\
+        <svg xml\
+ns=\x22http://www.w\
+3.org/2000/svg\x22 \
+role=\x22img\x22 viewB\
+ox=\x220 0 24 24\x22 a\
+ria-hidden=\x22true\
+\x22 class=\x22d-block\
+\x22 width=\x2218\x22 hei\
+ght=\x2218\x22><title>\
+Instagram</title\
+><path d=\x22M12 0C\
+8.74 0 8.333.015\
+ 7.053.072 5.775\
+.132 4.905.333 4\
+.14.63c-.789.306\
+-1.459.717-2.126\
+ 1.384S.935 3.35\
+.63 4.14C.333 4.\
+905.131 5.775.07\
+2 7.053.012 8.33\
+3 0 8.74 0 12s.0\
+15 3.667.072 4.9\
+47c.06 1.277.261\
+ 2.148.558 2.913\
+.306.788.717 1.4\
+59 1.384 2.126.6\
+67.666 1.336 1.0\
+79 2.126 1.384.7\
+66.296 1.636.499\
+ 2.913.558C8.333\
+ 23.988 8.74 24 \
+12 24s3.667-.015\
+ 4.947-.072c1.27\
+7-.06 2.148-.262\
+ 2.913-.558.788-\
+.306 1.459-.718 \
+2.126-1.384.666-\
+.667 1.079-1.335\
+ 1.384-2.126.296\
+-.765.499-1.636.\
+558-2.913.06-1.2\
+8.072-1.687.072-\
+4.947s-.015-3.66\
+7-.072-4.947c-.0\
+6-1.277-.262-2.1\
+49-.558-2.913-.3\
+06-.789-.718-1.4\
+59-1.384-2.126C2\
+1.319 1.347 20.6\
+51.935 19.86.63c\
+-.765-.297-1.636\
+-.499-2.913-.558\
+C15.667.012 15.2\
+6 0 12 0zm0 2.16\
+c3.203 0 3.585.0\
+16 4.85.071 1.17\
+.055 1.805.249 2\
+.227.415.562.217\
+.96.477 1.382.89\
+6.419.42.679.819\
+.896 1.381.164.4\
+22.36 1.057.413 \
+2.227.057 1.266.\
+07 1.646.07 4.85\
+s-.015 3.585-.07\
+4 4.85c-.061 1.1\
+7-.256 1.805-.42\
+1 2.227-.224.562\
+-.479.96-.899 1.\
+382-.419.419-.82\
+4.679-1.38.896-.\
+42.164-1.065.36-\
+2.235.413-1.274.\
+057-1.649.07-4.8\
+59.07-3.211 0-3.\
+586-.015-4.859-.\
+074-1.171-.061-1\
+.816-.256-2.236-\
+.421-.569-.224-.\
+96-.479-1.379-.8\
+99-.421-.419-.69\
+-.824-.9-1.38-.1\
+65-.42-.359-1.06\
+5-.42-2.235-.045\
+-1.26-.061-1.649\
+-.061-4.844 0-3.\
+196.016-3.586.06\
+1-4.861.061-1.17\
+.255-1.814.42-2.\
+234.21-.57.479-.\
+96.9-1.381.419-.\
+419.81-.689 1.37\
+9-.898.42-.166 1\
+.051-.361 2.221-\
+.421 1.275-.045 \
+1.65-.06 4.859-.\
+06l.045.03zm0 3.\
+678c-3.405 0-6.1\
+62 2.76-6.162 6.\
+162 0 3.405 2.76\
+ 6.162 6.162 6.1\
+62 3.405 0 6.162\
+-2.76 6.162-6.16\
+2 0-3.405-2.76-6\
+.162-6.162-6.162\
+zM12 16c-2.21 0-\
+4-1.79-4-4s1.79-\
+4 4-4 4 1.79 4 4\
+-1.79 4-4 4zm7.8\
+46-10.405c0 .795\
+-.646 1.44-1.44 \
+1.44-.795 0-1.44\
+-.646-1.44-1.44 \
+0-.794.646-1.439\
+ 1.44-1.439.793-\
+.001 1.44.645 1.\
+44 1.439z\x22 fill=\
+\x22currentColor\x22><\
+/path></svg>\x0a   \
+     <span class\
+=\x22sr-only\x22>GitHu\
+b on Instagram</\
+span>\x0a      </a>\
+\x0a    </li>\x0a    <\
+li>\x0a      <a hre\
+f=\x22https://www.y\
+outube.com/githu\
+b\x22 class=\x22footer\
+-social-icon d-b\
+lock Link--outli\
+neOffset\x22 data-a\
+nalytics-event=\x22\
+{&quot;category&\
+quot;:&quot;Foot\
+er&quot;,&quot;a\
+ction&quot;:&quo\
+t;go to YouTube&\
+quot;,&quot;labe\
+l&quot;:&quot;te\
+xt:youtube&quot;\
+}\x22>\x0a        <svg\
+ xmlns=\x22http://w\
+ww.w3.org/2000/s\
+vg\x22 viewBox=\x220 0\
+ 19.17 13.6\x22 ari\
+a-hidden=\x22true\x22 \
+class=\x22d-block\x22 \
+width=\x2223\x22 heigh\
+t=\x2216\x22><path d=\x22\
+M18.77 2.13A2.4 \
+2.4 0 0 0 17.09.\
+42C15.59 0 9.58 \
+0 9.58 0a57.55 5\
+7.55 0 0 0-7.5.4\
+A2.49 2.49 0 0 0\
+ .39 2.13 26.27 \
+26.27 0 0 0 0 6.\
+8a26.15 26.15 0 \
+0 0 .39 4.67 2.4\
+3 2.43 0 0 0 1.6\
+9 1.71c1.52.42 7\
+.5.42 7.5.42a57.\
+69 57.69 0 0 0 7\
+.51-.4 2.4 2.4 0\
+ 0 0 1.68-1.71 2\
+5.63 25.63 0 0 0\
+ .4-4.67 24 24 0\
+ 0 0-.4-4.69zM7.\
+67 9.71V3.89l5 2\
+.91z\x22 fill=\x22curr\
+entColor\x22></path\
+></svg>\x0a        \
+<span class=\x22sr-\
+only\x22>GitHub on \
+YouTube</span>\x0a \
+     </a>\x0a    </\
+li>\x0a    <li>\x0a   \
+   <a href=\x22http\
+s://x.com/github\
+\x22 class=\x22footer-\
+social-icon d-bl\
+ock Link--outlin\
+eOffset\x22 data-an\
+alytics-event=\x22{\
+&quot;category&q\
+uot;:&quot;Foote\
+r&quot;,&quot;ac\
+tion&quot;:&quot\
+;go to X&quot;,&\
+quot;label&quot;\
+:&quot;text:x&qu\
+ot;}\x22>\x0a        <\
+svg xmlns=\x22http:\
+//www.w3.org/200\
+0/svg\x22 viewBox=\x22\
+0 0 1200 1227\x22 f\
+ill=\x22currentColo\
+r\x22 aria-hidden=\x22\
+true\x22 class=\x22d-b\
+lock\x22 width=\x2216\x22\
+ height=\x2216\x22><pa\
+th d=\x22M714.163 5\
+19.284 1160.89 0\
+h-105.86L667.137\
+ 450.887 357.328\
+ 0H0l468.492 681\
+.821L0 1226.37h1\
+05.866l409.625-4\
+76.152 327.181 4\
+76.152H1200L714.\
+137 519.284h.026\
+ZM569.165 687.82\
+8l-47.468-67.894\
+-377.686-540.24h\
+162.604l304.797 \
+435.991 47.468 6\
+7.894 396.2 566.\
+721H892.476L569.\
+165 687.854v-.02\
+6Z\x22></path></svg\
+>\x0a        <span \
+class=\x22sr-only\x22>\
+GitHub on X</spa\
+n>\x0a      </a>\x0a  \
+  </li>\x0a    <li>\
+\x0a      <a href=\x22\
+https://www.tikt\
+ok.com/@github\x22 \
+class=\x22footer-so\
+cial-icon d-bloc\
+k Link--outlineO\
+ffset\x22 data-anal\
+ytics-event=\x22{&q\
+uot;category&quo\
+t;:&quot;Footer&\
+quot;,&quot;acti\
+on&quot;:&quot;g\
+o to tiktok&quot\
+;,&quot;label&qu\
+ot;:&quot;text:t\
+iktok&quot;}\x22>\x0a \
+       <svg xmln\
+s=\x22http://www.w3\
+.org/2000/svg\x22 r\
+ole=\x22img\x22 viewBo\
+x=\x220 0 24 24\x22 ar\
+ia-hidden=\x22true\x22\
+ class=\x22d-block\x22\
+ width=\x2218\x22 heig\
+ht=\x2218\x22><title>T\
+ikTok</title><pa\
+th d=\x22M12.525.02\
+c1.31-.02 2.61-.\
+01 3.91-.02.08 1\
+.53.63 3.09 1.75\
+ 4.17 1.12 1.11 \
+2.7 1.62 4.24 1.\
+79v4.03c-1.44-.0\
+5-2.89-.35-4.2-.\
+97-.57-.26-1.1-.\
+59-1.62-.93-.01 \
+2.92.01 5.84-.02\
+ 8.75-.08 1.4-.5\
+4 2.79-1.35 3.94\
+-1.31 1.92-3.58 \
+3.17-5.91 3.21-1\
+.43.08-2.86-.31-\
+4.08-1.03-2.02-1\
+.19-3.44-3.37-3.\
+65-5.71-.02-.5-.\
+03-1-.01-1.49.18\
+-1.9 1.12-3.72 2\
+.58-4.96 1.66-1.\
+44 3.98-2.13 6.1\
+5-1.72.02 1.48-.\
+04 2.96-.04 4.44\
+-.99-.32-2.15-.2\
+3-3.02.37-.63.41\
+-1.11 1.04-1.36 \
+1.75-.21.51-.15 \
+1.07-.14 1.61.24\
+ 1.64 1.82 3.02 \
+3.5 2.87 1.12-.0\
+1 2.19-.66 2.77-\
+1.61.19-.33.4-.6\
+7.41-1.06.1-1.79\
+.06-3.57.07-5.36\
+.01-4.03-.01-8.0\
+5.02-12.07z\x22 fil\
+l=\x22currentColor\x22\
+></path></svg>\x0a \
+       <span cla\
+ss=\x22sr-only\x22>Git\
+Hub on TikTok</s\
+pan>\x0a      </a>\x0a\
+    </li>\x0a    <l\
+i>\x0a      <a href\
+=\x22https://www.tw\
+itch.tv/github\x22 \
+class=\x22footer-so\
+cial-icon d-bloc\
+k Link--outlineO\
+ffset\x22 data-anal\
+ytics-event=\x22{&q\
+uot;category&quo\
+t;:&quot;Footer&\
+quot;,&quot;acti\
+on&quot;:&quot;g\
+o to Twitch&quot\
+;,&quot;label&qu\
+ot;:&quot;text:t\
+witch&quot;}\x22>\x0a \
+       <svg xmln\
+s=\x22http://www.w3\
+.org/2000/svg\x22 r\
+ole=\x22img\x22 viewBo\
+x=\x220 0 24 24\x22 ar\
+ia-hidden=\x22true\x22\
+ class=\x22d-block\x22\
+ width=\x2218\x22 heig\
+ht=\x2218\x22><title>T\
+witch</title><pa\
+th d=\x22M11.571 4.\
+714h1.715v5.143H\
+11.57zm4.715 0H1\
+8v5.143h-1.714zM\
+6 0L1.714 4.286v\
+15.428h5.143V24l\
+4.286-4.286h3.42\
+8L22.286 12V0zm1\
+4.571 11.143l-3.\
+428 3.428h-3.429\
+l-3 3v-3H6.857V1\
+.714h13.714Z\x22 fi\
+ll=\x22currentColor\
+\x22></path></svg>\x0a\
+        <span cl\
+ass=\x22sr-only\x22>Gi\
+tHub on Twitch</\
+span>\x0a      </a>\
+\x0a    </li>\x0a    <\
+li>\x0a      <a hre\
+f=\x22https://githu\
+b.com/github\x22 cl\
+ass=\x22footer-soci\
+al-icon d-block \
+Link--outlineOff\
+set\x22 data-analyt\
+ics-event=\x22{&quo\
+t;category&quot;\
+:&quot;Footer&qu\
+ot;,&quot;action\
+&quot;:&quot;go \
+to github&#39;s \
+org&quot;,&quot;\
+label&quot;:&quo\
+t;text:github&qu\
+ot;}\x22>\x0a        <\
+svg xmlns=\x22http:\
+//www.w3.org/200\
+0/svg\x22 height=\x222\
+0\x22 viewBox=\x220 0 \
+16 16\x22 width=\x2220\
+\x22 aria-hidden=\x22t\
+rue\x22 class=\x22d-bl\
+ock\x22><path fill=\
+\x22currentColor\x22 d\
+=\x22M8 0C3.58 0 0 \
+3.58 0 8c0 3.54 \
+2.29 6.53 5.47 7\
+.59.4.07.55-.17.\
+55-.38 0-.19-.01\
+-.82-.01-1.49-2.\
+01.37-2.53-.49-2\
+.69-.94-.09-.23-\
+.48-.94-.82-1.13\
+-.28-.15-.68-.52\
+-.01-.53.63-.01 \
+1.08.58 1.23.82.\
+72 1.21 1.87.87 \
+2.33.66.07-.52.2\
+8-.87.51-1.07-1.\
+78-.2-3.64-.89-3\
+.64-3.95 0-.87.3\
+1-1.59.82-2.15-.\
+08-.2-.36-1.02.0\
+8-2.12 0 0 .67-.\
+21 2.2.82.64-.18\
+ 1.32-.27 2-.27.\
+68 0 1.36.09 2 .\
+27 1.53-1.04 2.2\
+-.82 2.2-.82.44 \
+1.1.16 1.92.08 2\
+.12.51.56.82 1.2\
+7.82 2.15 0 3.07\
+-1.87 3.75-3.65 \
+3.95.29.25.54.73\
+.54 1.48 0 1.07-\
+.01 1.93-.01 2.2\
+ 0 .21.15.46.55.\
+38A8.013 8.013 0\
+ 0016 8c0-4.42-3\
+.58-8-8-8z\x22></pa\
+th></svg>\x0a      \
+  <span class=\x22s\
+r-only\x22>GitHub\xe2\x80\
+\x99s organization \
+on GitHub</span>\
+\x0a      </a>\x0a    \
+</li>\x0a</ul>\x0a\x0a   \
+       \x0a\x0a  <loca\
+le-selector>\x0a   \
+ <experimental-a\
+ction-menu data-\
+anchor-align=\x22st\
+art\x22 data-anchor\
+-side=\x22outside-b\
+ottom\x22 data-view\
+-component=\x22true\
+\x22 class=\x22footer-\
+social-icon\x22>\x0a  \
+<button role=\x22bu\
+tton\x22 aria-haspo\
+pup=\x22true\x22 aria-\
+controls=\x22locale\
+-selector-list\x22 \
+aria-expanded=\x22f\
+alse\x22 id=\x22locale\
+-selector-text\x22 \
+aria-label=\x22Engl\
+ish - Select lan\
+guage\x22 type=\x22but\
+ton\x22 data-view-c\
+omponent=\x22true\x22 \
+class=\x22d-flex fl\
+ex-items-center \
+border-0 color-b\
+g-transparent p-\
+0 locale-trigger\
+ Button--seconda\
+ry Button--mediu\
+m Button\x22>  <spa\
+n class=\x22Button-\
+content\x22>\x0a    <s\
+pan class=\x22Butto\
+n-label\x22><span c\
+lass=\x22locale-sel\
+ector-trigger\x22>\x0a\
+          <svg h\
+eight=\x2216\x22 aria-\
+hidden=\x22true\x22 vi\
+ewBox=\x220 0 16 16\
+\x22 version=\x221.1\x22 \
+width=\x2216\x22 data-\
+view-component=\x22\
+true\x22 class=\x22oct\
+icon octicon-glo\
+be mr-1 color-fg\
+-muted locale-ic\
+on\x22>\x0a    <path d\
+=\x22M8 0a8 8 0 1 1\
+ 0 16A8 8 0 0 1 \
+8 0ZM5.78 8.75a9\
+.64 9.64 0 0 0 1\
+.363 4.177c.255.\
+426.542.832.857 \
+1.215.245-.296.5\
+51-.705.857-1.21\
+5A9.64 9.64 0 0 \
+0 10.22 8.75Zm4.\
+44-1.5a9.64 9.64\
+ 0 0 0-1.363-4.1\
+77c-.307-.51-.61\
+2-.919-.857-1.21\
+5a9.927 9.927 0 \
+0 0-.857 1.215A9\
+.64 9.64 0 0 0 5\
+.78 7.25Zm-5.944\
+ 1.5H1.543a6.507\
+ 6.507 0 0 0 4.6\
+66 5.5c-.123-.18\
+1-.24-.365-.352-\
+.552-.715-1.192-\
+1.437-2.874-1.58\
+1-4.948Zm-2.733-\
+1.5h2.733c.144-2\
+.074.866-3.756 1\
+.58-4.948.12-.19\
+7.237-.381.353-.\
+552a6.507 6.507 \
+0 0 0-4.666 5.5Z\
+m10.181 1.5c-.14\
+4 2.074-.866 3.7\
+56-1.58 4.948-.1\
+2.197-.237.381-.\
+353.552a6.507 6.\
+507 0 0 0 4.666-\
+5.5Zm2.733-1.5a6\
+.507 6.507 0 0 0\
+-4.666-5.5c.123.\
+181.24.365.353.5\
+52.714 1.192 1.4\
+36 2.874 1.58 4.\
+948Z\x22></path>\x0a</\
+svg>\x0a          <\
+span class=\x22colo\
+r-fg-muted Link-\
+-secondary f6\x22>E\
+nglish</span>\x0a  \
+        <svg hei\
+ght=\x2216\x22 aria-hi\
+dden=\x22true\x22 view\
+Box=\x220 0 16 16\x22 \
+version=\x221.1\x22 wi\
+dth=\x2216\x22 data-vi\
+ew-component=\x22tr\
+ue\x22 class=\x22octic\
+on octicon-chevr\
+on-down ml-1 col\
+or-fg-muted loca\
+le-icon\x22>\x0a    <p\
+ath d=\x22M12.78 5.\
+22a.749.749 0 0 \
+1 0 1.06l-4.25 4\
+.25a.749.749 0 0\
+ 1-1.06 0L3.22 6\
+.28a.749.749 0 1\
+ 1 1.06-1.06L8 8\
+.939l3.72-3.719a\
+.749.749 0 0 1 1\
+.06 0Z\x22></path>\x0a\
+</svg>\x0a        <\
+/span></span>\x0a  \
+</span>\x0a</button\
+>\x0a\x0a  <div class=\
+\x22Overlay-backdro\
+p--anchor\x22 data-\
+menu-overlay>\x0a  \
+  <div class=\x22Ov\
+erlay Overlay-wh\
+enNarrow Overlay\
+--height-auto Ov\
+erlay--width-aut\
+o\x22 hidden>\x0a     \
+ <div class=\x22Ove\
+rlay-body Overla\
+y-body--paddingN\
+one\x22>\x0a        <u\
+l class=\x22ActionL\
+ist\x22 id=\x22locale-\
+selector-list\x22 r\
+ole=\x22menu\x22 aria-\
+labelledby=\x22loca\
+le-selector-text\
+\x22>\x0a             \
+   <li role=\x22non\
+e\x22 data-view-com\
+ponent=\x22true\x22 cl\
+ass=\x22ActionList-\
+item\x22>\x0a    <a hr\
+ef=\x22\x22 selected=\x22\
+selected\x22 style=\
+\x22white-space: no\
+rmal;\x22 data-acti\
+on=\x22click:locale\
+-selector#handle\
+SelectLocale\x22 da\
+ta-locale=\x22en-us\
+\x22 data-analytics\
+-click=\x22{&quot;c\
+ategory&quot;:&q\
+uot;Locale Picke\
+r&quot;,&quot;ac\
+tion&quot;:&quot\
+;select language\
+&quot;,&quot;lab\
+el&quot;:&quot;l\
+ocale:en-us&quot\
+;}\x22 role=\x22menuit\
+em\x22 tabindex=\x22-1\
+\x22 data-view-comp\
+onent=\x22true\x22 cla\
+ss=\x22footer-socia\
+l-locale ActionL\
+ist-content\x22>\x0a  \
+    \x0a      <span\
+ class=\x22ActionLi\
+st-item-label\x22>\x0a\
+                \
+  <div style=\x22wi\
+dth: 16px; displ\
+ay: inline-block\
+; text-align: ce\
+nter; margin-rig\
+ht: 8px; flex-sh\
+rink: 0;\x22>\x0a     \
+       <svg heig\
+ht=\x2216\x22 aria-hid\
+den=\x22true\x22 viewB\
+ox=\x220 0 16 16\x22 v\
+ersion=\x221.1\x22 wid\
+th=\x2216\x22 data-vie\
+w-component=\x22tru\
+e\x22 class=\x22octico\
+n octicon-check\x22\
+>\x0a    <path d=\x22M\
+13.78 4.22a.75.7\
+5 0 0 1 0 1.06l-\
+7.25 7.25a.75.75\
+ 0 0 1-1.06 0L2.\
+22 9.28a.751.751\
+ 0 0 1 .018-1.04\
+2.751.751 0 0 1 \
+1.042-.018L6 10.\
+94l6.72-6.72a.75\
+.75 0 0 1 1.06 0\
+Z\x22></path>\x0a</svg\
+>\x0a          </di\
+v>\x0a          <sp\
+an>English</span\
+>\x0a\x0a      </span>\
+\x0a</a></li>\x0a     \
+           <li r\
+ole=\x22none\x22 data-\
+view-component=\x22\
+true\x22 class=\x22Act\
+ionList-item\x22>\x0a \
+   <a href=\x22\x22 st\
+yle=\x22white-space\
+: normal;\x22 data-\
+action=\x22click:lo\
+cale-selector#ha\
+ndleSelectLocale\
+\x22 data-locale=\x22p\
+t-br\x22 data-analy\
+tics-click=\x22{&qu\
+ot;category&quot\
+;:&quot;Locale P\
+icker&quot;,&quo\
+t;action&quot;:&\
+quot;select lang\
+uage&quot;,&quot\
+;label&quot;:&qu\
+ot;locale:pt-br&\
+quot;}\x22 role=\x22me\
+nuitem\x22 tabindex\
+=\x22-1\x22 data-view-\
+component=\x22true\x22\
+ class=\x22footer-s\
+ocial-locale Act\
+ionList-content\x22\
+>\x0a      \x0a      <\
+span class=\x22Acti\
+onList-item-labe\
+l\x22>\x0a            \
+      <div style\
+=\x22width: 16px; d\
+isplay: inline-b\
+lock; text-align\
+: center; margin\
+-right: 8px; fle\
+x-shrink: 0;\x22>\x0a \
+           \x0a    \
+      </div>\x0a   \
+       <span>Por\
+tugu\xc3\xaas (Brasil)\
+</span>\x0a\x0a      <\
+/span>\x0a</a></li>\
+\x0a               \
+ <li role=\x22none\x22\
+ data-view-compo\
+nent=\x22true\x22 clas\
+s=\x22ActionList-it\
+em\x22>\x0a    <a href\
+=\x22\x22 style=\x22white\
+-space: normal;\x22\
+ data-action=\x22cl\
+ick:locale-selec\
+tor#handleSelect\
+Locale\x22 data-loc\
+ale=\x22es-419\x22 dat\
+a-analytics-clic\
+k=\x22{&quot;catego\
+ry&quot;:&quot;L\
+ocale Picker&quo\
+t;,&quot;action&\
+quot;:&quot;sele\
+ct language&quot\
+;,&quot;label&qu\
+ot;:&quot;locale\
+:es-419&quot;}\x22 \
+role=\x22menuitem\x22 \
+tabindex=\x22-1\x22 da\
+ta-view-componen\
+t=\x22true\x22 class=\x22\
+footer-social-lo\
+cale ActionList-\
+content\x22>\x0a      \
+\x0a      <span cla\
+ss=\x22ActionList-i\
+tem-label\x22>\x0a    \
+              <d\
+iv style=\x22width:\
+ 16px; display: \
+inline-block; te\
+xt-align: center\
+; margin-right: \
+8px; flex-shrink\
+: 0;\x22>\x0a         \
+   \x0a          </\
+div>\x0a          <\
+span>Espa\xc3\xb1ol (A\
+m\xc3\xa9rica Latina)<\
+/span>\x0a\x0a      </\
+span>\x0a</a></li>\x0a\
+                \
+<li role=\x22none\x22 \
+data-view-compon\
+ent=\x22true\x22 class\
+=\x22ActionList-ite\
+m\x22>\x0a    <a href=\
+\x22\x22 style=\x22white-\
+space: normal;\x22 \
+data-action=\x22cli\
+ck:locale-select\
+or#handleSelectL\
+ocale\x22 data-loca\
+le=\x22ja\x22 data-ana\
+lytics-click=\x22{&\
+quot;category&qu\
+ot;:&quot;Locale\
+ Picker&quot;,&q\
+uot;action&quot;\
+:&quot;select la\
+nguage&quot;,&qu\
+ot;label&quot;:&\
+quot;locale:ja&q\
+uot;}\x22 role=\x22men\
+uitem\x22 tabindex=\
+\x22-1\x22 data-view-c\
+omponent=\x22true\x22 \
+class=\x22footer-so\
+cial-locale Acti\
+onList-content\x22>\
+\x0a      \x0a      <s\
+pan class=\x22Actio\
+nList-item-label\
+\x22>\x0a             \
+     <div style=\
+\x22width: 16px; di\
+splay: inline-bl\
+ock; text-align:\
+ center; margin-\
+right: 8px; flex\
+-shrink: 0;\x22>\x0a  \
+          \x0a     \
+     </div>\x0a    \
+      <span>\xe6\x97\xa5\xe6\
+\x9c\xac\xe8\xaa\x9e</span>\x0a\x0a  \
+    </span>\x0a</a>\
+</li>\x0a          \
+      <li role=\x22\
+none\x22 data-view-\
+component=\x22true\x22\
+ class=\x22ActionLi\
+st-item\x22>\x0a    <a\
+ href=\x22\x22 style=\x22\
+white-space: nor\
+mal;\x22 data-actio\
+n=\x22click:locale-\
+selector#handleS\
+electLocale\x22 dat\
+a-locale=\x22ko-kr\x22\
+ data-analytics-\
+click=\x22{&quot;ca\
+tegory&quot;:&qu\
+ot;Locale Picker\
+&quot;,&quot;act\
+ion&quot;:&quot;\
+select language&\
+quot;,&quot;labe\
+l&quot;:&quot;lo\
+cale:ko-kr&quot;\
+}\x22 role=\x22menuite\
+m\x22 tabindex=\x22-1\x22\
+ data-view-compo\
+nent=\x22true\x22 clas\
+s=\x22footer-social\
+-locale ActionLi\
+st-content\x22>\x0a   \
+   \x0a      <span \
+class=\x22ActionLis\
+t-item-label\x22>\x0a \
+                \
+ <div style=\x22wid\
+th: 16px; displa\
+y: inline-block;\
+ text-align: cen\
+ter; margin-righ\
+t: 8px; flex-shr\
+ink: 0;\x22>\x0a      \
+      \x0a         \
+ </div>\x0a        \
+  <span>\xed\x95\x9c\xea\xb5\xad\xec\x96\
+\xb4</span>\x0a\x0a      \
+</span>\x0a</a></li\
+>\x0a        </ul>\x0a\
+      </div>\x0a   \
+ </div>\x0a  </div>\
+\x0a</experimental-\
+action-menu>  </\
+locale-selector>\
+\x0a\x0a      </nav>\x0a \
+   </div>\x0a  </di\
+v>\x0a</footer>\x0a\x0a\x0a\x0a\
+    <ghcc-consen\
+t id=\x22ghcc\x22 clas\
+s=\x22position-fixe\
+d bottom-0 left-\
+0\x22 style=\x22z-inde\
+x: 999999\x22\x0a     \
+ data-locale=\x22en\
+\x22\x0a      data-ini\
+tial-cookie-cons\
+ent-allowed=\x22\x22\x0a \
+     data-cookie\
+-consent-require\
+d=\x22false\x22\x0a    ><\
+/ghcc-consent>\x0a\x0a\
+\x0a\x0a  <div id=\x22aja\
+x-error-message\x22\
+ class=\x22ajax-err\
+or-message flash\
+ flash-error\x22 hi\
+dden>\x0a    <svg a\
+ria-hidden=\x22true\
+\x22 height=\x2216\x22 vi\
+ewBox=\x220 0 16 16\
+\x22 version=\x221.1\x22 \
+width=\x2216\x22 data-\
+view-component=\x22\
+true\x22 class=\x22oct\
+icon octicon-ale\
+rt\x22>\x0a    <path d\
+=\x22M6.457 1.047c.\
+659-1.234 2.427-\
+1.234 3.086 0l6.\
+082 11.378A1.75 \
+1.75 0 0 1 14.08\
+2 15H1.918a1.75 \
+1.75 0 0 1-1.543\
+-2.575Zm1.763.70\
+7a.25.25 0 0 0-.\
+44 0L1.698 13.13\
+2a.25.25 0 0 0 .\
+22.368h12.164a.2\
+5.25 0 0 0 .22-.\
+368Zm.53 3.996v2\
+.5a.75.75 0 0 1-\
+1.5 0v-2.5a.75.7\
+5 0 0 1 1.5 0ZM9\
+ 11a1 1 0 1 1-2 \
+0 1 1 0 0 1 2 0Z\
+\x22></path>\x0a</svg>\
+\x0a    <button typ\
+e=\x22button\x22 class\
+=\x22flash-close js\
+-ajax-error-dism\
+iss\x22 aria-label=\
+\x22Dismiss error\x22>\
+\x0a      <svg aria\
+-hidden=\x22true\x22 h\
+eight=\x2216\x22 viewB\
+ox=\x220 0 16 16\x22 v\
+ersion=\x221.1\x22 wid\
+th=\x2216\x22 data-vie\
+w-component=\x22tru\
+e\x22 class=\x22octico\
+n octicon-x\x22>\x0a  \
+  <path d=\x22M3.72\
+ 3.72a.75.75 0 0\
+ 1 1.06 0L8 6.94\
+l3.22-3.22a.749.\
+749 0 0 1 1.275.\
+326.749.749 0 0 \
+1-.215.734L9.06 \
+8l3.22 3.22a.749\
+.749 0 0 1-.326 \
+1.275.749.749 0 \
+0 1-.734-.215L8 \
+9.06l-3.22 3.22a\
+.751.751 0 0 1-1\
+.042-.018.751.75\
+1 0 0 1-.018-1.0\
+42L6.94 8 3.72 4\
+.78a.75.75 0 0 1\
+ 0-1.06Z\x22></path\
+>\x0a</svg>\x0a    </b\
+utton>\x0a    You c\
+an\xe2\x80\x99t perform t\
+hat action at th\
+is time.\x0a  </div\
+>\x0a\x0a    <template\
+ id=\x22site-detail\
+s-dialog\x22>\x0a  <de\
+tails class=\x22det\
+ails-reset detai\
+ls-overlay detai\
+ls-overlay-dark \
+lh-default color\
+-fg-default hx_r\
+sm\x22 open>\x0a    <s\
+ummary role=\x22but\
+ton\x22 aria-label=\
+\x22Close dialog\x22><\
+/summary>\x0a    <d\
+etails-dialog cl\
+ass=\x22Box Box--ov\
+erlay d-flex fle\
+x-column anim-fa\
+de-in fast hx_rs\
+m-dialog hx_rsm-\
+modal\x22>\x0a      <b\
+utton class=\x22Box\
+-btn-octicon m-0\
+ btn-octicon pos\
+ition-absolute r\
+ight-0 top-0\x22 ty\
+pe=\x22button\x22 aria\
+-label=\x22Close di\
+alog\x22 data-close\
+-dialog>\x0a       \
+ <svg aria-hidde\
+n=\x22true\x22 height=\
+\x2216\x22 viewBox=\x220 \
+0 16 16\x22 version\
+=\x221.1\x22 width=\x2216\
+\x22 data-view-comp\
+onent=\x22true\x22 cla\
+ss=\x22octicon octi\
+con-x\x22>\x0a    <pat\
+h d=\x22M3.72 3.72a\
+.75.75 0 0 1 1.0\
+6 0L8 6.94l3.22-\
+3.22a.749.749 0 \
+0 1 1.275.326.74\
+9.749 0 0 1-.215\
+.734L9.06 8l3.22\
+ 3.22a.749.749 0\
+ 0 1-.326 1.275.\
+749.749 0 0 1-.7\
+34-.215L8 9.06l-\
+3.22 3.22a.751.7\
+51 0 0 1-1.042-.\
+018.751.751 0 0 \
+1-.018-1.042L6.9\
+4 8 3.72 4.78a.7\
+5.75 0 0 1 0-1.0\
+6Z\x22></path>\x0a</sv\
+g>\x0a      </butto\
+n>\x0a      <div cl\
+ass=\x22octocat-spi\
+nner my-6 js-det\
+ails-dialog-spin\
+ner\x22></div>\x0a    \
+</details-dialog\
+>\x0a  </details>\x0a<\
+/template>\x0a\x0a    \
+<div class=\x22Popo\
+ver js-hovercard\
+-content positio\
+n-absolute\x22 styl\
+e=\x22display: none\
+; outline: none;\
+\x22>\x0a  <div class=\
+\x22Popover-message\
+ Popover-message\
+--bottom-left Po\
+pover-message--l\
+arge Box color-s\
+hadow-large\x22 sty\
+le=\x22width:360px;\
+\x22>\x0a  </div>\x0a</di\
+v>\x0a\x0a    <templat\
+e id=\x22snippet-cl\
+ipboard-copy-but\
+ton\x22>\x0a  <div cla\
+ss=\x22zeroclipboar\
+d-container posi\
+tion-absolute ri\
+ght-0 top-0\x22>\x0a  \
+  <clipboard-cop\
+y aria-label=\x22Co\
+py\x22 class=\x22Clipb\
+oardButton btn j\
+s-clipboard-copy\
+ m-2 p-0\x22 data-c\
+opy-feedback=\x22Co\
+pied!\x22 data-tool\
+tip-direction=\x22w\
+\x22>\x0a      <svg ar\
+ia-hidden=\x22true\x22\
+ height=\x2216\x22 vie\
+wBox=\x220 0 16 16\x22\
+ version=\x221.1\x22 w\
+idth=\x2216\x22 data-v\
+iew-component=\x22t\
+rue\x22 class=\x22octi\
+con octicon-copy\
+ js-clipboard-co\
+py-icon m-2\x22>\x0a  \
+  <path d=\x22M0 6.\
+75C0 5.784.784 5\
+ 1.75 5h1.5a.75.\
+75 0 0 1 0 1.5h-\
+1.5a.25.25 0 0 0\
+-.25.25v7.5c0 .1\
+38.112.25.25.25h\
+7.5a.25.25 0 0 0\
+ .25-.25v-1.5a.7\
+5.75 0 0 1 1.5 0\
+v1.5A1.75 1.75 0\
+ 0 1 9.25 16h-7.\
+5A1.75 1.75 0 0 \
+1 0 14.25Z\x22></pa\
+th><path d=\x22M5 1\
+.75C5 .784 5.784\
+ 0 6.75 0h7.5C15\
+.216 0 16 .784 1\
+6 1.75v7.5A1.75 \
+1.75 0 0 1 14.25\
+ 11h-7.5A1.75 1.\
+75 0 0 1 5 9.25Z\
+m1.75-.25a.25.25\
+ 0 0 0-.25.25v7.\
+5c0 .138.112.25.\
+25.25h7.5a.25.25\
+ 0 0 0 .25-.25v-\
+7.5a.25.25 0 0 0\
+-.25-.25Z\x22></pat\
+h>\x0a</svg>\x0a      \
+<svg aria-hidden\
+=\x22true\x22 height=\x22\
+16\x22 viewBox=\x220 0\
+ 16 16\x22 version=\
+\x221.1\x22 width=\x2216\x22\
+ data-view-compo\
+nent=\x22true\x22 clas\
+s=\x22octicon octic\
+on-check js-clip\
+board-check-icon\
+ color-fg-succes\
+s d-none m-2\x22>\x0a \
+   <path d=\x22M13.\
+78 4.22a.75.75 0\
+ 0 1 0 1.06l-7.2\
+5 7.25a.75.75 0 \
+0 1-1.06 0L2.22 \
+9.28a.751.751 0 \
+0 1 .018-1.042.7\
+51.751 0 0 1 1.0\
+42-.018L6 10.94l\
+6.72-6.72a.75.75\
+ 0 0 1 1.06 0Z\x22>\
+</path>\x0a</svg>\x0a \
+   </clipboard-c\
+opy>\x0a  </div>\x0a</\
+template>\x0a<templ\
+ate id=\x22snippet-\
+clipboard-copy-b\
+utton-unposition\
+ed\x22>\x0a  <div clas\
+s=\x22zeroclipboard\
+-container\x22>\x0a   \
+ <clipboard-copy\
+ aria-label=\x22Cop\
+y\x22 class=\x22Clipbo\
+ardButton btn bt\
+n-invisible js-c\
+lipboard-copy m-\
+2 p-0 d-flex fle\
+x-justify-center\
+ flex-items-cent\
+er\x22 data-copy-fe\
+edback=\x22Copied!\x22\
+ data-tooltip-di\
+rection=\x22w\x22>\x0a   \
+   <svg aria-hid\
+den=\x22true\x22 heigh\
+t=\x2216\x22 viewBox=\x22\
+0 0 16 16\x22 versi\
+on=\x221.1\x22 width=\x22\
+16\x22 data-view-co\
+mponent=\x22true\x22 c\
+lass=\x22octicon oc\
+ticon-copy js-cl\
+ipboard-copy-ico\
+n\x22>\x0a    <path d=\
+\x22M0 6.75C0 5.784\
+.784 5 1.75 5h1.\
+5a.75.75 0 0 1 0\
+ 1.5h-1.5a.25.25\
+ 0 0 0-.25.25v7.\
+5c0 .138.112.25.\
+25.25h7.5a.25.25\
+ 0 0 0 .25-.25v-\
+1.5a.75.75 0 0 1\
+ 1.5 0v1.5A1.75 \
+1.75 0 0 1 9.25 \
+16h-7.5A1.75 1.7\
+5 0 0 1 0 14.25Z\
+\x22></path><path d\
+=\x22M5 1.75C5 .784\
+ 5.784 0 6.75 0h\
+7.5C15.216 0 16 \
+.784 16 1.75v7.5\
+A1.75 1.75 0 0 1\
+ 14.25 11h-7.5A1\
+.75 1.75 0 0 1 5\
+ 9.25Zm1.75-.25a\
+.25.25 0 0 0-.25\
+.25v7.5c0 .138.1\
+12.25.25.25h7.5a\
+.25.25 0 0 0 .25\
+-.25v-7.5a.25.25\
+ 0 0 0-.25-.25Z\x22\
+></path>\x0a</svg>\x0a\
+      <svg aria-\
+hidden=\x22true\x22 he\
+ight=\x2216\x22 viewBo\
+x=\x220 0 16 16\x22 ve\
+rsion=\x221.1\x22 widt\
+h=\x2216\x22 data-view\
+-component=\x22true\
+\x22 class=\x22octicon\
+ octicon-check j\
+s-clipboard-chec\
+k-icon color-fg-\
+success d-none\x22>\
+\x0a    <path d=\x22M1\
+3.78 4.22a.75.75\
+ 0 0 1 0 1.06l-7\
+.25 7.25a.75.75 \
+0 0 1-1.06 0L2.2\
+2 9.28a.751.751 \
+0 0 1 .018-1.042\
+.751.751 0 0 1 1\
+.042-.018L6 10.9\
+4l6.72-6.72a.75.\
+75 0 0 1 1.06 0Z\
+\x22></path>\x0a</svg>\
+\x0a    </clipboard\
+-copy>\x0a  </div>\x0a\
+</template>\x0a\x0a\x0a\x0a\x0a\
+    </div>\x0a    <\
+div id=\x22js-globa\
+l-screen-reader-\
+notice\x22 class=\x22s\
+r-only mt-n1\x22 ar\
+ia-live=\x22polite\x22\
+ aria-atomic=\x22tr\
+ue\x22 ></div>\x0a    \
+<div id=\x22js-glob\
+al-screen-reader\
+-notice-assertiv\
+e\x22 class=\x22sr-onl\
+y mt-n1\x22 aria-li\
+ve=\x22assertive\x22 a\
+ria-atomic=\x22true\
+\x22></div>\x0a  </bod\
+y>\x0a</html>\x0a\x0a\
+\x00\x00\x01N\
+<\
+svg\x0a  xmlns=\x22htt\
+p://www.w3.org/2\
+000/svg\x22\x0a  width\
+=\x2224\x22\x0a  height=\x22\
+24\x22\x0a  viewBox=\x220\
+ 0 24 24\x22\x0a  fill\
+=\x22none\x22\x0a  stroke\
+=\x22currentColor\x22\x0a\
+  stroke-width=\x22\
+2\x22\x0a  stroke-line\
+cap=\x22round\x22\x0a  st\
+roke-linejoin=\x22r\
+ound\x22\x0a>\x0a  <path \
+d=\x22M20.985 12.48\
+6a9 9 0 1 1-9.47\
+3-9.472c.405-.02\
+2.617.46.402.803\
+a6 6 0 0 0 8.268\
+ 8.268c.344-.215\
+.825-.004.803.40\
+1\x22 />\x0a</svg>\x0a\
+\x00\x00\x02J\
+<\
+svg\x0a  xmlns=\x22htt\
+p://www.w3.org/2\
+000/svg\x22\x0a  width\
+=\x2224\x22\x0a  height=\x22\
+24\x22\x0a  viewBox=\x220\
+ 0 24 24\x22\x0a  fill\
+=\x22none\x22\x0a  stroke\
+=\x22currentColor\x22\x0a\
+  stroke-width=\x22\
+2\x22\x0a  stroke-line\
+cap=\x22round\x22\x0a  st\
+roke-linejoin=\x22r\
+ound\x22\x0a>\x0a  <path \
+d=\x22M9.671 4.136a\
+2.34 2.34 0 0 1 \
+4.659 0 2.34 2.3\
+4 0 0 0 3.319 1.\
+915 2.34 2.34 0 \
+0 1 2.33 4.033 2\
+.34 2.34 0 0 0 0\
+ 3.831 2.34 2.34\
+ 0 0 1-2.33 4.03\
+3 2.34 2.34 0 0 \
+0-3.319 1.915 2.\
+34 2.34 0 0 1-4.\
+659 0 2.34 2.34 \
+0 0 0-3.32-1.915\
+ 2.34 2.34 0 0 1\
+-2.33-4.033 2.34\
+ 2.34 0 0 0 0-3.\
+831A2.34 2.34 0 \
+0 1 6.35 6.051a2\
+.34 2.34 0 0 0 3\
+.319-1.915\x22 />\x0a \
+ <circle cx=\x2212\x22\
+ cy=\x2212\x22 r=\x223\x22 /\
+>\x0a</svg>\x0a\
+\x00\x00\x01J\
+<\
+svg\x0a  xmlns=\x22htt\
+p://www.w3.org/2\
+000/svg\x22\x0a  width\
+=\x2224\x22\x0a  height=\x22\
+24\x22\x0a  viewBox=\x220\
+ 0 24 24\x22\x0a  fill\
+=\x22none\x22\x0a  stroke\
+=\x22currentColor\x22\x0a\
+  stroke-width=\x22\
+2\x22\x0a  stroke-line\
+cap=\x22round\x22\x0a  st\
+roke-linejoin=\x22r\
+ound\x22\x0a>\x0a  <path \
+d=\x22M9 17H7A5 5 0\
+ 0 1 7 7h2\x22 />\x0a \
+ <path d=\x22M15 7h\
+2a5 5 0 1 1 0 10\
+h-2\x22 />\x0a  <line \
+x1=\x228\x22 x2=\x2216\x22 y\
+1=\x2212\x22 y2=\x2212\x22 /\
+>\x0a</svg>\x0a\
+\x00\x00\x01&\
+<\
+svg\x0a  xmlns=\x22htt\
+p://www.w3.org/2\
+000/svg\x22\x0a  width\
+=\x2224\x22\x0a  height=\x22\
+24\x22\x0a  viewBox=\x220\
+ 0 24 24\x22\x0a  fill\
+=\x22none\x22\x0a  stroke\
+=\x22currentColor\x22\x0a\
+  stroke-width=\x22\
+2\x22\x0a  stroke-line\
+cap=\x22round\x22\x0a  st\
+roke-linejoin=\x22r\
+ound\x22\x0a>\x0a  <circl\
+e cx=\x2212\x22 cy=\x2212\
+\x22 r=\x2210\x22 />\x0a  <p\
+ath d=\x22M12 16v-4\
+\x22 />\x0a  <path d=\x22\
+M12 8h.01\x22 />\x0a</\
+svg>\x0a\
+\x00\x00\x01\x9d\
+<\
+svg\x0a  xmlns=\x22htt\
+p://www.w3.org/2\
+000/svg\x22\x0a  width\
+=\x2224\x22\x0a  height=\x22\
+24\x22\x0a  viewBox=\x220\
+ 0 24 24\x22\x0a  fill\
+=\x22none\x22\x0a  stroke\
+=\x22currentColor\x22\x0a\
+  stroke-width=\x22\
+2\x22\x0a  stroke-line\
+cap=\x22round\x22\x0a  st\
+roke-linejoin=\x22r\
+ound\x22\x0a>\x0a  <rect \
+width=\x2220\x22 heigh\
+t=\x228\x22 x=\x222\x22 y=\x222\
+\x22 rx=\x222\x22 ry=\x222\x22 \
+/>\x0a  <rect width\
+=\x2220\x22 height=\x228\x22\
+ x=\x222\x22 y=\x2214\x22 rx\
+=\x222\x22 ry=\x222\x22 />\x0a \
+ <line x1=\x226\x22 x2\
+=\x226.01\x22 y1=\x226\x22 y\
+2=\x226\x22 />\x0a  <line\
+ x1=\x226\x22 x2=\x226.01\
+\x22 y1=\x2218\x22 y2=\x2218\
+\x22 />\x0a</svg>\x0a\
+\x00\x00\x01\xe5\
+<\
+svg\x0a  xmlns=\x22htt\
+p://www.w3.org/2\
+000/svg\x22\x0a  width\
+=\x2224\x22\x0a  height=\x22\
+24\x22\x0a  viewBox=\x220\
+ 0 24 24\x22\x0a  fill\
+=\x22none\x22\x0a  stroke\
+=\x22currentColor\x22\x0a\
+  stroke-width=\x22\
+2\x22\x0a  stroke-line\
+cap=\x22round\x22\x0a  st\
+roke-linejoin=\x22r\
+ound\x22\x0a>\x0a  <circl\
+e cx=\x2212\x22 cy=\x2212\
+\x22 r=\x224\x22 />\x0a  <pa\
+th d=\x22M12 2v2\x22 /\
+>\x0a  <path d=\x22M12\
+ 20v2\x22 />\x0a  <pat\
+h d=\x22m4.93 4.93 \
+1.41 1.41\x22 />\x0a  \
+<path d=\x22m17.66 \
+17.66 1.41 1.41\x22\
+ />\x0a  <path d=\x22M\
+2 12h2\x22 />\x0a  <pa\
+th d=\x22M20 12h2\x22 \
+/>\x0a  <path d=\x22m6\
+.34 17.66-1.41 1\
+.41\x22 />\x0a  <path \
+d=\x22m19.07 4.93-1\
+.41 1.41\x22 />\x0a</s\
+vg>\x0a\
+\x00\x00\x01\xa0\
+<\
+svg\x0a  xmlns=\x22htt\
+p://www.w3.org/2\
+000/svg\x22\x0a  width\
+=\x2224\x22\x0a  height=\x22\
+24\x22\x0a  viewBox=\x220\
+ 0 24 24\x22\x0a  fill\
+=\x22none\x22\x0a  stroke\
+=\x22currentColor\x22\x0a\
+  stroke-width=\x22\
+2\x22\x0a  stroke-line\
+cap=\x22round\x22\x0a  st\
+roke-linejoin=\x22r\
+ound\x22\x0a>\x0a  <rect \
+width=\x227\x22 height\
+=\x229\x22 x=\x223\x22 y=\x223\x22\
+ rx=\x221\x22 />\x0a  <re\
+ct width=\x227\x22 hei\
+ght=\x225\x22 x=\x2214\x22 y\
+=\x223\x22 rx=\x221\x22 />\x0a \
+ <rect width=\x227\x22\
+ height=\x229\x22 x=\x221\
+4\x22 y=\x2212\x22 rx=\x221\x22\
+ />\x0a  <rect widt\
+h=\x227\x22 height=\x225\x22\
+ x=\x223\x22 y=\x2216\x22 rx\
+=\x221\x22 />\x0a</svg>\x0a\
+\x00\x00\x01n\
+<\
+svg\x0a  xmlns=\x22htt\
+p://www.w3.org/2\
+000/svg\x22\x0a  width\
+=\x2224\x22\x0a  height=\x22\
+24\x22\x0a  viewBox=\x220\
+ 0 24 24\x22\x0a  fill\
+=\x22none\x22\x0a  stroke\
+=\x22currentColor\x22\x0a\
+  stroke-width=\x22\
+2\x22\x0a  stroke-line\
+cap=\x22round\x22\x0a  st\
+roke-linejoin=\x22r\
+ound\x22\x0a>\x0a  <path \
+d=\x22M3 7V5a2 2 0 \
+0 1 2-2h2\x22 />\x0a  \
+<path d=\x22M17 3h2\
+a2 2 0 0 1 2 2v2\
+\x22 />\x0a  <path d=\x22\
+M21 17v2a2 2 0 0\
+ 1-2 2h-2\x22 />\x0a  \
+<path d=\x22M7 21H5\
+a2 2 0 0 1-2-2v-\
+2\x22 />\x0a</svg>\x0a\
+\x00\x00\x01\x04\
+<\
+svg\x0a  xmlns=\x22htt\
+p://www.w3.org/2\
+000/svg\x22\x0a  width\
+=\x2224\x22\x0a  height=\x22\
+24\x22\x0a  viewBox=\x220\
+ 0 24 24\x22\x0a  fill\
+=\x22none\x22\x0a  stroke\
+=\x22currentColor\x22\x0a\
+  stroke-width=\x22\
+2\x22\x0a  stroke-line\
+cap=\x22round\x22\x0a  st\
+roke-linejoin=\x22r\
+ound\x22\x0a>\x0a  <path \
+d=\x22M18 6 6 18\x22 /\
+>\x0a  <path d=\x22m6 \
+6 12 12\x22 />\x0a</sv\
+g>\x0a\
+\x00\x00\x01f\
+<\
+svg\x0a  xmlns=\x22htt\
+p://www.w3.org/2\
+000/svg\x22\x0a  width\
+=\x2224\x22\x0a  height=\x22\
+24\x22\x0a  viewBox=\x220\
+ 0 24 24\x22\x0a  fill\
+=\x22none\x22\x0a  stroke\
+=\x22currentColor\x22\x0a\
+  stroke-width=\x22\
+2\x22\x0a  stroke-line\
+cap=\x22round\x22\x0a  st\
+roke-linejoin=\x22r\
+ound\x22\x0a>\x0a  <rect \
+width=\x2218\x22 heigh\
+t=\x2218\x22 x=\x223\x22 y=\x22\
+3\x22 rx=\x222\x22 ry=\x222\x22\
+ />\x0a  <circle cx\
+=\x229\x22 cy=\x229\x22 r=\x222\
+\x22 />\x0a  <path d=\x22\
+m21 15-3.086-3.0\
+86a2 2 0 0 0-2.8\
+28 0L6 21\x22 />\x0a</\
+svg>\x0a\
+\x00\x00\x00\xef\
+<\
+svg\x0a  xmlns=\x22htt\
+p://www.w3.org/2\
+000/svg\x22\x0a  width\
+=\x2224\x22\x0a  height=\x22\
+24\x22\x0a  viewBox=\x220\
+ 0 24 24\x22\x0a  fill\
+=\x22none\x22\x0a  stroke\
+=\x22currentColor\x22\x0a\
+  stroke-width=\x22\
+2\x22\x0a  stroke-line\
+cap=\x22round\x22\x0a  st\
+roke-linejoin=\x22r\
+ound\x22\x0a>\x0a  <path \
+d=\x22M20 6 9 17l-5\
+-5\x22 />\x0a</svg>\x0a\
+\x00\x00\x01>\
+<\
+svg\x0a  xmlns=\x22htt\
+p://www.w3.org/2\
+000/svg\x22\x0a  width\
+=\x2224\x22\x0a  height=\x22\
+24\x22\x0a  viewBox=\x220\
+ 0 24 24\x22\x0a  fill\
+=\x22none\x22\x0a  stroke\
+=\x22currentColor\x22\x0a\
+  stroke-width=\x22\
+2\x22\x0a  stroke-line\
+cap=\x22round\x22\x0a  st\
+roke-linejoin=\x22r\
+ound\x22\x0a>\x0a  <path \
+d=\x22M12 15V3\x22 />\x0a\
+  <path d=\x22M21 1\
+5v4a2 2 0 0 1-2 \
+2H5a2 2 0 0 1-2-\
+2v-4\x22 />\x0a  <path\
+ d=\x22m7 10 5 5 5-\
+5\x22 />\x0a</svg>\x0a\
+"
+
+qt_resource_name = b"\
+\x00\x05\
+\x00o\xa6S\
+\x00i\
+\x00c\x00o\x00n\x00s\
+\x00\x05\
+\x00me\xb3\
+\x00f\
+\x00o\x00n\x00t\x00s\
+\x00\x06\
+\x07\xae\xc3\xc3\
+\x00t\
+\x00h\x00e\x00m\x00e\x00s\
+\x00\x08\
+\x08\x8eU\xe3\
+\x00d\
+\x00a\x00r\x00k\x00.\x00q\x00s\x00s\
+\x00\x09\
+\x0d\xf7\xbdC\
+\x00l\
+\x00i\x00g\x00h\x00t\x00.\x00q\x00s\x00s\
+\x00\x11\
+\x09\x95M&\
+\x00I\
+\x00n\x00t\x00e\x00r\x00-\x00R\x00e\x00g\x00u\x00l\x00a\x00r\x00.\x00t\x00t\x00f\
+\
+\x00\x08\
+\x06aTG\
+\x00m\
+\x00o\x00o\x00n\x00.\x00s\x00v\x00g\
+\x00\x0c\
+\x0b\xdf,\xc7\
+\x00s\
+\x00e\x00t\x00t\x00i\x00n\x00g\x00s\x00.\x00s\x00v\x00g\
+\x00\x0a\
+\x0e\x0b:G\
+\x00l\
+\x00i\x00n\x00k\x00-\x002\x00.\x00s\x00v\x00g\
+\x00\x08\
+\x04\xd2T\xc7\
+\x00i\
+\x00n\x00f\x00o\x00.\x00s\x00v\x00g\
+\x00\x0a\
+\x0c\xcac\xe7\
+\x00s\
+\x00e\x00r\x00v\x00e\x00r\x00.\x00s\x00v\x00g\
+\x00\x07\
+\x0a\xc1Z'\
+\x00s\
+\x00u\x00n\x00.\x00s\x00v\x00g\
+\x00\x14\
+\x09\x8f\xad\xc7\
+\x00l\
+\x00a\x00y\x00o\x00u\x00t\x00-\x00d\x00a\x00s\x00h\x00b\x00o\x00a\x00r\x00d\x00.\
+\x00s\x00v\x00g\
+\x00\x08\
+\x09\x81U\xe7\
+\x00s\
+\x00c\x00a\x00n\x00.\x00s\x00v\x00g\
+\x00\x05\
+\x00{Z\xc7\
+\x00x\
+\x00.\x00s\x00v\x00g\
+\x00\x09\
+\x07\xd8\xba\xa7\
+\x00i\
+\x00m\x00a\x00g\x00e\x00.\x00s\x00v\x00g\
+\x00\x09\
+\x0b\x9e\x89\x07\
+\x00c\
+\x00h\x00e\x00c\x00k\x00.\x00s\x00v\x00g\
+\x00\x0c\
+\x08\x1a\x90\xa7\
+\x00d\
+\x00o\x00w\x00n\x00l\x00o\x00a\x00d\x00.\x00s\x00v\x00g\
+"
+
+qt_resource_struct = b"\
+\x00\x00\x00\x00\x00\x02\x00\x00\x00\x03\x00\x00\x00\x01\
+\x00\x00\x00\x00\x00\x00\x00\x00\
+\x00\x00\x00\x10\x00\x02\x00\x00\x00\x01\x00\x00\x00\x12\
+\x00\x00\x00\x00\x00\x00\x00\x00\
+\x00\x00\x00\x00\x00\x02\x00\x00\x00\x0c\x00\x00\x00\x06\
+\x00\x00\x00\x00\x00\x00\x00\x00\
+\x00\x00\x00 \x00\x02\x00\x00\x00\x02\x00\x00\x00\x04\
+\x00\x00\x00\x00\x00\x00\x00\x00\
+\x00\x00\x002\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\
+\x00\x00\x01\x98\xa6#H\xda\
+\x00\x00\x00H\x00\x00\x00\x00\x00\x01\x00\x00\x05V\
+\x00\x00\x01\x98\xa6#S\x06\
+\x00\x00\x01^\x00\x00\x00\x00\x00\x01\x00\x04\x85\x8e\
+\x00\x00\x01\x98\xa6#7\xa6\
+\x00\x00\x00\xd6\x00\x00\x00\x00\x00\x01\x00\x04}\xc4\
+\x00\x00\x01\x98\xa6#5j\
+\x00\x00\x00\x88\x00\x00\x00\x00\x00\x01\x00\x04x\xd6\
+\x00\x00\x01\x98\xa6#3\x16\
+\x00\x00\x01n\x00\x00\x00\x00\x00\x01\x00\x04\x86\x96\
+\x00\x00\x01\x98\xa6#/\xc2\
+\x00\x00\x01\x9e\x00\x00\x00\x00\x00\x01\x00\x04\x88\xf3\
+\x00\x00\x01\x98\xa6#1V\
+\x00\x00\x01H\x00\x00\x00\x00\x00\x01\x00\x04\x84\x1c\
+\x00\x00\x01\x98\xa6#0\x9e\
+\x00\x00\x01\x1a\x00\x00\x00\x00\x00\x01\x00\x04\x82x\
+\x00\x00\x01\x98\xa6#::\
+\x00\x00\x01\x06\x00\x00\x00\x00\x00\x01\x00\x04\x80\x8f\
+\x00\x00\x01\x98\xa6#4\xa2\
+\x00\x00\x01\x86\x00\x00\x00\x00\x00\x01\x00\x04\x88\x00\
+\x00\x00\x01\x98\xa6#6\xe2\
+\x00\x00\x00\x9e\x00\x00\x00\x00\x00\x01\x00\x04z(\
+\x00\x00\x01\x98\xa6#26\
+\x00\x00\x00\xec\x00\x00\x00\x00\x00\x01\x00\x04~\xee\
+\x00\x00\x01\x98\xa6#8r\
+\x00\x00\x00\xbc\x00\x00\x00\x00\x00\x01\x00\x04|v\
+\x00\x00\x01\x98\xa6#9V\
+\x00\x00\x00`\x00\x00\x00\x00\x00\x01\x00\x00\x09\xf5\
+\x00\x00\x01\x98\xa6#d\x8a\
+"
+
+def qInitResources():
+    QtCore.qRegisterResourceData(0x03, qt_resource_struct, qt_resource_name, qt_resource_data)
+
+def qCleanupResources():
+    QtCore.qUnregisterResourceData(0x03, qt_resource_struct, qt_resource_name, qt_resource_data)
+
+qInitResources()
+
+### >>> localapp/ui_animations.py (83 lignes)
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+from PySide6.QtCore import (
+    QEasingCurve,
+    QParallelAnimationGroup,
+    QPropertyAnimation,
+    QPoint,
+    QTimer,
+    Qt,
+)
+from PySide6.QtWidgets import QLabel, QStackedWidget, QWidget
+try:
+    from PySide6.QtWidgets import QGraphicsOpacityEffect
+except Exception:  # pragma: no cover - gracefully degrade when Qt widgets missing
+    QGraphicsOpacityEffect = None
+
+
+def fade_in(w: QWidget, msec=180):
+    if QGraphicsOpacityEffect is None:
+        return  # pas d'animation si indisponible
+    eff = QGraphicsOpacityEffect(w)
+    w.setGraphicsEffect(eff)
+    anim = QPropertyAnimation(eff, b"opacity", w)
+    anim.setDuration(msec)
+    anim.setStartValue(0.0)
+    anim.setEndValue(1.0)
+    anim.setEasingCurve(QEasingCurve.Type.InOutQuad)
+    anim.start(QPropertyAnimation.DeletionPolicy.DeleteWhenStopped)
+
+
+class AnimatedStack(QStackedWidget):
+    def setCurrentIndex(self, index: int) -> None:
+        if index == self.currentIndex():
+            return super().setCurrentIndex(index)
+        old = self.currentWidget()
+        super().setCurrentIndex(index)
+        new = self.currentWidget()
+        if not new or QGraphicsOpacityEffect is None:
+            return
+        eff = QGraphicsOpacityEffect(new)
+        new.setGraphicsEffect(eff)
+        fade = QPropertyAnimation(eff, b"opacity", self)
+        fade.setDuration(180)
+        fade.setStartValue(0.0)
+        fade.setEndValue(1.0)
+        fade.setEasingCurve(QEasingCurve.Type.InOutQuad)
+        pos = QPropertyAnimation(new, b"pos", self)
+        pos.setDuration(180)
+        pos.setStartValue(new.pos() + QPoint(0, 10))
+        pos.setEndValue(new.pos())
+        pos.setEasingCurve(QEasingCurve.Type.OutCubic)
+        grp = QParallelAnimationGroup(self)
+        grp.addAnimation(fade)
+        grp.addAnimation(pos)
+        grp.start(QPropertyAnimation.DeletionPolicy.DeleteWhenStopped)
+
+
+class Toast(QWidget):
+    def __init__(self, parent=None, text="", kind="info"):
+        super().__init__(parent, flags=Qt.ToolTip | Qt.FramelessWindowHint)
+        self.setObjectName("Toast")
+        self.lbl = QLabel(text, self)
+        self.lbl.setWordWrap(True)
+        self.lbl.setStyleSheet(
+            """
+            QLabel{padding:8px 12px; border-radius:10px;
+            background: rgba(26, 32, 44, .92); color: #fff; font-weight:600;}
+            """
+        )
+        self.lbl.adjustSize()
+        self.resize(self.lbl.size())
+        QTimer.singleShot(2400, self.close)
+        fade_in(self, 160)
+
+
+def toast(parent: QWidget, text: str, kind="info"):
+    if not parent:
+        return
+    t = Toast(parent, text, kind)
+    g = parent.geometry()
+    t.adjustSize()
+    t.move(g.center().x() - t.width() // 2, g.bottom() - t.height() - 40)
+    t.show()
+
+### >>> localapp/ui_icons.py (25 lignes)
+from PySide6.QtWidgets import QApplication, QStyle
+from PySide6.QtGui import QIcon
+from PySide6.QtCore import QResource
+
+def get_icon(name: str) -> QIcon:
+    st = QApplication.style()
+    mp = {
+        "dashboard": QStyle.SP_ComputerIcon,
+        "journal": QStyle.SP_FileIcon,
+        "grand_livre": QStyle.SP_DirIcon,
+        "bilan": QStyle.SP_DialogApplyButton,
+        "resultat": QStyle.SP_DialogOkButton,
+        "comptes": QStyle.SP_DirHomeIcon,
+        "revision": getattr(QStyle, "SP_BrowserReload", QStyle.SP_BrowserStop),
+        "parametres": QStyle.SP_FileDialogDetailedView,
+        "scrap": QStyle.SP_MediaPlay,
+        "profil_scraping": QStyle.SP_FileDialogInfoView,
+        "galerie": QStyle.SP_DirOpenIcon,
+    }
+    if name in mp:
+        return st.standardIcon(mp[name])
+    path = f":/icons/{name}.svg"
+    if QResource.registerResource:
+        return QIcon(path)
+    return QIcon()
+
+### >>> localapp/ui_theme.py (98 lignes)
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+from pathlib import Path
+from PySide6.QtCore import QObject, Signal, QFile, QIODevice, QSettings
+from PySide6.QtGui import QFontDatabase, QPalette, QColor
+
+
+class ThemeManager(QObject):
+    theme_changed = Signal(str)
+
+    def __init__(self, app, *, org="app", name="ui"):
+        super().__init__()
+        self.app = app
+        self.settings = QSettings(org, name)
+        self._theme = self.settings.value("theme", "dark")
+        self._ensure_font()
+        self.apply(self._theme)
+
+    def _ensure_font(self):
+        """
+        Charge la police Inter depuis le qrc seulement si la ressource existe
+        ET a une taille cohérente. En cas d'échec, on ignore silencieusement
+        pour éviter le spam 'qt.qpa.fonts' (DirectWrite).
+        """
+        try:
+            f = QFile(":/fonts/Inter-Regular.ttf")
+            if not f.exists():
+                return
+            if not f.open(QIODevice.ReadOnly):
+                return
+            data = f.readAll()
+            f.close()
+
+            # sanity checks: taille & signatures TTF/OTF
+            if data.size() < 2048:
+                return
+            head = bytes(data[:4])
+            if head not in (b"\x00\x01\x00\x00", b"OTTO"):  # TTF or OTF(CFF)
+                return
+
+            fid = QFontDatabase.addApplicationFont(":/fonts/Inter-Regular.ttf")
+            if fid == -1:
+                # si la police n'est pas acceptée, on n'insiste pas
+                return
+        except Exception:
+            # Ne jamais bloquer le démarrage sur la police
+            return
+
+    def _load_qss(self, path: str) -> str:
+        """
+        Charge un fichier QSS en UTF-8.
+        - Tente d'abord la ressource Qt (ex: :/themes/dark.qss)
+        - Si absente, fallback vers un fichier sur disque: <dir>/themes/<name>.qss
+        """
+        # 1) Essai via ressource Qt
+        f = QFile(path)
+        if f.exists():
+            if not f.open(QIODevice.ReadOnly | QIODevice.Text):
+                return ""
+            try:
+                # Qt6: plus de setCodec; on lit les octets et on décode nous-mêmes
+                data = f.readAll()              # QByteArray
+                qss = bytes(data).decode("utf-8", errors="replace")
+                return qss
+            finally:
+                f.close()
+
+        # 2) Fallback fichier local (même nom que la ressource)
+        name = Path(path).name  # ex: 'dark.qss' ou 'light.qss'
+        local = Path(__file__).resolve().parent / "themes" / name
+        if local.exists():
+            return local.read_text(encoding="utf-8", errors="replace")
+
+        return ""
+
+    def apply(self, theme: str):
+        qss = self._load_qss(f":/themes/{'dark' if theme=='dark' else 'light'}.qss")
+        self.app.setStyleSheet(qss)
+        pal = QPalette()
+        if theme == "dark":
+            pal.setColor(QPalette.ColorRole.Highlight, QColor("#3f8cff"))
+            pal.setColor(QPalette.ColorRole.Window, QColor("#0f1115"))
+            pal.setColor(QPalette.ColorRole.WindowText, QColor("#e7eaf0"))
+        else:
+            pal.setColor(QPalette.ColorRole.Highlight, QColor("#2463eb"))
+            pal.setColor(QPalette.ColorRole.Window, QColor("#f7f8fb"))
+            pal.setColor(QPalette.ColorRole.WindowText, QColor("#0e1726"))
+        self.app.setPalette(pal)
+        self._theme = theme
+        self.settings.setValue("theme", theme)
+        self.theme_changed.emit(theme)
+
+    def toggle(self):
+        self.apply("light" if self._theme == "dark" else "dark")
+
+    @property
+    def current(self) -> str:
+        return self._theme
+
+### >>> localapp/utf8_bootstrap.py (39 lignes)
+# -*- coding: utf-8 -*-
+# localapp/utf8_bootstrap.py
+import os, sys, io
+
+
+def _reconfig_stream(stream_name: str):
+    s = getattr(sys, stream_name, None)
+    if not s:
+        return
+    try:
+        if hasattr(s, "reconfigure"):
+            s.reconfigure(encoding="utf-8", errors="replace")
+            return
+    except Exception:
+        pass
+    try:
+        if hasattr(s, "buffer"):
+            wrapped = io.TextIOWrapper(s.buffer, encoding="utf-8", errors="replace")
+            setattr(sys, stream_name, wrapped)
+    except Exception:
+        pass
+
+
+def _set_console_cp_utf8_on_windows():
+    try:
+        import ctypes
+        kernel32 = ctypes.windll.kernel32
+        kernel32.SetConsoleOutputCP(65001)
+        kernel32.SetConsoleCP(65001)
+    except Exception:
+        pass
+
+
+def force_utf8_stdio():
+    os.environ.setdefault("PYTHONUTF8", "1")
+    os.environ.setdefault("PYTHONIOENCODING", "utf-8")
+    _set_console_cp_utf8_on_windows()
+    _reconfig_stream("stdout")
+    _reconfig_stream("stderr")
+
+### >>> localapp/utils_collect.py (78 lignes)
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+import os, sys, time
+from pathlib import Path
+from typing import Iterable, List
+
+ALLOWED_EXTS = {
+    ".py", ".pyi", ".txt", ".md", ".json", ".yaml", ".yml", ".ini", ".cfg",
+    ".qss", ".qrc", ".html", ".htm", ".css", ".js", ".ts", ".tsx", ".svg"
+}
+IGNORE_DIRS = {".git", "__pycache__", ".mypy_cache", ".pytest_cache", ".idea", ".vscode",
+               "venv", ".venv", "env", "node_modules", "build", "dist", ".tox", ".ruff_cache"}
+MAX_BYTES = 1_000_000  # 1 Mo
+
+def detect_project_root(start: Path | None = None) -> Path:
+    """Essaie ../ (repo) puis répertoire courant du fichier appelant."""
+    if start is None:
+        start = Path(__file__).resolve()
+    # remonte jusqu'à trouver .git ou requirements/pyproject
+    cur = start
+    for _ in range(6):
+        p = cur.parent
+        if (p / '.git').exists() or (p / 'requirements.txt').exists() or (p / 'pyproject.toml').exists():
+            return p
+        cur = p
+    # fallback: deux niveaux au-dessus de /localapp/
+    return Path(__file__).resolve().parents[1]
+
+def iter_sources(root: Path, *, out_path: Path | None = None) -> Iterable[Path]:
+    """Parcourt root en ignorant dossiers poubelles; garde extensions whitelistées, < MAX_BYTES, et exclut out_path."""
+    for dirpath, dirnames, filenames in os.walk(root):
+        # prune des dossiers ignorés
+        dirnames[:] = [d for d in dirnames if d not in IGNORE_DIRS]
+        for fn in filenames:
+            p = Path(dirpath) / fn
+            # exclure copy.txt lui-même
+            if out_path and p.resolve() == out_path.resolve():
+                continue
+            ext = p.suffix.lower()
+            if ext not in ALLOWED_EXTS:
+                continue
+            try:
+                if p.stat().st_size > MAX_BYTES:
+                    continue
+            except Exception:
+                continue
+            yield p
+
+def build_copy_txt(root: Path, out_path: Path) -> dict:
+    """Construit copy.txt; renvoie stats."""
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    files: List[Path] = list(iter_sources(root, out_path=out_path))
+    files.sort(key=lambda x: x.as_posix())
+
+    written_bytes = 0
+    written_files = 0
+    now = time.strftime("%Y-%m-%dT%H:%M:%S", time.localtime())
+    with open(out_path, "w", encoding="utf-8", errors="replace") as out:
+        out.write("# copy.txt regénéré automatiquement\n")
+        out.write(f"# {now}\n\n")
+        for fp in files:
+            rel = fp.relative_to(root)
+            try:
+                txt = fp.read_text(encoding="utf-8", errors="replace")
+            except Exception as ex:
+                # si lecture impossible, on note et on continue
+                out.write(f"### >>> {rel} (lecture impossible: {ex})\n\n")
+                continue
+            lines = txt.count("\n") + (1 if txt and not txt.endswith("\n") else 0)
+            header = f"### >>> {rel} ({lines} lignes)\n"
+            out.write(header)
+            out.write(txt)
+            if not txt.endswith("\n"):
+                out.write("\n")
+            out.write("\n")
+            written_files += 1
+            written_bytes += len(header.encode("utf-8")) + len(txt.encode("utf-8")) + 1
+    return {"files": written_files, "bytes": written_bytes, "out": str(out_path)}
+
+### >>> log_safe.py (30 lignes)
+import sys
+from typing import Any
+
+def _safe_write(stream, text: str):
+    # Écrit en gérant les caractères non encodables (remplacement)
+    try:
+        stream.write(text + "\n")
+    except Exception:
+        enc = getattr(stream, "encoding", None) or "utf-8"
+        # backslashreplace évite les plantages même en cp1252
+        stream.write(text.encode(enc, "backslashreplace").decode(enc) + "\n")
+
+def print_safe(*args: Any, sep: str=" ", end: str="\n"):
+    # Équivalent print, mais robuste à l'encodage
+    out = getattr(sys, "stdout", None)
+    if not out:
+        return
+    s = sep.join("" if a is None else str(a) for a in args)
+    if end and not s.endswith(end):
+        s = s + end
+    try:
+        out.write(s)
+    except Exception:
+        _safe_write(out, s.rstrip("\n"))
+
+def open_utf8(path: str, mode: str="r"):
+    # Ouvre un fichier texte en UTF-8 avec remplacement robuste
+    if "b" in mode:
+        return open(path, mode)  # binaire: inchangé
+    return open(path, mode, encoding="utf-8", errors="replace")
+
+### >>> openapi/lamine-product-bridge.yaml (111 lignes)
+openapi: 3.1.0
+info:
+  title: Lamine Product Bridge
+  version: "1.0"
+servers:
+  - url: https://YOUR_PUBLIC_DOMAIN
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-KEY
+security:
+  - ApiKeyAuth: []
+paths:
+  /files/list:
+    get:
+      operationId: listFiles
+      summary: Liste les fichiers d'un dossier
+      parameters:
+        - in: query
+          name: folder
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  files:
+                    type: array
+                    items: { type: string }
+                  urls:
+                    type: array
+                    items: { type: string }
+                  folder:
+                    type: string
+  /files/raw:
+    get:
+      operationId: getRawFile
+      summary: Récupère un fichier brut
+      parameters:
+        - in: query
+          name: folder
+          required: true
+          schema: { type: string }
+        - in: query
+          name: name
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: OK
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        "404": { description: Not found }
+  /products:
+    get:
+      operationId: listProducts
+      summary: Liste les produits (dossiers sous images_root)
+      responses:
+        "200": { description: OK }
+  /products/{slug}/images:
+    get:
+      operationId: getProductImages
+      summary: URLs publiques des images d’un produit
+      parameters:
+        - in: path
+          name: slug
+          required: true
+          schema: { type: string }
+      responses:
+        "200": { description: OK }
+        "404": { description: Not found }
+  /products/{slug}/descriptions:
+    post:
+      operationId: saveProductDescription
+      summary: Sauvegarde CSV/JSON de la fiche produit
+      parameters:
+        - in: path
+          name: slug
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name: { type: string }
+                short_description: { type: string }
+                description: { type: string }
+                categories: { type: array, items: { type: string } }
+                tags: { type: array, items: { type: string } }
+                regular_price: { type: string }
+                sale_price: { type: string }
+                slug: { type: string }
+                focus_keyword: { type: string }
+                meta_title: { type: string }
+                meta_description: { type: string }
+                internal_link: { type: string }
+      responses:
+        "200": { description: OK }
+        "401": { description: Unauthorized }
+
+### >>> requirements.txt (8 lignes)
+PySide6
+pytest
+selenium>=4.10
+requests
+openpyxl
+Flask
+pyngrok
+Pillow>=10.0.0
+
+### >>> scrape_subprocess.py (65 lignes)
+# --- Bootstrap UTF-8, compatible run module ET run direct ---
+try:
+    from localapp.utf8_bootstrap import force_utf8_stdio
+except ImportError:
+    from utf8_bootstrap import force_utf8_stdio
+force_utf8_stdio()
+
+# Logs robustes (print_safe)
+try:
+    from localapp.log_safe import print_safe, open_utf8
+except ImportError:
+    from log_safe import print_safe, open_utf8
+
+import sys
+import json
+from pathlib import Path
+from selenium.webdriver.common.by import By
+
+from MOTEUR.scraping.image_scraper import scrape_images, scrape_variants
+from MOTEUR.scraping import history
+
+
+def main():
+    if len(sys.argv) < 5:
+        print_safe(json.dumps({"event": "error", "msg": "missing args"}))
+        sys.stdout.flush()
+        return
+    cfg = {
+        "input": sys.argv[1],
+        "selector": sys.argv[2],
+        "folder": sys.argv[3],
+        "with_variants": sys.argv[4] == "1",
+    }
+    print_safe(json.dumps({"event": "start", "cfg": cfg}))
+    sys.stdout.flush()
+    with open_utf8(cfg["input"]) as f:
+        urls = [u.strip() for u in f if u.strip()]
+    total_urls = len(urls)
+    for i, url in enumerate(urls, 1):
+        try:
+            if cfg["with_variants"]:
+                total, driver = scrape_images(url, cfg["selector"], cfg["folder"], keep_driver=True)
+                try:
+                    driver.find_element(By.TAG_NAME, "h1")
+                except Exception:
+                    pass
+                variants = scrape_variants(driver)
+                driver.quit()
+            else:
+                total = scrape_images(url, cfg["selector"], cfg["folder"])
+                variants = {}
+            history.log_scrape(url, cfg["selector"], total, cfg["folder"])
+            print_safe(json.dumps({"event": "item", "url": url, "total": total, "variants": variants}))
+            sys.stdout.flush()
+        except Exception as e:
+            print_safe(json.dumps({"event": "log", "msg": f"Erreur sur {url}: {e}"}))
+            sys.stdout.flush()
+        print_safe(json.dumps({"event": "progress", "done": i, "total": total_urls}))
+        sys.stdout.flush()
+    print_safe(json.dumps({"event": "done", "total": total_urls}))
+    sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()
+
+### >>> server_config.json (17 lignes)
+{
+  "port": 5001,
+  "api_key": "dev-key",
+  "expose": false,
+  "ngrok_token": "",
+  "headless": true,
+  "ignore_robots": false,
+  "rate": 0,
+  "max_workers": 1,
+  "path_aliases": {
+    "sample_folder": "",
+    "images_root": "C:\\Users\\Lamine\\Desktop\\scrap\\projet\\images"
+  },
+  "aliases": {
+    "images_root": "C:\\Users\\Lamine\\Desktop\\scrap\\projet\\images"
+  }
+}
+
+### >>> tests/manual_profiles_test.md (16 lignes)
+# Manual Profiles Test
+
+1. Lancer l'application Qt et démarrer le serveur Flask depuis l'onglet dédié.
+2. Depuis un terminal ou Postman, envoyer :
+   ```bash
+   curl -X POST https://<ngrok>.ngrok-free.app/profiles \
+        -H "X-API-KEY: <CLE>" -H "Content-Type: application/json" \
+        -d '{"name":"Test","selector":".img-class"}'
+   ```
+3. Vérifier que la réponse HTTP est `201` et que le profil "Test" apparaît immédiatement dans l'onglet Profil Scraping.
+4. Répéter la requête POST identique : la réponse doit être `409` et aucun doublon ne doit apparaître dans l'UI.
+5. Tester la route de liste :
+   ```bash
+   curl -X GET https://<ngrok>.ngrok-free.app/profiles -H "X-API-KEY: <CLE>"
+   ```
+   Le profil "Test" doit être présent dans le JSON retourné.
+
+### >>> tests/test_aliases_and_validation.py (91 lignes)
+import time
+from pathlib import Path
+import os, sys
+
+sys.path.append(os.getcwd())
+
+from PIL import Image
+
+from MOTEUR.scraping.server.flask_server import FlaskBridgeServer
+
+
+def _make_image(path: Path) -> None:
+    img = Image.new("RGB", (10, 10), "red")
+    img.save(path)
+
+
+def test_aliases_and_image_edit(tmp_path):
+    img_dir = tmp_path / "imgs"
+    img_dir.mkdir()
+    _make_image(img_dir / "a.png")
+
+    srv = FlaskBridgeServer()
+    srv.api_key = "k"
+    client = srv.app.test_client()
+
+    resp = client.get("/aliases", headers={"X-API-KEY": "k"})
+    assert resp.status_code == 200
+    assert resp.get_json() == {"sample_folder": ""}
+
+    resp = client.post(
+        "/aliases",
+        json={"sample_folder": str(img_dir)},
+        headers={"X-API-KEY": "k"},
+    )
+    assert resp.status_code == 200
+    assert resp.get_json() == {
+        "sample_folder": str(img_dir),
+        "sample_images": str(img_dir),
+    }
+
+    payload = {
+        "source": {"folder": "sample_images"},
+        "operations": [{"op": "resize", "width": 5, "height": 5}],
+    }
+    resp = client.post(
+        "/actions/image-edit", json=payload, headers={"X-API-KEY": "k"}
+    )
+    assert resp.status_code == 202
+    job_id = resp.get_json()["job_id"]
+
+    for _ in range(30):
+        data = client.get(
+            f"/jobs/{job_id}", headers={"X-API-KEY": "k"}
+        ).get_json()
+        if data["status"] in {"done", "error"}:
+            break
+        time.sleep(0.1)
+    assert data["status"] == "done"
+    assert data["progress"]["downloaded"] == 1
+
+
+def test_image_edit_validation_errors(tmp_path):
+    srv = FlaskBridgeServer()
+    srv.api_key = "k"
+    client = srv.app.test_client()
+
+    payload = {
+        "source": {"folder": str(tmp_path / "missing")},
+        "operations": [{"op": "resize", "width": 5, "height": 5}],
+    }
+    resp = client.post(
+        "/actions/image-edit", json=payload, headers={"X-API-KEY": "k"}
+    )
+    assert resp.status_code == 400
+    assert "source not found" in resp.get_json()["detail"]
+
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+    payload["source"] = {"folder": str(empty_dir)}
+    resp = client.post(
+        "/actions/image-edit", json=payload, headers={"X-API-KEY": "k"}
+    )
+    assert resp.status_code == 400
+    assert "no images" in resp.get_json()["detail"]
+
+    payload["source"] = {"folder": ""}
+    resp = client.post(
+        "/actions/image-edit", json=payload, headers={"X-API-KEY": "k"}
+    )
+    assert resp.status_code == 400
+    assert resp.get_json()["detail"] == "source.folder is empty"
+
+### >>> tests/test_download_naming.py (44 lignes)
+from pathlib import Path
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from MOTEUR.scraping.image_scraper import _download
+
+
+class DummyResponse:
+    def __init__(self):
+        from PIL import Image
+        from io import BytesIO
+
+        buf = BytesIO()
+        Image.new("RGB", (50, 50), "white").save(buf, format="PNG")
+        self.content = buf.getvalue()
+        self.headers = {"Content-Type": "image/png"}
+
+    def raise_for_status(self):
+        pass
+
+
+class DummySession:
+    def get(self, url, timeout):
+        return DummyResponse()
+
+
+def test_download_name_cleanup(tmp_path, monkeypatch):
+    monkeypatch.setenv("SCRAPER_FORCE_WEBP", "1")
+    monkeypatch.setattr(
+        "MOTEUR.scraping.image_scraper._make_http_session",
+        lambda: DummySession(),
+    )
+
+    url1 = "http://example.com/bob-avec-lacet-409.jpg"
+    url2 = "http://example.com/bob-avec-lacet-1023.jpg"
+    _download(url1, tmp_path)
+    _download(url2, tmp_path)
+
+    names = sorted(p.name for p in tmp_path.iterdir())
+    assert names == ["bob-avec-lacet.webp", "bob-avec-lacet_1.webp"]
+
+
+### >>> tests/test_image_action_endpoint.py (44 lignes)
+import time
+from pathlib import Path
+
+from PIL import Image
+
+from MOTEUR.scraping.server.flask_server import FlaskBridgeServer
+
+
+def _make_image(path: Path, color: str) -> None:
+    img = Image.new("RGB", (10, 10), color)
+    img.save(path)
+
+
+def test_image_action_endpoint(tmp_path):
+    _make_image(tmp_path / "a.png", "red")
+    _make_image(tmp_path / "b.jpg", "blue")
+
+    srv = FlaskBridgeServer()
+    srv.api_key = "k"
+    client = srv.app.test_client()
+
+    payload = {
+        "source": {"folder": str(tmp_path)},
+        "operations": [{"op": "resize", "width": 5, "height": 5, "keep_ratio": True}],
+        "target_subdir": "out",
+    }
+    resp = client.post(
+        "/actions/image-edit", json=payload, headers={"X-API-KEY": "k"}
+    )
+    assert resp.status_code == 202
+    job_id = resp.get_json()["job_id"]
+
+    for _ in range(30):
+        data = client.get(
+            f"/jobs/{job_id}", headers={"X-API-KEY": "k"}
+        ).get_json()
+        if data["status"] in {"done", "error"}:
+            break
+        time.sleep(0.1)
+    assert data["status"] == "done"
+    assert data["progress"]["downloaded"] == 2
+    out_dir = Path(data["output_dir"])
+    assert (out_dir / "a.png").exists()
+    assert (out_dir / "b.jpg").exists()
+
+### >>> tests/test_image_scraper_widget.py (85 lignes)
+from pathlib import Path
+import sys
+import os
+import pytest
+
+QtWidgets = pytest.importorskip("PySide6.QtWidgets")
+QApplication = QtWidgets.QApplication
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from MOTEUR.scraping import profile_manager as pm
+from MOTEUR.scraping import history
+from MOTEUR.scraping.widgets.image_widget import ImageScraperWidget
+
+
+def test_scrape_logs_history(tmp_path, monkeypatch):
+    pm.PROFILES_FILE = tmp_path / "profiles.json"
+    history.HISTORY_FILE = tmp_path / "history.json"
+    history.LAST_USED_FILE = tmp_path / "last.json"
+    pm.save_profiles([{"name": "p1", "selector": ".a"}])
+
+    app = QApplication.instance() or QApplication([])
+    widget = ImageScraperWidget()
+    widget.refresh_profiles()
+    widget.set_selected_profile("p1")
+    urls_file = tmp_path / "urls.txt"
+    urls_file.write_text("http://example.com\nhttp://ex2.com\n")
+    widget.file_edit.setText(str(urls_file))
+    widget.folder_edit.setText(str(tmp_path))
+
+    monkeypatch.setattr(
+        "MOTEUR.scraping.widgets.image_worker.scrape_images",
+        lambda url, sel, folder, keep_driver=False: 5,
+    )
+
+    widget._start()
+    while widget._thread.isRunning():
+        app.processEvents()
+
+    entries = history.load_history()
+    assert len(entries) == 2
+    assert entries[0]["url"] == "http://example.com"
+    assert entries[1]["url"] == "http://ex2.com"
+    assert all(e["profile"] == ".a" and e["images"] == 5 for e in entries)
+    widget.close()
+
+
+def test_export_excel(tmp_path, monkeypatch):
+    pm.PROFILES_FILE = tmp_path / "profiles.json"
+    pm.save_profiles([{"name": "p1", "selector": ".a"}])
+
+    app = QApplication.instance() or QApplication([])
+    widget = ImageScraperWidget()
+    widget.export_data = [
+        {"URL": "u1", "Variant": "v1", "Image": "img1"},
+        {"URL": "u2", "Variant": "v2", "Image": "img2"},
+    ]
+
+    out_file = tmp_path / "out.xlsx"
+
+    monkeypatch.setattr(
+        "MOTEUR.scraping.widgets.image_widget.QFileDialog.getSaveFileName",
+        lambda *a, **k: (str(out_file), "")
+    )
+    infos = []
+    monkeypatch.setattr(
+        "MOTEUR.scraping.widgets.image_widget.QMessageBox.information",
+        lambda *a, **k: infos.append(1)
+    )
+
+    widget._export_excel()
+
+    assert out_file.exists()
+    from openpyxl import load_workbook
+
+    wb = load_workbook(out_file)
+    ws = wb.active
+    data = list(ws.iter_rows(values_only=True))
+    assert data[1] == ("u1", "v1", "img1")
+    assert data[2] == ("u2", "v2", "img2")
+    widget.close()
+
+### >>> tests/test_mainwindow.py (22 lignes)
+import sys
+from pathlib import Path
+import pytest
+
+QtWidgets = pytest.importorskip("PySide6.QtWidgets")
+QApplication = QtWidgets.QApplication
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+import os
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from localapp.app import MainWindow
+
+
+def test_mainwindow_creation():
+    app = QApplication.instance() or QApplication([])
+    window = MainWindow()
+    assert window.windowTitle() == "COMPTA - Interface de gestion comptable"
+    window.close()
+
+### >>> tests/test_profile_manager.py (49 lignes)
+from pathlib import Path
+import sys
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+import pytest
+
+from MOTEUR.scraping import profile_manager as pm
+
+
+def test_load_profiles_empty(tmp_path: Path):
+    pm.PROFILES_FILE = tmp_path / "profiles.json"
+    assert pm.load_profiles() == []
+
+
+def test_add_update_delete_profile(tmp_path: Path):
+    pm.PROFILES_FILE = tmp_path / "profiles.json"
+
+    # Add a profile
+    pm.add_profile("test", ".selector")
+    profiles = pm.load_profiles()
+    assert profiles == [{"name": "test", "selector": ".selector"}]
+
+    # Update the profile
+    updated = pm.update_profile("test", "div.img")
+    assert updated is True
+    profiles = pm.load_profiles()
+    assert profiles[0]["selector"] == "div.img"
+
+    # Delete the profile
+    removed = pm.delete_profile("test")
+    assert removed is True
+    assert pm.load_profiles() == []
+
+    # Update/delete non-existing returns False
+    assert pm.update_profile("missing", "x") is False
+    assert pm.delete_profile("missing") is False
+
+
+def test_profile_persistence(tmp_path: Path):
+    """Profiles created via :mod:`profile_manager` should persist on disk."""
+    pm.PROFILES_FILE = tmp_path / "profiles.json"
+
+    pm.add_profile("persist", ".x")
+    # Reload from disk to verify persistence
+    new_list = pm.load_profiles()
+    assert new_list == [{"name": "persist", "selector": ".x"}]
+
+### >>> tests/test_profile_widget.py (78 lignes)
+from pathlib import Path
+import sys
+import os
+import pytest
+
+QtWidgets = pytest.importorskip("PySide6.QtWidgets")
+QApplication = QtWidgets.QApplication
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from MOTEUR.scraping import profile_manager as pm
+from MOTEUR.scraping.widgets.profile_widget import ProfileWidget
+
+
+def setup_widget(tmp_path):
+    pm.PROFILES_FILE = tmp_path / "profiles.json"
+    pm.save_profiles([
+        {"name": "p1", "selector": ".a"},
+        {"name": "p2", "selector": ".b"},
+    ])
+    app = QApplication.instance() or QApplication([])
+    widget = ProfileWidget()
+    return widget
+
+
+def test_load_and_select(tmp_path):
+    widget = setup_widget(tmp_path)
+    assert widget.profile_list.count() == 2
+
+    chosen = []
+    widget.profile_chosen.connect(lambda name: chosen.append(name))
+    widget.profile_list.setCurrentRow(1)
+    assert chosen == ["p2"]
+    widget.close()
+
+
+def test_add_and_delete(tmp_path):
+    widget = setup_widget(tmp_path)
+    updates = []
+    widget.profiles_updated.connect(lambda: updates.append(1))
+
+    widget.name_edit.setText("new")
+    widget.selector_edit.setText(".c")
+    widget.add_btn.click()
+    assert widget.profile_list.count() == 3
+    assert len(updates) == 1
+
+    widget.profile_list.setCurrentRow(0)
+    widget.delete_btn.click()
+    assert widget.profile_list.count() == 2
+    assert len(updates) == 2
+    widget.close()
+
+
+def test_profile_selection_updates_image_widget(tmp_path):
+    """Selecting a profile should update the ImageScraperWidget."""
+    from MOTEUR.scraping.widgets.image_widget import ImageScraperWidget
+
+    pm.PROFILES_FILE = tmp_path / "profiles.json"
+    pm.save_profiles([
+        {"name": "p1", "selector": ".a"},
+        {"name": "p2", "selector": ".b"},
+    ])
+
+    app = QApplication.instance() or QApplication([])
+    profile_widget = ProfileWidget()
+    image_widget = ImageScraperWidget()
+    image_widget.refresh_profiles()
+    profile_widget.profile_chosen.connect(image_widget.set_selected_profile)
+
+    profile_widget.profile_list.setCurrentRow(1)
+    assert image_widget.profile_combo.currentText() == "p2"
+    profile_widget.close()
+    image_widget.close()
+
+### >>> tests/test_restart_utils.py (27 lignes)
+import os
+import sys
+import subprocess
+import time
+
+from MOTEUR.scraping.utils.restart import relaunch_current_process
+
+
+def test_relaunch_uses_absolute_script_path(monkeypatch, tmp_path):
+    # simulate a script launched with a relative path
+    script = tmp_path / "script.py"
+    script.write_text("print('hi')\n")
+    monkeypatch.setattr(sys, 'argv', [script.name, 'arg1'])
+
+    called = {}
+    def fake_popen(argv, **kwargs):
+        called['argv'] = argv
+        class Dummy: pass
+        return Dummy()
+
+    monkeypatch.setattr(subprocess, 'Popen', fake_popen)
+    monkeypatch.setattr(time, 'sleep', lambda s: None)
+
+    relaunch_current_process()
+
+    assert os.path.isabs(called['argv'][1])
+    assert called['argv'][1].endswith('script.py')
+
+### >>> tests/test_scrape_variants.py (68 lignes)
+from pathlib import Path
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from MOTEUR.scraping import image_scraper
+from MOTEUR.scraping.image_scraper import scrape_variants
+from selenium.webdriver.common.by import By
+
+class DummyElement:
+    def __init__(self, attrs=None):
+        self.attrs = attrs or {}
+    def get_attribute(self, name):
+        return self.attrs.get(name)
+    def is_displayed(self):
+        return True
+    def find_element(self, by, value):
+        # only used to get following sibling label
+        return DummyElement()
+
+class DummyDriver:
+    def __init__(self, url):
+        self.current_url = url
+        self.inputs = [
+            DummyElement({'value': 'Camel', 'id': 'v1'}),
+            DummyElement({'value': 'Noir', 'id': 'v2'})
+        ]
+        self.label_map = { 'v1': DummyElement(), 'v2': DummyElement() }
+        self.img = DummyElement({'src': 'http://x'})
+    def find_elements(self, by, value):
+        if value == ".variant-picker__option-values input[type='radio']":
+            return self.inputs
+        return []
+    def find_element(self, by, value):
+        if value.startswith("label[for='"):
+            key = value.split("'")[1]
+            return self.label_map[key]
+        return self.img
+    def execute_script(self, script, el):
+        pass
+
+class DummyWait:
+    def __init__(self, driver, timeout):
+        pass
+    def until(self, method):
+        method(None)
+
+
+def test_scrape_variants_generate_urls(monkeypatch):
+    monkeypatch.setattr('MOTEUR.scraping.image_scraper.WebDriverWait', DummyWait)
+    class DummyDateTime:
+        @staticmethod
+        def now():
+            class D:
+                year = 2025
+                month = 7
+
+            return D
+
+    monkeypatch.setattr(image_scraper, 'datetime', DummyDateTime)
+    driver = DummyDriver('https://competitor.com/products/bob-avec-lacet')
+    mapping = scrape_variants(driver)
+    assert mapping == {
+        'Camel': 'https://www.planetebob.fr/wp-content/uploads/2025/07/bob-avec-lacet-camel.webp',
+        'Noir': 'https://www.planetebob.fr/wp-content/uploads/2025/07/bob-avec-lacet-noir.webp',
+    }
+
+### >>> tests/test_settings_widget.py (41 lignes)
+from pathlib import Path
+import sys
+import os
+import pytest
+
+QtWidgets = pytest.importorskip("PySide6.QtWidgets")
+QApplication = QtWidgets.QApplication
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from MOTEUR.scraping.widgets.settings_widget import ScrapingSettingsWidget
+from MOTEUR.scraping.utils import update
+
+
+def test_update_button_triggers_git_pull(monkeypatch):
+    started = {}
+
+    app = QApplication.instance() or QApplication([])
+    widget = ScrapingSettingsWidget(show_maintenance=True)
+
+    def fake_start(program, arguments):
+        started["program"] = program
+        started["arguments"] = list(arguments)
+
+    def fake_waitForStarted(timeout):
+        return True
+
+    monkeypatch.setattr(widget._git_proc, "start", fake_start)
+    monkeypatch.setattr(widget._git_proc, "waitForStarted", fake_waitForStarted)
+
+    btn = widget.findChild(QtWidgets.QPushButton, "btn_update")
+    btn.click()
+    widget.close()
+
+    assert started["program"] == "git"
+    assert started["arguments"] == ["pull", "origin", "main"]
+    assert widget._git_proc.workingDirectory() == str(update.PROJECT_ROOT)
+
+### >>> tests/test_storage_integration.py (64 lignes)
+import sys
+import os
+from pathlib import Path
+import pytest
+
+QtWidgets = pytest.importorskip("PySide6.QtWidgets")
+QApplication = QtWidgets.QApplication
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from MOTEUR.scraping import profile_manager as pm, history
+from MOTEUR.scraping.widgets.image_widget import ImageScraperWidget
+from MOTEUR.scraping.widgets.storage_widget import StorageWidget
+
+
+class DummyDriver:
+    def find_element(self, by, value):
+        class El:
+            text = "Bob"
+        return El()
+
+    def quit(self):
+        pass
+
+
+def test_image_scraper_adds_to_storage(tmp_path, monkeypatch):
+    pm.PROFILES_FILE = tmp_path / "profiles.json"
+    history.HISTORY_FILE = tmp_path / "history.json"
+    history.LAST_USED_FILE = tmp_path / "last.json"
+    pm.save_profiles([{"name": "p1", "selector": ".a"}])
+
+    app = QApplication.instance() or QApplication([])
+    storage = StorageWidget()
+    widget = ImageScraperWidget(storage_widget=storage)
+    widget.refresh_profiles()
+    widget.set_selected_profile("p1")
+    urls_file = tmp_path / "urls.txt"
+    urls_file.write_text("http://example.com\n")
+    widget.file_edit.setText(str(urls_file))
+    widget.folder_edit.setText(str(tmp_path))
+    widget.variants_checkbox.setChecked(True)
+
+    monkeypatch.setattr(
+        "MOTEUR.scraping.widgets.image_worker.scrape_images",
+        lambda url, sel, folder, keep_driver=False: (0, DummyDriver()),
+    )
+    monkeypatch.setattr(
+        "MOTEUR.scraping.widgets.image_worker.scrape_variants",
+        lambda driver: {"Noir": "img1", "Beige": "img2"},
+    )
+
+    widget._start()
+    while widget._thread.isRunning():
+        app.processEvents()
+
+    assert storage.table.rowCount() == 1
+    assert storage.table.item(0, 0).text() == ""
+    assert "Noir" in storage.table.item(0, 1).text()
+    widget.close()
+    storage.close()
+
+### >>> tests/test_storage_widget.py (29 lignes)
+import sys
+import os
+from pathlib import Path
+import pytest
+
+QtWidgets = pytest.importorskip("PySide6.QtWidgets")
+QApplication = QtWidgets.QApplication
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from MOTEUR.scraping.widgets.storage_widget import StorageWidget
+from MOTEUR.scraping.widgets.woocommerce_widget import WooCommerceProductWidget
+
+
+def test_storage_basic_operations():
+    app = QApplication.instance() or QApplication([])
+    storage = StorageWidget()
+    storage.add_product("bob", ["Noir", "Beige"])
+    assert storage.table.rowCount() == 1
+    products = storage.get_products()
+    assert products[0]["name"] == "bob"
+    assert products[0]["variants"] == ["Noir", "Beige"]
+    storage.clear()
+    assert storage.table.rowCount() == 0
+    storage.close()
+
+### >>> tests/test_woocommerce_export.py (207 lignes)
+from pathlib import Path
+import sys
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+import woocommerce_export as we
+
+
+def test_transform_rows_example():
+    rows = [
+        {"Type": "variable", "SKU": "SKU-ABC", "Name": "Bob Test", "Images": "url/beige.jpg, url/noir.jpg"},
+        {"Type": "variation", "SKU": "SKU-ABC-beige", "Name": "Bob Test Beige", "Images": "url/beige.jpg"},
+        {"Type": "variation", "SKU": "SKU-ABC-noir", "Name": "Bob Test Noir", "Images": "url/noir.jpg"},
+    ]
+
+    transformed = we.transform_woocommerce_rows(rows)
+
+    expected = [
+        {
+            "ID": "",
+            "Type": "variable",
+            "SKU": "SKU-ABC",
+            "Parent": "",
+            "Name": "Bob Test",
+            "Published": "1",
+            "Short description": "",
+            "Description": "",
+            "Regular price": "",
+            "Sale price": "",
+            "Categories": "",
+            "Tags": "",
+            "Images": f"url/beige.jpg{we.IMAGES_JOINER}url/noir.jpg",
+            "In stock?": "yes",
+            "Stock": "",
+            "Tax status": "taxable",
+            "Shipping class": "",
+            "Attribute 1 name": "Couleur",
+            "Attribute 1 value(s)": "Beige|Noir",
+            "Attribute 1 visible": "1",
+            "Attribute 1 global": "1",
+        },
+        {
+            "ID": "",
+            "Type": "variation",
+            "SKU": "SKU-ABC-beige",
+            "Parent": "SKU-ABC",
+            "Name": "Bob Test Beige",
+            "Published": "1",
+            "Short description": "",
+            "Description": "",
+            "Regular price": "",
+            "Sale price": "",
+            "Categories": "",
+            "Tags": "",
+            "Images": "url/beige.jpg",
+            "In stock?": "yes",
+            "Stock": "",
+            "Tax status": "taxable",
+            "Shipping class": "",
+            "Attribute 1 name": "Couleur",
+            "Attribute 1 value(s)": "Beige",
+            "Attribute 1 visible": "1",
+            "Attribute 1 global": "1",
+        },
+        {
+            "ID": "",
+            "Type": "variation",
+            "SKU": "SKU-ABC-noir",
+            "Parent": "SKU-ABC",
+            "Name": "Bob Test Noir",
+            "Published": "1",
+            "Short description": "",
+            "Description": "",
+            "Regular price": "",
+            "Sale price": "",
+            "Categories": "",
+            "Tags": "",
+            "Images": "url/noir.jpg",
+            "In stock?": "yes",
+            "Stock": "",
+            "Tax status": "taxable",
+            "Shipping class": "",
+            "Attribute 1 name": "Couleur",
+            "Attribute 1 value(s)": "Noir",
+            "Attribute 1 visible": "1",
+            "Attribute 1 global": "1",
+        },
+    ]
+
+    assert transformed == expected
+
+
+def test_export_parent_images_aggregated():
+    base = "https://www.planetebob.fr/wp-content/uploads/2025/08"
+    rows = [
+        {
+            "Type": "variable",
+            "SKU": "SKU-FMMTNZTB",
+            "Name": "bob avec lacet",
+            "Images": f"{base}/bob-avec-lacet.webp",
+            "Regular price": 29.9,
+        },
+        {
+            "Type": "variation",
+            "SKU": "SKU-FMMTNZTB-camel",
+            "Name": "bob avec lacet Camel",
+            "Images": f"{base}/bob-avec-lacet-camel.webp",
+        },
+        {
+            "Type": "variation",
+            "SKU": "SKU-FMMTNZTB-noir",
+            "Name": "bob avec lacet Noir",
+            "Images": f"{base}/bob-avec-lacet-noir.webp",
+        },
+    ]
+    transformed = we.transform_woocommerce_rows(rows)
+    parent = transformed[0]
+    assert (
+        parent["Images"]
+        == f"{base}/bob-avec-lacet.webp{we.IMAGES_JOINER}{base}/bob-avec-lacet-camel.webp{we.IMAGES_JOINER}{base}/bob-avec-lacet-noir.webp"
+    )
+    assert transformed[1]["Images"] == f"{base}/bob-avec-lacet-camel.webp"
+
+
+def test_variation_inherits_regular_price():
+    rows = [
+        {
+            "Type": "variable",
+            "SKU": "SKU-PRICE",
+            "Name": "parent",
+            "Images": "url/base.webp",
+            "Regular price": 29.9,
+        },
+        {
+            "Type": "variation",
+            "SKU": "SKU-PRICE-red",
+            "Name": "parent Red",
+            "Images": "url/red.webp",
+        },
+    ]
+    transformed = we.transform_woocommerce_rows(rows)
+    assert transformed[1]["Regular price"] == 29.9
+
+
+def test_csv_semicolon_and_quoting(tmp_path):
+    base = "https://example.com"
+    rows = [
+        {
+            "Type": "variable",
+            "SKU": "SKU-CSV",
+            "Name": "Parent",
+            "Images": f"{base}/img1.webp",
+            "Regular price": 29.9,
+        },
+        {
+            "Type": "variation",
+            "SKU": "SKU-CSV-red",
+            "Name": "Parent Red",
+            "Images": f"{base}/img2.webp",
+        },
+    ]
+    transformed = we.transform_woocommerce_rows(rows)
+    path = tmp_path / "out.csv"
+    we.write_woocommerce_csv(transformed, path)
+    content = path.read_text(encoding="utf-8")
+    lines = content.splitlines()
+    assert we.CSV_DELIM in lines[0]
+    assert (
+        f"\"{base}/img1.webp{we.IMAGES_JOINER}{base}/img2.webp\"" in lines[1]
+    )
+    assert content.count("29,9") == 2
+
+
+def test_decimal_comma_toggle(tmp_path, monkeypatch):
+    rows = [
+        {
+            "Type": "variable",
+            "SKU": "SKU-DC",
+            "Name": "Parent",
+            "Images": "img.webp",
+            "Regular price": 29.9,
+        }
+    ]
+    monkeypatch.setattr(we, "DECIMAL_COMMA", False)
+    path = tmp_path / "no_comma.csv"
+    we.write_woocommerce_csv(rows, path)
+    content = path.read_text(encoding="utf-8")
+    assert "29.9" in content
+
+
+def test_env_overrides(tmp_path):
+    pytest.importorskip("dotenv")
+    env_path = PROJECT_ROOT / ".env"
+    env_path.write_text("CSV_DELIM=,\nIMAGES_JOINER=,\nDECIMAL_COMMA=0\n", encoding="utf-8")
+    import importlib
+    import woocommerce_export as we
+    importlib.reload(we)
+    try:
+        assert we.CSV_DELIM == ","
+        assert we.IMAGES_JOINER == ","
+        assert we.DECIMAL_COMMA is False
+    finally:
+        env_path.unlink()
+        importlib.reload(we)
+
+### >>> tests/test_woocommerce_widget.py (253 lignes)
+import sys
+import os
+from pathlib import Path
+import csv
+import pytest
+
+QtWidgets = pytest.importorskip("PySide6.QtWidgets")
+QApplication = QtWidgets.QApplication
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from MOTEUR.scraping.widgets.woocommerce_widget import (
+    WooCommerceProductWidget,
+    IMAGES_JOINER,
+)
+from MOTEUR.scraping.widgets.scrap_widget import ScrapWidget
+from MOTEUR.scraping.widgets.storage_widget import StorageWidget
+
+
+def test_widget_headers():
+    app = QApplication.instance() or QApplication([])
+    widget = WooCommerceProductWidget(storage_widget=StorageWidget())
+    assert widget.table.columnCount() == len(widget.HEADERS)
+    widget.close()
+
+
+def test_tab_added_to_scrapwidget():
+    app = QApplication.instance() or QApplication([])
+    sw = ScrapWidget()
+    labels = [sw.tabs.tabText(i) for i in range(sw.tabs.count())]
+    assert "Fiche Produit WooCommerce" in labels
+    assert "Stockage" in labels
+    sw.close()
+
+def test_fill_from_storage(tmp_path, monkeypatch):
+    app = QApplication.instance() or QApplication([])
+    storage = StorageWidget()
+    storage.add_product("bob", ["Noir", "Beige"])
+    storage.add_product("chapeau", ["Unique"])
+
+    images_root = tmp_path / "images"
+    (images_root / "bob").mkdir(parents=True)
+    (images_root / "bob" / "bob.jpg").write_text("x")
+    (images_root / "bob" / "bob-noir.jpg").write_text("x")
+    (images_root / "bob" / "bob-beige.jpg").write_text("x")
+    (images_root / "chapeau").mkdir()
+    (images_root / "chapeau" / "chapeau.jpg").write_text("x")
+    (images_root / "chapeau" / "chapeau-unique.jpg").write_text("x")
+
+    monkeypatch.setattr(WooCommerceProductWidget, "IMAGES_ROOT", images_root)
+    widget = WooCommerceProductWidget(storage_widget=storage)
+    widget.auto_upload_subdir_checkbox.setChecked(False)
+    widget.upload_subdir_edit.setText("2025/07")
+    widget.fill_from_storage()
+    assert widget.table.rowCount() == 4
+    type_col = widget.HEADERS.index("Type")
+    name_col = widget.HEADERS.index("Name")
+    sku_col = widget.HEADERS.index("SKU")
+    img_col = widget.HEADERS.index("Images")
+
+    parent_sku = widget.table.item(0, sku_col).text()
+    assert widget.table.item(0, name_col).text() == "bob"
+    assert widget.table.item(0, type_col).text() == "variable"
+    images0 = set(widget.table.item(0, img_col).text().split(IMAGES_JOINER))
+    assert images0 == {
+        "https://www.planetebob.fr/wp-content/uploads/2025/07/bob.jpg",
+        "https://www.planetebob.fr/wp-content/uploads/2025/07/bob-noir.jpg",
+        "https://www.planetebob.fr/wp-content/uploads/2025/07/bob-beige.jpg",
+    }
+
+    assert widget.table.item(1, type_col).text() == "variation"
+    assert widget.table.item(1, sku_col).text() == f"{parent_sku}-noir"
+    assert widget.table.item(1, name_col).text() == "bob Noir"
+    assert widget.table.item(1, img_col).text() == (
+        "https://www.planetebob.fr/wp-content/uploads/2025/07/bob-noir.jpg"
+    )
+
+    assert widget.table.item(2, type_col).text() == "variation"
+    assert widget.table.item(2, sku_col).text() == f"{parent_sku}-beige"
+    assert widget.table.item(2, img_col).text() == (
+        "https://www.planetebob.fr/wp-content/uploads/2025/07/bob-beige.jpg"
+    )
+
+    assert widget.table.item(3, type_col).text() == "simple"
+    images3 = set(widget.table.item(3, img_col).text().split(IMAGES_JOINER))
+    assert images3 == {
+        "https://www.planetebob.fr/wp-content/uploads/2025/07/chapeau.jpg",
+        "https://www.planetebob.fr/wp-content/uploads/2025/07/chapeau-unique.jpg",
+    }
+    widget.close()
+    storage.close()
+
+
+def test_export_csv_delimiter(tmp_path, monkeypatch):
+    app = QApplication.instance() or QApplication([])
+    widget = WooCommerceProductWidget(storage_widget=StorageWidget())
+    widget.add_row()
+    name_col = widget.HEADERS.index("Name")
+    widget.table.setItem(0, name_col, QtWidgets.QTableWidgetItem("bob"))
+
+    out_file = tmp_path / "out.csv"
+    monkeypatch.setattr(
+        "MOTEUR.scraping.widgets.woocommerce_widget.QFileDialog.getSaveFileName",
+        lambda *a, **k: (str(out_file), ""),
+    )
+
+    widget.export_csv()
+
+    with open(out_file, newline="", encoding="utf-8") as f:
+        rows = list(csv.reader(f, delimiter=";"))
+
+    assert rows[0] == widget.HEADERS
+    assert rows[1][name_col] == "bob"
+    widget.close()
+
+
+def test_clean_image_urls_option(tmp_path, monkeypatch):
+    app = QApplication.instance() or QApplication([])
+    storage = StorageWidget()
+    storage.add_product("bob", ["Unique"])
+
+    images_root = tmp_path / "images"
+    (images_root / "bob").mkdir(parents=True)
+    (images_root / "bob" / "bob.jpg").write_text("x")
+    (images_root / "bob" / "bob_1.jpg").write_text("x")
+    (images_root / "bob" / "bob-unique.jpg").write_text("x")
+
+    monkeypatch.setattr(WooCommerceProductWidget, "IMAGES_ROOT", images_root)
+
+    # Cleaning enabled (default)
+    widget = WooCommerceProductWidget(storage_widget=storage)
+    widget.auto_upload_subdir_checkbox.setChecked(False)
+    widget.upload_subdir_edit.setText("2025/07")
+    widget.fill_from_storage()
+    img_col = widget.HEADERS.index("Images")
+    images = widget.table.item(0, img_col).text().split(IMAGES_JOINER)
+    assert images == [
+        "https://www.planetebob.fr/wp-content/uploads/2025/07/bob.jpg",
+        "https://www.planetebob.fr/wp-content/uploads/2025/07/bob-unique.jpg",
+    ]
+    widget.close()
+
+    # Cleaning disabled
+    widget2 = WooCommerceProductWidget(storage_widget=storage)
+    widget2.clean_images_checkbox.setChecked(False)
+    widget2.auto_upload_subdir_checkbox.setChecked(False)
+    widget2.upload_subdir_edit.setText("2025/07")
+    widget2.fill_from_storage()
+    images2 = widget2.table.item(0, img_col).text().split(IMAGES_JOINER)
+    assert images2 == [
+        "https://www.planetebob.fr/wp-content/uploads/2025/07/bob.jpg",
+        "https://www.planetebob.fr/wp-content/uploads/2025/07/bob_1.jpg",
+        "https://www.planetebob.fr/wp-content/uploads/2025/07/bob-unique.jpg",
+    ]
+    widget2.close()
+
+
+def test_fill_multiple_times_no_duplicates(tmp_path, monkeypatch):
+    app = QApplication.instance() or QApplication([])
+    storage = StorageWidget()
+    storage.add_product("bob", ["Unique"])
+
+    widget = WooCommerceProductWidget(storage_widget=storage)
+    widget.auto_upload_subdir_checkbox.setChecked(False)
+    widget.upload_subdir_edit.setText("2025/07")
+    widget.fill_from_storage()
+    first_count = widget.table.rowCount()
+
+    # Fill again - row count should remain the same
+    widget.fill_from_storage()
+    assert widget.table.rowCount() == first_count
+
+    out_file = tmp_path / "out.csv"
+    monkeypatch.setattr(
+        "MOTEUR.scraping.widgets.woocommerce_widget.QFileDialog.getSaveFileName",
+        lambda *a, **k: (str(out_file), ""),
+    )
+
+    widget.export_csv()
+
+    with open(out_file, newline="", encoding="utf-8") as f:
+        rows = list(csv.reader(f, delimiter=";"))
+
+    # one header row + one product row
+    assert len(rows) - 1 == first_count
+    widget.close()
+    storage.close()
+
+
+@pytest.mark.parametrize("delim", [",", ";", "\t"])
+def test_import_csv_sniffer(tmp_path, monkeypatch, delim):
+    app = QApplication.instance() or QApplication([])
+    widget = WooCommerceProductWidget(storage_widget=StorageWidget())
+    infile = tmp_path / "in.csv"
+    infile.write_text(f"1{delim}2\n", encoding="utf-8")
+    monkeypatch.setattr(
+        "MOTEUR.scraping.widgets.woocommerce_widget.QFileDialog.getOpenFileName",
+        lambda *a, **k: (str(infile), ""),
+    )
+    widget.import_csv()
+    assert widget.table.item(0, 0).text() == "1"
+    assert widget.table.item(0, 1).text() == "2"
+    widget.close()
+
+
+def test_export_csv_adds_extension(tmp_path, monkeypatch):
+    app = QApplication.instance() or QApplication([])
+    widget = WooCommerceProductWidget(storage_widget=StorageWidget())
+    widget.add_row()
+    out_file = tmp_path / "out"
+    monkeypatch.setattr(
+        "MOTEUR.scraping.widgets.woocommerce_widget.QFileDialog.getSaveFileName",
+        lambda *a, **k: (str(out_file), ""),
+    )
+    widget.export_csv()
+    assert out_file.with_suffix(".csv").exists()
+    widget.close()
+
+
+def test_check_urls_head_fallback(tmp_path, monkeypatch):
+    app = QApplication.instance() or QApplication([])
+    widget = WooCommerceProductWidget(storage_widget=StorageWidget())
+    widget.add_row()
+    img_col = widget.HEADERS.index("Images")
+    widget.table.setItem(0, img_col, QtWidgets.QTableWidgetItem("http://x"))
+    outfile = tmp_path / "res.csv"
+    monkeypatch.setattr(
+        "MOTEUR.scraping.widgets.woocommerce_widget.QFileDialog.getSaveFileName",
+        lambda *a, **k: (str(outfile), ""),
+    )
+
+    class Resp:
+        def __init__(self, code):
+            self.status_code = code
+
+    def fake_head(url, timeout, allow_redirects=True):
+        return Resp(405)
+
+    def fake_get(url, timeout, stream=True, headers=None):
+        return Resp(200)
+
+    monkeypatch.setattr("requests.head", fake_head)
+    monkeypatch.setattr("requests.get", fake_get)
+
+    widget.check_urls()
+    with open(outfile, newline="", encoding="utf-8") as f:
+        rows = list(csv.reader(f, delimiter=";"))
+    assert rows[1] == ["http://x", "oui"]
+    widget.close()
+
+### >>> ui_helpers.py (43 lignes)
+from contextlib import contextmanager
+from PySide6.QtCore import Qt, QTimer
+from PySide6.QtWidgets import QWidget, QLabel, QProgressDialog
+
+
+class Toast(QWidget):
+    def __init__(self, parent=None, text="", error=False):
+        super().__init__(parent)
+        self.setWindowFlags(Qt.ToolTip | Qt.FramelessWindowHint)
+        self.lbl = QLabel(text, self)
+        self.lbl.setWordWrap(True)
+        self.lbl.setStyleSheet(
+            "QLabel{padding:8px 12px;border-radius:8px;"
+            f"background:{'#C62828' if error else '#424242'};color:white;font-weight:600;"
+            "}"
+        )
+        self.lbl.adjustSize()
+        self.resize(self.lbl.size())
+        QTimer.singleShot(2200, self.close)
+
+
+def show_toast(parent: QWidget, text: str, error: bool = False):
+    if parent is None:
+        return
+    t = Toast(parent, text, error)
+    g = parent.geometry()
+    t.adjustSize()
+    t.move(g.center().x() - t.width() // 2, g.top() + 30)
+    t.show()
+
+
+@contextmanager
+def busy_dialog(parent: QWidget, message="Traitement en cours…"):
+    dlg = QProgressDialog(message, None, 0, 0, parent)
+    dlg.setWindowModality(Qt.WindowModal)
+    dlg.setAutoClose(False)
+    dlg.setMinimumDuration(0)
+    dlg.show()
+    try:
+        yield dlg
+    finally:
+        dlg.close()
+        dlg.deleteLater()
+
+### >>> utf8_bootstrap.py (42 lignes)
+import os, sys, io
+
+def _reconfig_stream(stream_name: str):
+    s = getattr(sys, stream_name, None)
+    if not s:
+        return
+    try:
+        # Python 3.7+: reconfigure si dispo
+        if hasattr(s, "reconfigure"):
+            s.reconfigure(encoding="utf-8", errors="replace")
+            return
+    except Exception:
+        pass
+    # Fallback: ré-enrouler le buffer (si possible)
+    try:
+        if hasattr(s, "buffer"):
+            wrapped = io.TextIOWrapper(s.buffer, encoding="utf-8", errors="replace")
+            setattr(sys, stream_name, wrapped)
+    except Exception:
+        pass
+
+def _set_console_cp_utf8_on_windows():
+    # Optionnel: bascule code page de la console Windows en UTF-8 (si console présente)
+    try:
+        import ctypes
+        kernel32 = ctypes.windll.kernel32
+        kernel32.SetConsoleOutputCP(65001)  # UTF-8
+        kernel32.SetConsoleCP(65001)
+    except Exception:
+        pass
+
+def force_utf8_stdio():
+    # Variables d'env pour les sous-processus Python
+    os.environ.setdefault("PYTHONUTF8", "1")
+    os.environ.setdefault("PYTHONIOENCODING", "utf-8")
+
+    # Console Windows si présente
+    _set_console_cp_utf8_on_windows()
+
+    # Reconfig streams du process courant (si existent)
+    _reconfig_stream("stdout")
+    _reconfig_stream("stderr")
+
+### >>> woocommerce_export.py (324 lignes)
+"""Utilities to transform WooCommerce CSV exports.
+
+This module exposes two helpers:
+
+- ``transform_woocommerce_rows`` converts raw exported rows into rows
+  ready for import into WooCommerce. It handles parent SKU linking, color
+  attributes, image cleanup and default values.
+- ``write_woocommerce_csv`` writes the transformed rows to a CSV file in
+  UTF-8 without BOM.
+
+Example
+=======
+A minimal example with one variable product and two variations::
+
+    >>> rows = [
+    ...     {"Type": "variable", "SKU": "SKU-ABC", "Name": "Bob Test",
+    ...      "Images": "url/beige.jpg, url/noir.jpg"},
+    ...     {"Type": "variation", "SKU": "SKU-ABC-beige",
+    ...      "Name": "Bob Test Beige", "Images": "url/beige.jpg"},
+    ...     {"Type": "variation", "SKU": "SKU-ABC-noir",
+    ...      "Name": "Bob Test Noir", "Images": "url/noir.jpg"},
+    ... ]
+    >>> transformed = transform_woocommerce_rows(rows)
+    >>> [r["Parent"] for r in transformed]
+    ['', 'SKU-ABC', 'SKU-ABC']
+    >>> transformed[0]['Attribute 1 value(s)']
+    'Beige|Noir'
+    >>> transformed[1]['Attribute 1 value(s)']
+    'Beige'
+    >>> transformed[0]['Images']
+    'url/beige.jpg;url/noir.jpg'
+
+The resulting rows are compatible with WooCommerce's CSV importer.
+"""
+
+from __future__ import annotations
+
+import csv
+import logging
+import os
+import re
+import unicodedata
+from collections import defaultdict
+from decimal import Decimal
+from typing import Dict, Iterable, List
+from contextlib import suppress
+
+# .env facultatif (global / par projet)
+with suppress(Exception):
+    from dotenv import load_dotenv
+    load_dotenv()
+
+# Columns expected by WooCommerce in the desired order.
+COLUMNS: List[str] = [
+    "ID",
+    "Type",
+    "SKU",
+    "Parent",
+    "Name",
+    "Published",
+    "Short description",
+    "Description",
+    "Regular price",
+    "Sale price",
+    "Categories",
+    "Tags",
+    "Images",
+    "In stock?",
+    "Stock",
+    "Tax status",
+    "Shipping class",
+    "Attribute 1 name",
+    "Attribute 1 value(s)",
+    "Attribute 1 visible",
+    "Attribute 1 global",
+]
+
+# Mapping for colour/adjective normalisation.
+_ADJECTIVE_MAP = {
+    "fonce": "foncé",
+    "foncé": "foncé",
+    "clair": "clair",
+    "ciel": "ciel",
+}
+
+
+# Defaults (overridable via environment variables)
+CSV_DELIM: str = os.getenv("CSV_DELIM", ";")
+IMAGES_JOINER: str = os.getenv("IMAGES_JOINER", ";")
+DECIMAL_COMMA: bool = bool(int(os.getenv("DECIMAL_COMMA", "1")))
+
+
+def _fix_encoding(text: str) -> str:
+    """Return text normalised in UTF-8 NFC form.
+
+    Many CSV exports have UTF-8 that was mistakenly decoded as latin-1,
+    leading to artefacts such as ``"Bleu foncÃ©"``.  This helper attempts to
+    round-trip the string to recover the proper representation and then
+    normalises it.
+    """
+    if not isinstance(text, str):
+        return text
+    try:
+        text = text.encode("latin1").decode("utf-8")
+    except UnicodeEncodeError:
+        # Already a proper unicode string.
+        pass
+    return unicodedata.normalize("NFC", text)
+
+
+def _normalize_color(value: str) -> str | None:
+    """Normalise a colour name from a slug or free text.
+
+    Parameters
+    ----------
+    value:
+        Raw colour value obtained from SKU or Name.
+    """
+    if not value:
+        return None
+    value = _fix_encoding(value)
+    value = re.sub(r"[-_]+", " ", value).strip().lower()
+    if not value:
+        return None
+    parts = value.split()
+    normalised = []
+    for i, part in enumerate(parts):
+        part = _ADJECTIVE_MAP.get(part, part)
+        if i == 0:
+            normalised.append(part.capitalize())
+        else:
+            normalised.append(part.lower())
+    return " ".join(normalised)
+
+
+def _slugify(value: str) -> str:
+    """Return a slugified version of ``value`` suitable for URLs."""
+    value = unicodedata.normalize("NFKD", value)
+    value = value.encode("ascii", "ignore").decode("ascii")
+    value = re.sub(r"[^a-zA-Z0-9]+", "-", value)
+    return value.strip("-").lower()
+
+
+def build_parent_images_cell(
+    base_url: str,
+    year: int,
+    month: int,
+    product_slug: str,
+    variant_values: list[str],
+    imgs_variant_map: dict[str, list[str]] | None = None,
+    images_joiner: str = IMAGES_JOINER,
+) -> str:
+    """Return a single string for the parent ``Images`` cell.
+
+    The resulting string starts with the generic image (if it exists) followed by
+    the first image of each variant in ``variant_values``.  Duplicates and empty
+    values are ignored and the URLs are joined with ``images_joiner``.
+    """
+    urls: List[str] = []
+    generic_url = (
+        f"{base_url}/wp-content/uploads/{year:04d}/{month:02d}/{product_slug}.webp"
+    )
+    try:  # Try to include the generic image only if it exists.
+        import requests
+
+        resp = requests.head(generic_url, timeout=5)
+        if resp.status_code < 400:
+            urls.append(generic_url)
+    except Exception:
+        # Network issues or 404 -> fall back to variants.
+        pass
+
+    for value in variant_values:
+        slug = _slugify(value)
+        url = None
+        if imgs_variant_map and imgs_variant_map.get(slug):
+            url = imgs_variant_map[slug][0]
+        if not url:
+            url = (
+                f"{base_url}/wp-content/uploads/{year:04d}/{month:02d}/{product_slug}-{slug}.webp"
+            )
+        if url and url not in urls:
+            urls.append(url)
+
+    return images_joiner.join(urls)
+
+
+def _extract_color(row: Dict[str, str]) -> str | None:
+    """Infer the colour for a variation row.
+
+    Tries SKU first (assuming ``parentSKU-colour`` pattern) and falls back to
+    the last word of the Name field.
+    """
+    sku = row.get("SKU", "")
+    if sku and "-" in sku:
+        candidate = sku.rsplit("-", 1)[1]
+        colour = _normalize_color(candidate)
+        if colour:
+            return colour
+    name = row.get("Name", "")
+    if name:
+        candidate = name.split()[-1]
+        colour = _normalize_color(candidate)
+        if colour:
+            return colour
+    return None
+
+
+def _clean_images(images: str, variation: bool) -> str:
+    """Remove spaces around commas and keep only the main image for variations."""
+    if not images:
+        return ""
+    urls = [u.strip() for u in images.split(",") if u.strip()]
+    if variation and urls:
+        urls = urls[:1]
+    return ",".join(urls)
+
+
+def _apply_defaults(row: Dict[str, str]) -> None:
+    if not row.get("Published"):
+        row["Published"] = "1"
+    if not row.get("In stock?"):
+        row["In stock?"] = "yes"
+    if not row.get("Tax status"):
+        row["Tax status"] = "taxable"
+
+
+def _format_for_csv(value) -> str:
+    """Format ``value`` for CSV output respecting ``DECIMAL_COMMA``."""
+    if DECIMAL_COMMA:
+        if isinstance(value, (float, Decimal)):
+            return f"{value}".replace(".", ",")
+        if isinstance(value, str) and re.match(r"^-?\d+\.\d+$", value):
+            return value.replace(".", ",")
+    return "" if value is None else str(value)
+
+
+def transform_woocommerce_rows(rows: Iterable[Dict[str, str]]) -> List[Dict[str, str]]:
+    """Transform raw WooCommerce export rows.
+
+    Parameters
+    ----------
+    rows:
+        Iterable of dictionaries representing CSV rows.
+    """
+    parent_colours: Dict[str, set] = defaultdict(set)
+    parent_images: Dict[str, List[str]] = defaultdict(list)
+    parent_prices: Dict[str, str] = {}
+    variations_needing_price: List[tuple[Dict[str, str], str]] = []
+    result: List[Dict[str, str]] = []
+
+    for row in rows:
+        r = {k: _fix_encoding(v) for k, v in row.items()}
+        r_type = r.get("Type", "")
+        sku = r.get("SKU", "")
+        r["Images"] = _clean_images(r.get("Images", ""), variation=r_type == "variation")
+
+        if r_type == "variable":
+            parent_prices[sku] = r.get("Regular price", "")
+            imgs = [u for u in r["Images"].split(",") if u]
+            existing = parent_images.get(sku, [])
+            combined: List[str] = []
+            for img in imgs + existing:
+                if img and img not in combined:
+                    combined.append(img)
+            parent_images[sku] = combined
+        elif r_type == "variation":
+            parent_sku = sku.rsplit("-", 1)[0] if "-" in sku else ""
+            r["Parent"] = parent_sku
+            colour = _extract_color(r)
+            if colour:
+                r["Attribute 1 name"] = "Couleur"
+                r["Attribute 1 value(s)"] = colour
+                r["Attribute 1 visible"] = "1"
+                r["Attribute 1 global"] = "1"
+                parent_colours[parent_sku].add(colour)
+            else:
+                logging.warning("No colour found for variation %s", sku)
+            img = r.get("Images")
+            if img and img not in parent_images[parent_sku]:
+                parent_images[parent_sku].append(img)
+        _apply_defaults(r)
+        result_row = {col: r.get(col, "") for col in COLUMNS}
+        result.append(result_row)
+        if r_type == "variation" and not result_row.get("Regular price"):
+            variations_needing_price.append((result_row, parent_sku))
+
+    # Populate parent attributes once all variation data are known.
+    for row in result:
+        if row["Type"] == "variable":
+            sku = row.get("SKU", "")
+            colours = parent_colours.get(sku)
+            if colours:
+                row["Attribute 1 name"] = "Couleur"
+                row["Attribute 1 value(s)"] = "|".join(sorted(colours))
+                row["Attribute 1 visible"] = "1"
+                row["Attribute 1 global"] = "1"
+            imgs = parent_images.get(sku)
+            if imgs:
+                row["Images"] = IMAGES_JOINER.join(imgs)
+        for key, value in list(row.items()):
+            if isinstance(value, str):
+                row[key] = _fix_encoding(value)
+
+    for row, parent_sku in variations_needing_price:
+        if not row.get("Regular price"):
+            row["Regular price"] = parent_prices.get(parent_sku, "")
+
+    return result
+
+
+def write_woocommerce_csv(
+    rows: Iterable[Dict[str, str]],
+    path: str,
+    delimiter: str = CSV_DELIM,
+) -> None:
+    """Write transformed rows to ``path`` with UTF-8 encoding and no BOM."""
+    with open(path, "w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(
+            f, fieldnames=COLUMNS, delimiter=delimiter, quoting=csv.QUOTE_MINIMAL
+        )
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({col: _format_for_csv(row.get(col, "")) for col in COLUMNS})
+


### PR DESCRIPTION
## Summary
- add helpers for Shopify URL normalisation and deduplication
- scrape only Shopify carousel images, dedupe ignoring width and apply limit with logging
- mirror the same logic when Selenium fallback is used

## Testing
- `python - <<'PY' ...` (manual HTML sample)
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f0f6b7f748330b96508b49dad7016